### PR TITLE
Send a netlink call to leave the mesh when meshd exits

### DIFF
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1252,7 +1252,7 @@ void fin(unsigned short reason, unsigned char *peer, unsigned char *buf, int len
 
 void term_handle(int i)
 {
-    exit(EXIT_FAILURE);
+    srv_cancel_main_loop(srvctx);
 }
 
 /* TODO: This config stuff should be in a common file to be shared by other
@@ -1419,6 +1419,7 @@ int main(int argc, char *argv[])
 
     sae_debug_mask = SAE_DEBUG_ERR;
     signal(SIGTERM, term_handle);
+    signal(SIGINT, term_handle);
 
     memset(&nlcfg, 0, sizeof(nlcfg));
 
@@ -1574,6 +1575,7 @@ int main(int argc, char *argv[])
     get_wiphy(&nlcfg);
 
     srv_main_loop(srvctx);
+    leave_mesh(&nlcfg);
 out:
     return exitcode;
 }

--- a/service.c
+++ b/service.c
@@ -396,7 +396,7 @@ srv_main_loop(service_context sc)
     fd_set rfds, wfds, efds;
     int i, active;
 
-    while (1) {
+    while (sc->keep_running) {
 	/*
 	 * first check whether any timers expired while we were doing other things
 	 */
@@ -459,6 +459,8 @@ srv_main_loop(service_context sc)
 	 * this condition in check_timers()
 	 */
     }
+
+    return 0;
 }
 
 /*
@@ -484,7 +486,20 @@ srv_create_context(void)
     blah->gbl_timer.tv_sec = 1000;
     blah->gbl_timer.tv_usec = 0;
     blah->exceptor = NULL;
+    blah->keep_running = 1;
 
     return blah;
 }
 
+/*
+ * srv_cancel_main_loop()
+ *	Exit the main loop in srv_main_loop()
+ *	at the earliest opportunity; It can be
+ *	called from within signal handler
+ *	context
+ */
+void
+srv_cancel_main_loop(service_context context)
+{
+	context->keep_running = 0;
+}

--- a/service.h
+++ b/service.h
@@ -39,6 +39,7 @@
 #ifndef _SERVICE_CONTEXT_H_
 #define _SERVICE_CONTEXT_H_
 
+#include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -99,6 +100,7 @@ typedef struct _servcxt {
     struct source inputs[NFDS];
     int noutputs;
     struct source outputs[NFDS];
+    volatile sig_atomic_t keep_running;
 } servcxt;
 
 typedef struct _servcxt *service_context;
@@ -125,6 +127,8 @@ void srv_add_exceptor(service_context, fdcb);
 int srv_main_loop(service_context);
 
 service_context srv_create_context(void);
+
+void srv_cancel_main_loop(service_context);
 
 #endif	/* _SERVICE_CONTEXT_H_ */
 


### PR DESCRIPTION
meshd-nl80211 exits, but does not leave the mesh; this leaves the
interface in an up/connected state.
