### PR TITLE
Removing potential memory leak of 'key' netlink message when first ne…

### DIFF
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -709,6 +709,8 @@ static int install_key(struct netlink_config_s *nlcfg, unsigned char *peer, unsi
     return ret;
 nla_put_failure:
     nlmsg_free(msg);
+    if (key)
+       nlmsg_free(key);
     return -ENOBUFS;
 }
 


### PR DESCRIPTION
…tlink message fails in install_key