### PR TITLE
AMPE fixes

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -412,6 +412,7 @@ static int check_frame_protection(struct candidate *cand, struct ieee80211_mgmt_
     unsigned short ampe_ie_len, cat_to_mic_len;
     int r;
     unsigned int* key_expiration_p;
+    u8 ftype = mgmt->action.action_code;
     u8 *gtkdata, *igtkdata;
 
     assert(len && cand && mgmt);
@@ -429,8 +430,9 @@ static int check_frame_protection(struct candidate *cand, struct ieee80211_mgmt_
     ampe_ie_len = len -
                 (elems->mic + elems->mic_len - (unsigned char *)mgmt);
 
-    /* expect at least MGTK + RSC + expiry */
-    if (ampe_ie_len < 2 + sizeof(struct ampe_ie) + 16 + 8 + 4) {
+    /* expect at least MGTK + RSC + expiry for open/confirm */
+    if (ftype != PLINK_CLOSE &&
+        ampe_ie_len < 2 + sizeof(struct ampe_ie) + 16 + 8 + 4) {
 		sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE too small\n");
         return -1;
     }

--- a/ampe.c
+++ b/ampe.c
@@ -72,6 +72,20 @@
 #define MESH_SECURITY_INCONSISTENT_PARAMS       59
 #define MESH_SECURITY_INVALID_CAPABILITY        60
 
+/* Mesh protocol identifiers */
+#define MESH_CONFIG_PP_HWMP                     1
+#define MESH_CONFIG_PM_ALM                      1
+#define MESH_CONFIG_CC_NONE                     0
+#define MESH_CONFIG_SP_NEIGHBOR_OFFSET          1
+#define MESH_CONFIG_AUTH_SAE                    1
+
+#ifndef BIT
+#define BIT(x) (1UL << (x))
+#endif
+
+#define MESH_CAPA_ACCEPT_PEERINGS               BIT(0)
+#define MESH_CAPA_FORWARDING                    BIT(3)
+
 static const unsigned char akm_suite_selector[4] = { 0x0, 0xf, 0xac, 0x8 };     /*  SAE  */
 static const unsigned char pw_suite_selector[4] = { 0x0, 0xf, 0xac, 0x4 };     /*  CCMP  */
 static const unsigned char null_nonce[32] = { 0 };
@@ -588,10 +602,14 @@ static int plink_frame_tx(struct candidate *cand, enum plink_action_code action,
 
         /* IE: mesh config */
         *ies++ = IEEE80211_EID_MESH_CONFIG;
-        *ies++ = 8;
-        /*  TODO: IIRC all the defaults are 0. Double check */
-        memset(ies, 0, 8);
-        ies += 8;
+        *ies++ = 7;
+        *ies++ = MESH_CONFIG_PP_HWMP;
+        *ies++ = MESH_CONFIG_PM_ALM;
+        *ies++ = MESH_CONFIG_CC_NONE;
+        *ies++ = MESH_CONFIG_SP_NEIGHBOR_OFFSET;
+        *ies++ = MESH_CONFIG_AUTH_SAE;
+        *ies++ = 0; /* TODO formation info */
+        *ies++ = MESH_CAPA_ACCEPT_PEERINGS | MESH_CAPA_FORWARDING;
 
         ie_len = 4 + 16;        /* min. + PMKID */
         /* IE: Mesh Peering Management element */

--- a/ampe.c
+++ b/ampe.c
@@ -1031,7 +1031,7 @@ int process_ampe_frame(struct ieee80211_mgmt_frame *mgmt, int len,
 
     /* match BSSBasicRateSet*/
     parse_ies(sta_fixed_ies, sta_fixed_ies_len, &our_elems);
-    if (get_basic_rates(&our_elems) != get_basic_rates(&elems)) {
+    if (ftype != PLINK_CLOSE && get_basic_rates(&our_elems) != get_basic_rates(&elems)) {
         sae_debug(AMPE_DEBUG_FSM, "mesh plink: mismatched BSSBasicRateSet!\n");
         return 0;
     }

--- a/ampe.h
+++ b/ampe.h
@@ -64,6 +64,7 @@ struct meshd_config {
 #define MAX_SUPP_RATES 32
     unsigned char rates[MAX_SUPP_RATES];
     uint16_t ht_prot_mode;
+    int pmf;
     int mcast_rate;
     int beacon_interval;
     int path_refresh_time;
@@ -87,6 +88,11 @@ struct mesh_node {
     /* current band */
     enum ieee80211_band band;
     struct meshd_config *conf;
+
+    /* integrity protection key */
+    int igtk_keyid;
+    uint8_t igtk_ipn[6];
+    uint8_t igtk_tx[16];
 };
 
 struct ampe_config {
@@ -111,6 +117,7 @@ int set_plink_state(unsigned char *peer, int state, void *cookie);
 void estab_peer_link(unsigned char *peer, unsigned char *mtk,
         int mtk_len, unsigned char *peer_mgtk, int peer_mgtk_len,
         unsigned int mgtk_expiration,
+        unsigned char *peer_igtk, int peer_igtk_len, int peer_igtk_keyid,
         unsigned char *sup_rates,
         unsigned short sup_rates_len,
         void *cookie);

--- a/ieee802_11.h
+++ b/ieee802_11.h
@@ -203,9 +203,13 @@ struct ampe_ie {
     unsigned char selected_pairwise_suite[4];
     unsigned char local_nonce[32];
     unsigned char peer_nonce[32];
-    unsigned char mgtk[16];
-    unsigned char key_rsc[8];
-    unsigned char key_expiration[4];
+
+    /*
+     * Key Replay Counter (optional)
+     * MGTK || Key RSC || Key Expiration (optional)
+     * IGTK KeyID || IPN || IGTK (optional)
+     */
+    unsigned char variable[0];
 } __attribute__ ((packed));
 
 struct mcs_info {

--- a/linux/meshd.c
+++ b/linux/meshd.c
@@ -252,11 +252,13 @@ int set_plink_state(unsigned char *peer, int state, void *cookie)
 	return 0;
 }
 
-void estab_peer_link(unsigned char *peer, unsigned char *mtk,
-        int mtk_len, unsigned char *peer_mgtk, int peer_mgtk_len,
+void estab_peer_link(unsigned char *peer,
+        unsigned char *mtk, int mtk_len,
+        unsigned char *peer_mgtk, int peer_mgtk_len,
         unsigned int mgtk_expiration,
-        unsigned char *sup_rates,
-        unsigned short sup_rates_len,
+        unsigned char *peer_igtk, int peer_igtk_len, int peer_igtk_keyid,
+        unsigned char *rates,
+        unsigned short rates_len,
         void *cookie)
 {
     printf("TODO: implement estab_peer_link\n");

--- a/peers.h
+++ b/peers.h
@@ -52,6 +52,8 @@ struct candidate {
     unsigned char mtk[16];
     unsigned char mgtk[16];
     unsigned int mgtk_expiration;
+    unsigned char igtk[16];
+    u16 igtk_keyid;
     unsigned char sup_rates[MAX_SUPP_RATES];
     unsigned short sup_rates_len;
     siv_ctx sivctx;


### PR DESCRIPTION
This PR includes changes to authsae to make it work with wpa_supplicant again, the latter being more compliant with the standard these days.  In particular:

 * use a more correct mesh config in the plink frames, which wpa_s checks but authsae does not
 * do not send or expect key data in plink close frames
 * separate gtk and igtk, and add an additional configuration to enable igtk (among other things this means that AES_CMAC is no longer a requirement for mesh, though hardware does still need to support multiple-peer group encryption for group addressed privacy frames -- a change in 4.8 kernel will be using encryption instead of BIP in this context)

I did not test this on hardware but the series enables hwsim to peer and exchange data when one is running wpas and one is running authsae.