### PR TITLE
allow the setting of mcast-rate

### DIFF
--- a/README
+++ b/README
@@ -103,7 +103,9 @@ Lines beginning with '#' are treated as comments and ignored.
 		is 11b.
 	channel: which channel to use in the defined band. Default
 		is 6.
-
+	mcast-rate: set multicast/broadcast transmission rate. Default is 
+		1Mbps for 2.4GHz or 6Mbps for 5GHz 
+	
 HOW TO USE
 
 meshd MUST be run as root. After it's built just run it. If a beacon

--- a/ampe.h
+++ b/ampe.h
@@ -59,6 +59,7 @@ struct meshd_config {
 #define MAX_SUPP_RATES 32
     unsigned char rates[MAX_SUPP_RATES];
     uint16_t ht_prot_mode;
+    int mcast_rate;
 };
 
 /* the single global interface and mesh node info we're handling.

--- a/config/authsae.sample.cfg
+++ b/config/authsae.sample.cfg
@@ -20,5 +20,6 @@ authsae:
     band = "11g";
     channel = 1;
     htmode = "none";
+    mcast-rate = 1;
   };
 };

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1056,6 +1056,8 @@ static int join_mesh_rsn(struct netlink_config_s *nlcfg, struct meshd_config *mc
     NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
     NLA_PUT(msg, NL80211_ATTR_MESH_ID, mconf->meshid_len, mconf->meshid);
 
+    NLA_PUT_U32(msg, NL80211_ATTR_MCAST_RATE, mconf->mcast_rate);
+
     ret = send_nlmsg(nlcfg->nl_sock, msg);
     if (ret < 0)
         fprintf(stderr,"Mesh start failed: %d (%s)\n", ret, strerror(-ret));
@@ -1186,6 +1188,8 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
             sae_debug(MESHD_DEBUG, "unknown HT mode \"%s\", disabling\n", str);
         }
     }
+
+    config_setting_lookup_int(meshd_section, "mcast-rate", (config_int_t *)&config->mcast_rate);
 
     return 0;
 }
@@ -1368,6 +1372,8 @@ int main(int argc, char *argv[])
     mesh.channel_type = meshd_conf.channel_type;
     mesh.band = meshd_conf.band == MESHD_11a ? IEEE80211_BAND_5GHZ
                                               : IEEE80211_BAND_2GHZ;
+
+    meshd_conf.mcast_rate = meshd_conf.mcast_rate * 10;
 
     /* this is the default in kernel as well, so no need to do anything else */
     meshd_conf.ht_prot_mode = IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED;


### PR DESCRIPTION
This patch allows the setting of multicast transmission rate to higher
legacy rate instead of using the lowest transmission rate, such as
1Mbps for 2.4GHz or 6Mbps for 5GHz. Setting can be done via authsae
config file.
