### PR TITLE
replacing ancient use of '__le16' with 'le16' to fix compilation erro…

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -254,7 +254,7 @@ static void peer_ampe_init(struct ampe_config *aconf,
 
 static void plink_timer(timerid id, void *data)
 {
-	__le16 reason;
+	le16 reason;
     struct candidate *cand;
 
 	cand = (struct candidate *)data;


### PR DESCRIPTION
…r on OpenWRT-DD