### PR TITLE
CMake: make libsae static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ LIST(APPEND libsae_sources
 	crypto/aes_siv.c
 )
 
-ADD_LIBRARY(sae ${libsae_sources})
+ADD_LIBRARY(sae STATIC ${libsae_sources})
 TARGET_LINK_LIBRARIES(sae ${libsae_libs})
 
 #####################################################################


### PR DESCRIPTION
libsae is only used as an internal library, so no need to
make it a dynamic library.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>