### PR TITLE
Fixed endianness issue reported by Francois Gervais

### DIFF
--- a/ieee802_11.h
+++ b/ieee802_11.h
@@ -39,7 +39,14 @@
 #ifndef _FRAME_H_
 #define _FRAME_H_
 
+#ifdef LINUX
+#include <endian.h>
+#else
+#include <sys/endian.h>
+#endif
+
 #include <stdint.h>
+
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 /*
  * IEEE does things bassackwards, networking in non-network order.


### PR DESCRIPTION
It seems that with our cross-compile toolchain __BYTE_ORDER == __LITTLE_ENDIAN is not true even if the system is little endian. Probably one of both of these are not defined or not defined correctly. This caused the wrong function to be used in ieee802_11.h. 

This in turn caused by:

frame_control = ieee_order(frame->frame_control); 

to invert bytes. 
