### PR TITLE
meshd-nl80211: fix CLI's help usage error

### DIFF
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -735,7 +735,7 @@ static void usage(void)
 "    -o <outfile>     output log file\n"
 "    -B               run in the background (i.e., daemonize)\n"
 "    -i <interface>   override interface value in config file\n"
-"    -m <meshid>      override mesh id provided in config file\n"
+"    -s <meshid>      override mesh id provided in config file\n"
 "\n"
 );
 }


### PR DESCRIPTION
```
From efe562ad5f52f634a4646ad92dc882250c7e48e1 Mon Sep 17 00:00:00 2001
From: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>
Date: Mon, 5 Aug 2013 16:28:01 -0700
Subject: [PATCH] meshd-nl80211: fix typo error in CLI help usage

Should be "-s" not "-m" for replacing the mesh id.

Signed-off-by: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>

---
 linux/meshd-nl80211.c |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/linux/meshd-nl80211.c b/linux/meshd-nl80211.c
index af8e303..f1e81db 100644
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -735,7 +735,7 @@ static void usage(void)
 "    -o <outfile>     output log file\n"
 "    -B               run in the background (i.e., daemonize)\n"
 "    -i <interface>   override interface value in config file\n"
-"    -m <meshid>      override mesh id provided in config file\n"
+"    -s <meshid>      override mesh id provided in config file\n"
 "\n"
 );
 }
-- 
1.7.9.5

```
