### PR TITLE
Fix for nlerror 19 on key refresh. Issue #22

### DIFF
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1192,6 +1192,7 @@ void peer_created(unsigned char *peer)
     NLA_PUT_U16(msg, NL80211_ATTR_STA_AID, 1);
     NLA_PUT_U16(msg, NL80211_ATTR_STA_LISTEN_INTERVAL, 100);
 
+    nlcfg.supress_error = -EEXIST;
     ret = send_nlmsg(nlcfg.nl_sock, msg);
     sae_debug(MESHD_DEBUG, "new peer candidate (seq num=%d)\n",
             nlmsg_hdr(msg)->nlmsg_seq);


### PR DESCRIPTION
Since we're not certain that we have perfect sync between kernel and meshd-nl80211 peer state, we simply call CMD_NEW_STATION every time just in case. More likely than not it will return -EEXISTS when we try to add new station during reauth. Failing to create new station when one exists appears to be harmless, though it generates an error -EEXIST for cmd 19. We should simply suppress the error.