### PR TITLE
meshd-nl80211: fix frequency display

### DIFF
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1123,7 +1123,7 @@ static int join_mesh_rsn(struct netlink_config_s *nlcfg,
         NLA_PUT_U32(msg, NL80211_ATTR_BEACON_INTERVAL, mconf->beacon_interval);
 
     sae_debug(MESHD_DEBUG, "joining mesh %s on freq %d, mode %d\n",
-                        mconf->meshid, mconf-mesh->freq, mesh->channel_type);
+                        mconf->meshid, mesh->freq, mesh->channel_type);
 
     ret = send_nlmsg(nlcfg->nl_sock, msg);
     if (ret < 0)


### PR DESCRIPTION
Due to an extraneous subtract it was showing nonsensical
values like "joining mesh bazooka on freq 6013952, mode 3".

Signed-off-by: Bob Copeland me@bobcopeland.com
