### PR TITLE
Rekey

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ LIST(APPEND libsae_sources
 	common.c
 	sae.c
 	service.c
+	rekey.c
 	ampe.c
 	crypto/aes_siv.c
 )

--- a/ampe.c
+++ b/ampe.c
@@ -37,6 +37,7 @@
 
 #include "os_glue.h"
 #include "peers.h"
+#include "rekey.h"
 #include "sae.h"
 
 /* Peer link cancel reasons */
@@ -814,6 +815,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event)
             changed |= mesh_set_ht_op_mode(cand->conf->mesh);
             sae_debug(AMPE_DEBUG_FSM, "mesh plink with "
                     MACSTR " established\n", MAC2STR(cand->peer_mac));
+            rekey_verify_peer(cand);
 			break;
 		default:
 			break;
@@ -852,6 +854,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event)
 			sae_debug(AMPE_DEBUG_FSM, "Mesh plink with "
                     MACSTR " ESTABLISHED\n", MAC2STR(cand->peer_mac));
 			plink_frame_tx(cand, PLINK_CONFIRM, 0);
+			rekey_verify_peer(cand);
 			break;
 		default:
 			break;

--- a/ampe.h
+++ b/ampe.h
@@ -2,6 +2,7 @@
 #define _SAE_AMPE_H_
 
 #include <net/if.h>
+#include <netinet/in.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -52,6 +53,11 @@ struct ieee80211_supported_band {
 	struct local_ht_caps ht_cap;
 };
 
+typedef union {
+    struct in_addr v4;
+    struct in6_addr v6;
+} ip_address;
+
 /* mesh configuration parameters. Our bss_conf */
 struct meshd_config {
     char interface[IFNAMSIZ + 1];
@@ -79,6 +85,19 @@ struct meshd_config {
     int hwmp_rann_interval;
     int hwmp_active_path_to_root_timeout;
     int hwmp_root_interval;
+
+    int rekey_enable;
+    volatile bool rekey_interface_is_bridge;
+    char bridge[IFNAMSIZ + 1];
+    int rekey_multicast_group_family;
+    ip_address rekey_multicast_group_address;
+    int rekey_ping_port;
+    int rekey_pong_port;
+    int rekey_ping_count_max;
+    int rekey_ping_timeout;
+    int rekey_ping_jitter;
+    int rekey_reauth_count_max;
+    int rekey_ok_ping_count_max;
 };
 
 /* the single global interface and mesh node info we're handling.

--- a/config/authsae.sample.cfg
+++ b/config/authsae.sample.cfg
@@ -18,5 +18,78 @@ authsae:
     channel = 1;
     htmode = "none";
     mcast-rate = 12;
+
+
+    /*
+     * Re-keying
+     *
+     * Restarts authentication when a peer does not respond to a multicast
+     * UDP packet (ping) with a unicast UDP packet (pong) after authentication.
+     */
+
+    /*
+     * A non-zero value enables re-keying.
+     * Default: 0
+     */
+    rekey_enable = 0;
+
+    /* The following parameters are only relevant re-keying is enabled */
+
+    /*
+     * Must be set when 'interface' is part of a bridge.
+     * Default: <empty>
+     */
+    bridge = "";
+
+    /*
+     * The multicast IP address (IPv4 or IPv6) to send the ping to
+     * NOTE: IPv6 is currently not supported.
+     * Default: 224.0.0.200
+     */
+    rekey_multicast_group = "224.0.0.200";
+
+    /*
+     * The port to send the ping to.
+     * Default: 4875
+     */
+    rekey_ping_port = 4875;
+
+    /*
+     * The port to receive the pong on.
+     * Default: 4876
+     */
+    rekey_pong_port = 4876;
+
+    /*
+     * The maximum number of pings to try before a re-authentication is initiated.
+     * Default: 20
+     */
+    rekey_ping_count_max = 20;
+
+    /*
+     * The ping timeout (msec).
+     * Default: 500
+     */
+    rekey_ping_timeout = 500;
+
+    /*
+     * The jitter of the first ping timeout (msec).
+     * Default: 100
+     */
+    rekey_ping_jitter = 100;
+
+    /*
+     * The maximum number of re-authentications to try for a peer.
+     * Default: 4
+     */
+    rekey_reauth_count_max = 4;
+
+    /*
+     * The maximum number of pings to accept from a peer - for which the keys
+     * are considered to be installed correctly - after which a
+     * re-authentication is initiated.
+     * Default: 4
+     */
+    rekey_ok_ping_count_max = 4;
   };
 };

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -90,6 +90,7 @@ LIST(APPEND meshd_sources
 	../common.c
 	../service.c
 	../ampe.c
+	../rekey.c
 	../crypto/aes_siv.c
 )
 
@@ -101,11 +102,14 @@ INSTALL(TARGETS meshd DESTINATION bin)
 MESSAGE(STATUS "")
 MESSAGE(STATUS "Configuring meshd-nl80211 ...")
 
+FIND_PACKAGE(Threads REQUIRED)
+
 LIST(APPEND meshd_nl80211_libs
 	${LIBCONFIG_LIBRARIES}
 	${LIBCRYPTO_LIBRARIES}
 	${LIBNL_LIBRARIES}
 	${LIBNL_GENL_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
 	sae
 )
 
@@ -118,6 +122,7 @@ ENDIF(LIBRT)
 LIST(APPEND meshd_nl80211_sources
 	meshd-nl80211.c
 	nlutils.c
+	watch_ips.c
 )
 
 ADD_EXECUTABLE(meshd-nl80211 ${meshd_nl80211_sources})

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -38,6 +38,7 @@
  * license (including the GNU public license).
  */
 
+#include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
 #include <netlink/genl/genl.h>
@@ -54,8 +55,10 @@
 #include "nl80211-copy.h"
 #include "nlutils.h"
 #include "peers.h"
+#include "rekey.h"
 #include "sae.h"
 #include "service.h"
+#include "watch_ips.h"
 
 #define CIPHER_CCMP 0x000FAC04
 #define CIPHER_AES_CMAC 0x000FAC06
@@ -1330,7 +1333,6 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
     CONFIG_LOOKUP(hwmp-active-path-to-root-timeout,
             hwmp_active_path_to_root_timeout, -1);
     CONFIG_LOOKUP(hwmp-root-interval,hwmp_root_interval, -1);
-#undef CONFIG_LOOKUP
 
     config->band = MESHD_11b;
 
@@ -1360,6 +1362,91 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
             sae_debug(MESHD_DEBUG, "unknown HT mode \"%s\", disabling\n", str);
         }
     }
+
+    CONFIG_LOOKUP(rekey_enable, rekey_enable, REKEY_ENABLE_DEF);
+    config->rekey_enable = (config->rekey_enable != 0);
+
+    if (config->rekey_enable) {
+      if (config_setting_lookup_string(meshd_section, "bridge", (const char **) &str)) {
+        strncpy(config->bridge, str, sizeof(config->bridge));
+        if (config->bridge[sizeof(config->bridge) - 1] != '\0') {
+          fprintf(stderr, "Bridge name is too long\n");
+          return -1;
+        }
+      }
+
+      config->rekey_multicast_group_family = REKEY_MULTICAST_GROUP_FAMILY_DEF;
+      config->rekey_multicast_group_address.v4.s_addr = REKEY_MULTICAST_GROUP_ADDRESS_DEF;
+      bool groupValid = true;
+      if (config_setting_lookup_string(meshd_section, "rekey_multicast_group", (const char **) &str)) {
+        if (inet_pton(AF_INET, str, &config->rekey_multicast_group_address.v4)) {
+          config->rekey_multicast_group_family = AF_INET;
+          groupValid = IN_MULTICAST(ntohl(config->rekey_multicast_group_address.v4.s_addr));
+        } else if (inet_pton(AF_INET6, str, &config->rekey_multicast_group_address.v6)) {
+          config->rekey_multicast_group_family = AF_INET6;
+          groupValid = IN6_IS_ADDR_MULTICAST(&config->rekey_multicast_group_address.v6);
+        } else {
+          groupValid = false;
+        }
+      }
+
+      if (!groupValid) {
+        fprintf(stderr, "Invalid rekey multicast group '%s'\n", str);
+        return -1;
+      }
+
+      /* IPv6 is currently not implemented for rekey */
+      if (config->rekey_multicast_group_family == AF_INET6) {
+        fprintf(stderr, "IPv6 is currently not supported for rekey\n");
+        return -1;
+      }
+
+      CONFIG_LOOKUP(rekey_ping_port, rekey_ping_port, REKEY_PING_PORT_DEF);
+      if ((config->rekey_ping_port <= 0) || (config->rekey_ping_port >= 65536)) {
+        fprintf(stderr, "Invalid rekey ping port %d\n", config->rekey_ping_port);
+        return -1;
+      }
+      config->rekey_ping_port = htons(config->rekey_ping_port);
+
+      CONFIG_LOOKUP(rekey_pong_port, rekey_pong_port, REKEY_PONG_PORT_DEF);
+      if ((config->rekey_pong_port <= 0) || (config->rekey_pong_port >= 65536)) {
+        fprintf(stderr, "Invalid rekey pong port %d\n", config->rekey_pong_port);
+        return -1;
+      }
+      config->rekey_pong_port = htons(config->rekey_pong_port);
+
+      CONFIG_LOOKUP(rekey_ping_count_max, rekey_ping_count_max, REKEY_PING_COUNT_MAX_DEF);
+      if (config->rekey_ping_count_max <= 0) {
+        fprintf(stderr, "Invalid rekey ping count maximum %d\n", config->rekey_ping_count_max);
+        return -1;
+      }
+
+      CONFIG_LOOKUP(rekey_ping_timeout, rekey_ping_timeout, REKEY_PING_TIMEOUT_MSECS_DEF);
+      if (config->rekey_ping_timeout <= 0) {
+        fprintf(stderr, "Invalid rekey ping timeout %d\n", config->rekey_ping_timeout);
+        return -1;
+      }
+
+      CONFIG_LOOKUP(rekey_ping_jitter, rekey_ping_jitter, REKEY_PING_JITTER_MSECS_DEF);
+      if (config->rekey_ping_jitter <= 0) {
+        fprintf(stderr, "Invalid rekey ping jitter %d\n", config->rekey_ping_jitter);
+        return -1;
+      }
+
+      CONFIG_LOOKUP(rekey_reauth_count_max, rekey_reauth_count_max, REKEY_REAUTH_COUNT_MAX_DEF);
+      if (config->rekey_reauth_count_max <= 0) {
+        fprintf(stderr, "Invalid rekey reauthorisation count maximum %d\n", config->rekey_reauth_count_max);
+        return -1;
+      }
+
+      CONFIG_LOOKUP(rekey_ok_ping_count_max, rekey_ok_ping_count_max, REKEY_OK_PING_COUNT_MAX_DEF);
+      if (config->rekey_ok_ping_count_max <= 0) {
+        fprintf(stderr, "Invalid rekey ok ping count maximum %d\n", config->rekey_ok_ping_count_max);
+        return -1;
+      }
+    }
+
+#undef CONFIG_LOOKUP
 
     return 0;
 }
@@ -1604,8 +1691,16 @@ int main(int argc, char *argv[])
 
     get_wiphy(&nlcfg);
 
+    rekey_init(srvctx, &mesh);
+    watch_ips_init(&mesh);
+
     srv_main_loop(srvctx);
+
+    watch_ips_close();
+    rekey_close();
+
     leave_mesh(&nlcfg);
+
 out:
     return exitcode;
 }

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1307,29 +1307,29 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
         config->meshid_len = strlen(config->meshid);
     }
 
-#define CONFIG_LOOKUP(name, config_val) \
+#define CONFIG_LOOKUP(name, config_val, dflt) \
     if (CONFIG_FALSE == config_setting_lookup_int(meshd_section, #name, (config_int_t *)&config->config_val)) \
-        config->config_val = -1;
+        config->config_val = dflt;
 
-    CONFIG_LOOKUP(channel, channel);
-    CONFIG_LOOKUP(mcast-rate, mcast_rate);
-    CONFIG_LOOKUP(beacon-interval,beacon_interval);
+    CONFIG_LOOKUP(channel, channel, -1);
+    CONFIG_LOOKUP(mcast-rate, mcast_rate, -1);
+    CONFIG_LOOKUP(beacon-interval,beacon_interval, -1);
 
     config_setting_lookup_int(meshd_section, "pmf",
             (config_int_t *) &config->pmf);
 
     /* Get mesh parameter */
-    CONFIG_LOOKUP(path-refresh-time,path_refresh_time);
-    CONFIG_LOOKUP(min-discovery-timeout,min_discovery_timeout);
-    CONFIG_LOOKUP(gate-announcements,gate_announcements);
-    CONFIG_LOOKUP(hwmp-active-path-timeout,hwmp_active_path_timeout);
+    CONFIG_LOOKUP(path-refresh-time,path_refresh_time, -1);
+    CONFIG_LOOKUP(min-discovery-timeout,min_discovery_timeout, -1);
+    CONFIG_LOOKUP(gate-announcements,gate_announcements, -1);
+    CONFIG_LOOKUP(hwmp-active-path-timeout,hwmp_active_path_timeout, -1);
     CONFIG_LOOKUP(hwmp-net-diameter-traversal-time,
-            hwmp_net_diameter_traversal_time);
-    CONFIG_LOOKUP(hwmp-rootmode,hwmp_rootmode);
-    CONFIG_LOOKUP(hwmp-rann-interval,hwmp_rann_interval);
+            hwmp_net_diameter_traversal_time, -1);
+    CONFIG_LOOKUP(hwmp-rootmode,hwmp_rootmode, -1);
+    CONFIG_LOOKUP(hwmp-rann-interval,hwmp_rann_interval, -1);
     CONFIG_LOOKUP(hwmp-active-path-to-root-timeout,
-            hwmp_active_path_to_root_timeout);
-    CONFIG_LOOKUP(hwmp-root-interval,hwmp_root_interval);
+            hwmp_active_path_to_root_timeout, -1);
+    CONFIG_LOOKUP(hwmp-root-interval,hwmp_root_interval, -1);
 #undef CONFIG_LOOKUP
 
     config->band = MESHD_11b;

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1283,7 +1283,7 @@ static void segv_handle(int sig) {
 
 void hup_handle(int i)
 {
-    rekey_ip_changes();
+    rekey_reopen_sockets();
 }
 
 /* TODO: This config stuff should be in a common file to be shared by other

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1281,6 +1281,11 @@ static void segv_handle(int sig) {
 }
 #endif /* defined(__linux__) && !defined(__ANDROID__) */
 
+void hup_handle(int i)
+{
+    rekey_ip_changes();
+}
+
 /* TODO: This config stuff should be in a common file to be shared by other
  * meshd implementations
  */
@@ -1537,6 +1542,7 @@ int main(int argc, char *argv[])
     signal(SIGTERM, term_handle);
     signal(SIGINT, term_handle);
     signal(SIGSEGV, segv_handle);
+    signal(SIGHUP, hup_handle);
 
     memset(&nlcfg, 0, sizeof(nlcfg));
 

--- a/linux/watch_ips.c
+++ b/linux/watch_ips.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2016
+ *
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
+ *  following conditions are met:
+ *     1. Redistribution of source code must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in all source files.
+ *     2. Redistribution in binary form must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *     3. All advertising materials and documentation mentioning features
+ *	  or use of this software must display the following acknowledgement:
+ *
+ *        "This product includes software written by
+ *         Jesse Jones (jjones at cococorp dot com)"
+ *
+ *  "DISCLAIMER OF LIABILITY
+ *
+ *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE."
+ *
+ * This license and distribution terms cannot be changed. In other words,
+ * this code cannot simply be copied and put under a different distribution
+ * license (including the GNU public license).
+ */
+#include "watch_ips.h"
+
+#include <errno.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "rekey.h"
+
+static struct mesh_node *cfg = NULL;
+
+static pthread_t thread = 0;
+static volatile bool run = true;
+static char buffer[4096];
+static int sock = -1;
+
+static bool open_socket(void) {
+  if (sock != -1) {
+    return true;
+  }
+
+  sock = socket(PF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+  if (sock == -1) {
+    return false;
+  }
+
+  struct sockaddr_nl addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.nl_family = AF_NETLINK;
+  addr.nl_groups = RTMGRP_IPV4_IFADDR; // TODO for IPv6 add RTMGRP_IPV6_IFADDR
+
+  bool r = !bind(sock, (struct sockaddr *) &addr, sizeof(addr));
+  if (!r) {
+    close(sock);
+    sock = -1;
+  }
+
+  return r;
+}
+
+static void close_socket(void) {
+  if (sock == -1) {
+    return;
+  }
+
+  shutdown(sock, SHUT_WR);
+  close(sock);
+  sock = -1;
+}
+
+static int get_interface_index(void) {
+  int index = 0;
+
+  char *ifname;
+  size_t len;
+  if (cfg->conf->rekey_interface_is_bridge) {
+    ifname = cfg->conf->bridge;
+    len = sizeof(cfg->conf->bridge);
+  } else {
+    ifname = cfg->conf->interface;
+    len = sizeof(cfg->conf->interface);
+  }
+
+  struct if_nameindex * ifaces = if_nameindex();
+  if (ifaces) {
+    bool loop = true;
+    struct if_nameindex *iface;
+    for (iface = ifaces; loop && (iface->if_index || iface->if_name); iface++) {
+      if (iface->if_name && !strncmp(ifname, iface->if_name, len)) {
+        index = iface->if_index;
+        loop = false;
+      }
+    }
+
+    if_freenameindex(ifaces);
+  }
+
+  return index;
+}
+
+static void* monitor_interface_addresses(void *info) {
+  ssize_t len = 0;
+
+  while (run && ((len = recv(sock, buffer, sizeof(buffer), 0)) > 0)) {
+    bool changed = false;
+
+    int idx = get_interface_index();
+
+    struct nlmsghdr *nlh = (struct nlmsghdr *) buffer;
+    while (NLMSG_OK(nlh, len) && (nlh->nlmsg_type != NLMSG_DONE) && !changed) {
+      if ((nlh->nlmsg_type == RTM_NEWADDR) || (nlh->nlmsg_type == RTM_DELADDR)) {
+        struct ifaddrmsg *ifa = (struct ifaddrmsg *) NLMSG_DATA(nlh);
+        struct rtattr *rth = IFA_RTA(ifa);
+        int rtl = IFA_PAYLOAD(nlh);
+
+        while (rtl && RTA_OK(rth, rtl) && !changed) {
+          if ((rth->rta_type == IFA_LOCAL) && (ifa->ifa_family == cfg->conf->rekey_multicast_group_family)
+              && (!idx || (idx == ifa->ifa_index))) {
+            sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: an IP address changed on interface with index %d\n",
+                ifa->ifa_index);
+            changed = true;
+          }
+          rth = RTA_NEXT(rth, rtl);
+        }
+      }
+      nlh = NLMSG_NEXT(nlh, len);
+    }
+
+    if (run && changed) {
+      rekey_ip_changes();
+    }
+  }
+
+  if (len == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: read error in monitor_addresses thread: %s\n", strerror(errno));
+  }
+
+  close_socket();
+
+  return NULL;
+}
+
+void watch_ips_init(struct mesh_node *config) {
+  if (thread || !config->conf->rekey_enable) {
+    return;
+  }
+
+  cfg = config;
+
+  run = true;
+  memset(buffer, 0, sizeof(buffer));
+
+  if (!open_socket()) {
+    goto err;
+  }
+
+  int ok = pthread_create(&thread, NULL, monitor_interface_addresses, NULL);
+  if (!ok) {
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_ERR, "rekey: creating the monitor_addresses thread failed (%d)\n", ok);
+
+  err: close_socket();
+  thread = 0;
+}
+
+void watch_ips_close() {
+  if (!thread) {
+    return;
+  }
+
+  run = false;
+  (void) pthread_cancel(thread);
+  /* close_socket() is called by the thread */
+  thread = 0;
+
+  cfg = NULL;
+}

--- a/linux/watch_ips.c
+++ b/linux/watch_ips.c
@@ -150,7 +150,7 @@ static void* monitor_interface_addresses(void *info) {
     }
 
     if (run && changed) {
-      rekey_ip_changes();
+      rekey_reopen_sockets();
     }
   }
 

--- a/linux/watch_ips.h
+++ b/linux/watch_ips.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Dan Harkins, 2008, 2009, 2010
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2016
  *
  *  Copyright holder grants permission for redistribution and use in source
  *  and binary forms, with or without modification, provided that the
@@ -15,7 +16,7 @@
  *	  or use of this software must display the following acknowledgement:
  *
  *        "This product includes software written by
- *         Dan Harkins (dharkins at lounge dot org)"
+ *         Jesse Jones (jjones at cococorp dot com)"
  *
  *  "DISCLAIMER OF LIABILITY
  *
@@ -36,43 +37,12 @@
  * license (including the GNU public license).
  */
 
-#ifndef _SAE_H_
-#define _SAE_H_
+#ifndef _SAE_WATCH_IPS_H_
+#define _SAE_WATCH_IPS_H_
 
-#include <libconfig.h>
+#include "ampe.h"
 
-#include "ieee802_11.h"
-#include "peers.h"
+void watch_ips_init(struct mesh_node *config);
+void watch_ips_close();
 
-#define    SAE_MAX_EC_GROUPS    10
-#define    SAE_MAX_PASSWORD_LEN 80
-
-struct sae_config {
-    int group[SAE_MAX_EC_GROUPS];
-    int num_groups;
-    char pwd[SAE_MAX_PASSWORD_LEN];
-    int debug;
-    int retrans;
-    int pmk_expiry;
-    int open_threshold;
-    int blacklist_timeout;
-    int giveup_threshold;
-};
-
-/* You may choose not to call sae_parse_config and
- * populate sae_config in some other way before
- * invoking sae_initialize() */
-int sae_parse_config(char* confdir, struct sae_config *config);
-int sae_parse_libconfig (struct config_setting_t *sae_section, struct sae_config* config);
-int sae_initialize(char *ssid, struct sae_config *config);
-int process_mgmt_frame(struct ieee80211_mgmt_frame *frame, int len,
-                       unsigned char *local_mac_addr, void *cookie);
-void sae_read_config(int signal);
-void sae_dump_db (int signal);
-int prf (unsigned char *key, int keylen, unsigned char *label, int labellen,
-     unsigned char *context, int contextlen,
-     unsigned char *result, int resultbitlen);
-
-void do_reauth(struct candidate *peer);
-
-#endif  /* _SAE_H_ */
+#endif  /* _SAE_WATCH_IPS_H_ */

--- a/peers.h
+++ b/peers.h
@@ -71,6 +71,12 @@ struct candidate {
     struct ampe_config *conf;
     unsigned int ch_type; /* nl80211_channel_type */
     int candidate_id;
+
+    timerid rekey_ping_timer;
+    unsigned int rekey_ping_count;
+    unsigned int rekey_reauth_count;
+    unsigned int rekey_ok;
+    unsigned int rekey_ok_ping_rx;
 };
 
 struct candidate *find_peer(unsigned char *mac, int accept);

--- a/rekey.c
+++ b/rekey.c
@@ -626,10 +626,10 @@ void rekey_close(void) {
  */
 
 /* volatile because it is accessed from multiple threads */
-static volatile bool ip_changes = false;
+static volatile bool reopen_sockets = false;
 
-void rekey_ip_changes(void) {
-  ip_changes = true;
+void rekey_reopen_sockets(void) {
+  reopen_sockets = true;
 }
 
 void rekey_verify_peer(struct candidate *peer) {
@@ -637,9 +637,9 @@ void rekey_verify_peer(struct candidate *peer) {
     return;
   }
 
-  if (ip_changes || !ALL_SOCKETS_OPEN) {
+  if (reopen_sockets || !ALL_SOCKETS_OPEN) {
     sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: reopening sockets\n");
-    ip_changes = false;
+    reopen_sockets = false;
     rekey_sockets_reopen();
   }
 

--- a/rekey.c
+++ b/rekey.c
@@ -1,0 +1,662 @@
+/*
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2016
+ *
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
+ *  following conditions are met:
+ *     1. Redistribution of source code must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in all source files.
+ *     2. Redistribution in binary form must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *     3. All advertising materials and documentation mentioning features
+ *	  or use of this software must display the following acknowledgement:
+ *
+ *        "This product includes software written by
+ *         Jesse Jones (jjones at cococorp dot com)"
+ *
+ *  "DISCLAIMER OF LIABILITY
+ *
+ *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE."
+ *
+ * This license and distribution terms cannot be changed. In other words,
+ * this code cannot simply be copied and put under a different distribution
+ * license (including the GNU public license).
+ */
+
+#include "rekey.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/ip.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "sae.h"
+
+#define MSEC_PER_USEC       1000
+
+#define EXPLODE_MAC(mac)    ((mac)[0]), ((mac)[1]), ((mac)[2]), ((mac)[3]), ((mac)[4]), ((mac)[5])
+
+#define PACKET_VERSION_PING (0x01)
+#define PACKET_VERSION_PONG (0x01)
+#define PACKET_TYPE_PING    (0x01)
+#define PACKET_TYPE_PONG    (0x02)
+
+typedef struct {
+  uint8_t version;
+  uint8_t type;
+}__attribute__((packed)) packet_header;
+
+typedef struct {
+  packet_header header;
+  uint8_t ping_mac[ETH_ALEN];
+  uint8_t pong_mac[ETH_ALEN];
+  in_port_t pong_port;
+  uint32_t pong_ip;
+}__attribute__((packed)) packet_ping;
+
+typedef struct {
+  packet_header header;
+  uint8_t pong_mac[ETH_ALEN];
+}__attribute__((packed)) packet_pong;
+
+typedef union {
+  packet_ping ping;
+  packet_pong pong;
+}__attribute__((packed)) packet_struct;
+
+static uint8_t my_mac[ETH_ALEN] = { 0 };
+static uint32_t my_ip = 0;
+
+static service_context ctx = NULL;
+static struct mesh_node *cfg = NULL;
+
+/*
+ * helpers
+ */
+
+static void *get_socket_address_ip(struct sockaddr *sa) {
+  if (sa->sa_family == AF_INET) {
+    return &(((struct sockaddr_in*) sa)->sin_addr);
+  }
+
+  return &(((struct sockaddr_in6*) sa)->sin6_addr);
+}
+
+static bool get_interface_mac_address(int af, const char* iface, uint8_t* mac, uint8_t mac_len) {
+  memset(mac, 0, mac_len);
+
+  int sock = socket(af, SOCK_DGRAM, 0);
+  if (sock == -1) {
+    return false;
+  }
+
+  struct ifreq ifr;
+  memset(&ifr, 0, sizeof(ifr));
+  strncpy(ifr.ifr_name, iface, sizeof(ifr.ifr_name));
+  ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+
+  bool r = (ioctl(sock, SIOCGIFHWADDR, &ifr) != -1);
+  if (r) {
+    memcpy(mac, ifr.ifr_hwaddr.sa_data, mac_len);
+  }
+
+  close(sock);
+  return r;
+}
+
+static bool get_ip_address(int af, const char* iface, uint32_t* ip) {
+  int sock = socket(af, SOCK_DGRAM, 0);
+  if (sock == -1) {
+    return false;
+  }
+
+  struct ifreq ifr;
+  memset(&ifr, 0, sizeof(ifr));
+  ifr.ifr_addr.sa_family = af;
+  strncpy(ifr.ifr_name, iface, sizeof(ifr.ifr_name));
+  ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+
+  bool r = (ioctl(sock, SIOCGIFADDR, &ifr) != -1);
+  if (r) {
+    *ip = (((struct sockaddr_in*) &ifr.ifr_addr)->sin_addr.s_addr);
+  }
+
+  close(sock);
+  return r;
+}
+
+static bool bind_socket(int sock, int af, uint32_t ip, in_port_t port) {
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = af;
+  addr.sin_addr.s_addr = ip;
+  addr.sin_port = port;
+
+  return !bind(sock, (struct sockaddr*) &addr, sizeof(addr));
+}
+
+static int create_socket(int af) {
+  int sock = socket(af, SOCK_DGRAM, 0);
+  if (sock == -1) {
+    return -1;
+  }
+
+  int reuse = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse))) {
+    close(sock);
+    return -1;
+  }
+
+  return sock;
+}
+
+/*
+ * pong send & receive
+ */
+
+static int pong_socket = -1;
+
+static void pong_tx(int af, uint32_t ip, in_port_t port) {
+  char str[INET6_ADDRSTRLEN];
+
+  if (pong_socket == -1) {
+    return;
+  }
+
+  packet_struct packet;
+  packet.pong.header.version = PACKET_VERSION_PONG;
+  packet.pong.header.type = PACKET_TYPE_PONG;
+  memcpy(packet.pong.pong_mac, my_mac, sizeof(packet.pong.pong_mac));
+
+  struct sockaddr_in dst;
+  memset(&dst, 0, sizeof(dst));
+  dst.sin_family = af;
+  dst.sin_addr.s_addr = ip;
+  dst.sin_port = port;
+
+  int bytes = sendto(pong_socket, &packet.pong, sizeof(packet.pong), 0, (struct sockaddr *) &dst, sizeof(dst));
+
+  if (bytes == sizeof(packet.pong)) {
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: pong to %s with MAC %02x:%02x:%02x:%02x:%02x:%02x\n",
+        inet_ntop(af, &dst.sin_addr.s_addr, str, sizeof(str)), EXPLODE_MAC(my_mac));
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: pong to %s with MAC %02x:%02x:%02x:%02x:%02x:%02x failed: %s\n",
+        inet_ntop(af, &dst.sin_addr.s_addr, str, sizeof(str)), EXPLODE_MAC(my_mac), strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_ERR, "rekey: pong to %s with MAC %02x:%02x:%02x:%02x:%02x:%02x sent %d bytes instead of %d\n",
+      inet_ntop(af, &dst.sin_addr.s_addr, str, sizeof(str)), EXPLODE_MAC(my_mac), bytes, sizeof(my_mac));
+}
+
+static void pong_rx(int sock, void *data) {
+  char str[INET6_ADDRSTRLEN];
+
+  uint8_t buffer[sizeof(packet_struct) + 1];
+  packet_struct *packet = (packet_struct *) buffer;
+  struct sockaddr src;
+  socklen_t src_len = sizeof(src);
+
+  int bytes = recvfrom(sock, buffer, sizeof(buffer), 0, (struct sockaddr *) &src, &src_len);
+
+  if (bytes == sizeof(packet->pong)) {
+    if (packet->pong.header.version != PACKET_VERSION_PONG) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: pong from %s sent version %u instead of %u, ignored\n",
+          inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+          packet->pong.header.version, PACKET_VERSION_PONG);
+      return;
+    }
+
+    if (packet->pong.header.type != PACKET_TYPE_PONG) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: pong from %s sent type %u instead of %u, ignored\n",
+          inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+          packet->pong.header.type, PACKET_TYPE_PONG);
+      return;
+    }
+
+    struct candidate *peer = find_peer(packet->pong.pong_mac, 1);
+    if (!peer) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: pong from %s sent unknown peer MAC %u:%u:%u:%u:%u:%u, ignored\n",
+          inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+          EXPLODE_MAC(packet->pong.pong_mac));
+      return;
+    }
+
+    /* keys are installed correctly */
+
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG,
+        "rekey: pong from %s sent known peer MAC %02x:%02x:%02x:%02x:%02x:%02x, keys are installed correctly\n",
+        inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+        EXPLODE_MAC(packet->pong.pong_mac));
+
+    srv_rem_timeout(ctx, peer->rekey_ping_timer);
+    peer->rekey_ping_timer = 0;
+    peer->rekey_ping_count = 0;
+    peer->rekey_reauth_count = 0;
+    peer->rekey_ok = 1;
+    peer->rekey_ok_ping_rx = 0;
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: pong rx failed: %s\n", strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_ERR, "rekey: pong from %s sent %d bytes instead of %d\n",
+      inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)), bytes,
+      sizeof(packet->pong));
+}
+
+static void pong_socket_close(void) {
+  if (pong_socket == -1) {
+    return;
+  }
+
+  srv_rem_input(ctx, pong_socket);
+  close(pong_socket);
+  pong_socket = -1;
+}
+
+static void pong_socket_create(int af, uint32_t ip) {
+  pong_socket = create_socket(af);
+  if (pong_socket == -1) {
+    goto err;
+  }
+
+  if (!bind_socket(pong_socket, af, ip, cfg->conf->rekey_pong_port)) {
+    goto err;
+  }
+
+  if (fcntl(pong_socket, F_SETFL, O_NDELAY)) {
+    goto err;
+  }
+
+  if (srv_add_input(ctx, pong_socket, NULL, pong_rx)) {
+    goto err;
+  }
+
+  return;
+
+  err: pong_socket_close();
+  return;
+}
+
+/*
+ * ping receive
+ */
+
+static int ping_socket_rx = -1;
+
+static void ping_rx(int sock, void *data) {
+  char str[INET6_ADDRSTRLEN];
+
+  uint8_t buffer[sizeof(packet_struct) + 1];
+  packet_struct *packet = (packet_struct *) buffer;
+  struct sockaddr src;
+  socklen_t src_len = sizeof(src);
+
+  int bytes = recvfrom(sock, buffer, sizeof(buffer), 0, (struct sockaddr *) &src, &src_len);
+
+  if (bytes == sizeof(packet->ping)) {
+    if (packet->ping.header.version != PACKET_VERSION_PING) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent version %u instead of %u, ignored\n",
+          inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+          packet->ping.header.version, PACKET_VERSION_PING);
+      return;
+    }
+
+    if (packet->ping.header.type != PACKET_TYPE_PING) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent type %u instead of %u, ignored\n",
+          inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+          packet->ping.header.type, PACKET_TYPE_PING);
+      return;
+    }
+
+    if (memcmp(packet->ping.ping_mac, my_mac, sizeof(my_mac))) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent MAC %u:%u:%u:%u:%u:%u instead of %u:%u:%u:%u:%u:%u, ignored\n",
+          inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+          EXPLODE_MAC(packet->ping.ping_mac), EXPLODE_MAC(my_mac));
+      return;
+    }
+
+    struct candidate *peer = find_peer(packet->ping.pong_mac, 1);
+    if (!peer) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent unknown peer MAC %u:%u:%u:%u:%u:%u, ignored\n",
+          inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
+          EXPLODE_MAC(packet->ping.ping_mac));
+      return;
+    }
+
+    /* re-authenticate when we concluded that keys are installed correctly but we are still receiving pings */
+    if (peer->rekey_ok) {
+      peer->rekey_ok_ping_rx++;
+      if (peer->rekey_ok_ping_rx > cfg->conf->rekey_ok_ping_count_max) {
+        sae_debug(SAE_DEBUG_ERR,
+            "rekey: too many pings from %s while considering keys correctly installed, doing reauth\n",
+            inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)));
+        peer->rekey_ok_ping_rx = 0;
+        do_reauth(peer);
+        return;
+      }
+    }
+
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: ping from %s, replying\n",
+        inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)));
+
+    pong_tx(cfg->conf->rekey_multicast_group_family, packet->ping.pong_ip, cfg->conf->rekey_pong_port);
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: ping rx failed: %s\n", strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent %d bytes instead of %d\n",
+      inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)), bytes,
+      sizeof(packet->ping));
+}
+
+static void ping_socket_close_rx(int af, uint32_t ip) {
+  if (ping_socket_rx == -1) {
+    return;
+  }
+
+  struct ip_mreq mreq;
+  memset(&mreq, 0, sizeof(mreq));
+  mreq.imr_multiaddr.s_addr = cfg->conf->rekey_multicast_group_address.v4.s_addr;
+  mreq.imr_interface.s_addr = ip;
+
+  (void) setsockopt(ping_socket_rx, IPPROTO_IP, IP_DROP_MEMBERSHIP, &mreq, sizeof(mreq));
+
+  srv_rem_input(ctx, ping_socket_rx);
+
+  close(ping_socket_rx);
+  ping_socket_rx = -1;
+}
+
+static void ping_socket_create_rx(int af, uint32_t ip) {
+  ping_socket_rx = create_socket(af);
+  if (ping_socket_rx == -1) {
+    goto err;
+  }
+
+  if (!bind_socket(ping_socket_rx, af, htonl(INADDR_ANY), cfg->conf->rekey_ping_port)) {
+    goto err;
+  }
+
+  uint8_t loopback = 0;
+  if (setsockopt(ping_socket_rx, IPPROTO_IP, IP_MULTICAST_LOOP, &loopback, sizeof(loopback)) == -1) {
+    goto err;
+  }
+
+  struct ip_mreq mreq;
+  memset(&mreq, 0, sizeof(mreq));
+  mreq.imr_multiaddr.s_addr = cfg->conf->rekey_multicast_group_address.v4.s_addr;
+  mreq.imr_interface.s_addr = ip;
+
+  if (setsockopt(ping_socket_rx, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) == -1) {
+    goto err;
+  }
+
+  if (srv_add_input(ctx, ping_socket_rx, NULL, ping_rx)) {
+    goto err;
+  }
+
+  return;
+
+  err: ping_socket_close_rx(af, ip);
+  return;
+}
+
+/*
+ * ping send
+ */
+
+static int ping_socket_tx = -1;
+
+static void ping_tx(timerid id, void *data) {
+  if (!data) {
+    return;
+  }
+
+  struct candidate *peer = (struct candidate *) data;
+
+  peer->rekey_ping_count++;
+
+  /* check whether we did too many pings */
+  if (peer->rekey_ping_count > cfg->conf->rekey_ping_count_max) {
+    srv_rem_timeout(ctx, peer->rekey_ping_timer);
+    peer->rekey_ping_timer = 0;
+    peer->rekey_ping_count = 0;
+
+    /* check whether we can do another reauth */
+    if (peer->rekey_reauth_count < cfg->conf->rekey_reauth_count_max) {
+      peer->rekey_reauth_count++;
+      sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: reauthentication #%u for %02x:%02x:%02x:%02x:%02x:%02x\n",
+          peer->rekey_reauth_count, EXPLODE_MAC(peer->peer_mac));
+      do_reauth(peer);
+    }
+
+    return;
+  }
+
+  /* ping */
+
+  packet_struct packet;
+  packet.ping.header.version = PACKET_VERSION_PING;
+  packet.ping.header.type = PACKET_TYPE_PING;
+  memcpy(packet.ping.ping_mac, peer->peer_mac, sizeof(packet.ping.ping_mac));
+  memcpy(packet.ping.pong_mac, my_mac, sizeof(packet.ping.pong_mac));
+  packet.ping.pong_port = cfg->conf->rekey_pong_port;
+  memcpy(&packet.ping.pong_ip, &my_ip, sizeof(packet.ping.pong_ip));
+
+  struct sockaddr_in dst;
+  memset(&dst, 0, sizeof(dst));
+  dst.sin_family = cfg->conf->rekey_multicast_group_family;
+  dst.sin_addr.s_addr = cfg->conf->rekey_multicast_group_address.v4.s_addr;
+  dst.sin_port = cfg->conf->rekey_ping_port;
+
+  int bytes = sendto(ping_socket_tx, &packet.ping, sizeof(packet.ping), 0, (struct sockaddr *) &dst, sizeof(dst));
+
+  if (bytes == sizeof(packet.ping)) {
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: ping #%u to %02x:%02x:%02x:%02x:%02x:%02x\n", peer->rekey_ping_count,
+        EXPLODE_MAC(peer->peer_mac));
+    srv_rem_timeout(ctx, peer->rekey_ping_timer);
+    peer->rekey_ping_timer = srv_add_timeout(ctx, cfg->conf->rekey_ping_timeout * MSEC_PER_USEC, ping_tx, peer);
+    if (!peer->rekey_ping_timer) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: ping #%u to %02x:%02x:%02x:%02x:%02x:%02x failed to reschedule ping timer\n",
+          peer->rekey_ping_count, EXPLODE_MAC(peer->peer_mac));
+    }
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: ping send failed: %s\n", strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_ERR, "rekey: ping sent %d bytes instead of %d\n", bytes, sizeof(packet.ping));
+}
+
+static void ping_socket_close_tx(void) {
+  if (ping_socket_tx == -1) {
+    return;
+  }
+
+  close(ping_socket_tx);
+  ping_socket_tx = -1;
+}
+
+static void ping_socket_create_tx(int af, uint32_t ip) {
+  ping_socket_tx = create_socket(af);
+  if (ping_socket_tx == -1) {
+    goto err;
+  }
+
+  if (!bind_socket(ping_socket_tx, af, ip, htons(0))) {
+    goto err;
+  }
+
+  uint8_t loopback = 0;
+  if (setsockopt(ping_socket_tx, IPPROTO_IP, IP_MULTICAST_LOOP, &loopback, sizeof(loopback)) == -1) {
+    goto err;
+  }
+
+  int ttl = 1;
+  if (setsockopt(ping_socket_tx, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl))) {
+    goto err;
+  }
+
+  if (fcntl(ping_socket_tx, F_SETFL, O_NDELAY)) {
+    goto err;
+  }
+
+  return;
+
+  err: ping_socket_close_tx();
+  return;
+}
+
+/*
+ * sockets
+ */
+
+#define ALL_SOCKETS_OPEN ((ping_socket_tx != -1) && (ping_socket_rx != -1) && (pong_socket != -1))
+
+static void rekey_sockets_close(void) {
+  int af = cfg->conf->rekey_multicast_group_family;
+
+  ping_socket_close_tx();
+  ping_socket_close_rx(af, my_ip);
+  pong_socket_close();
+}
+
+static void rekey_sockets_reopen(void) {
+  rekey_sockets_close();
+
+  int af = cfg->conf->rekey_multicast_group_family;
+
+  if (!get_interface_mac_address(af, cfg->conf->interface, my_mac, sizeof(my_mac))) {
+    goto err;
+  }
+
+  bool bridge = (cfg->conf->bridge[0] != '\0');
+
+  memset(&my_ip, 0, sizeof(my_ip));
+  bool ip_ok = false;
+
+  if (bridge) {
+    ip_ok = get_ip_address(af, cfg->conf->bridge, &my_ip);
+    cfg->conf->rekey_interface_is_bridge = ip_ok;
+  }
+
+  if (!ip_ok) {
+    bridge = false;
+    cfg->conf->rekey_interface_is_bridge = false;
+    ip_ok = get_ip_address(af, cfg->conf->interface, &my_ip);
+  }
+
+  if (!ip_ok) {
+    if (bridge) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: neither bridge '%s' nor interface '%s' have an IP address\n", cfg->conf->bridge,
+          cfg->conf->interface);
+    } else {
+      sae_debug(SAE_DEBUG_ERR, "rekey: interface '%s' doesn't have an IP address\n", cfg->conf->interface);
+    }
+
+    goto err;
+  }
+
+  pong_socket_create(af, my_ip);
+  ping_socket_create_rx(af, my_ip);
+  ping_socket_create_tx(af, my_ip);
+
+  if (ALL_SOCKETS_OPEN) {
+    return;
+  }
+
+  err: rekey_sockets_close();
+  memset(&my_ip, 0, sizeof(my_ip));
+  memset(my_mac, 0, sizeof(my_mac));
+}
+
+/*
+ * lifecycle
+ */
+
+void rekey_init(service_context context, struct mesh_node *config) {
+  ctx = context;
+  cfg = config;
+}
+
+void rekey_close(void) {
+  rekey_sockets_close();
+
+  cfg = NULL;
+  ctx = NULL;
+}
+
+/*
+ * interfaces
+ */
+
+/* volatile because it is accessed from multiple threads */
+static volatile bool ip_changes = false;
+
+void rekey_ip_changes(void) {
+  ip_changes = true;
+}
+
+void rekey_verify_peer(struct candidate *peer) {
+  if (!cfg || !cfg->conf->rekey_enable || !peer) {
+    return;
+  }
+
+  if (ip_changes || !ALL_SOCKETS_OPEN) {
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: reopening sockets\n");
+    ip_changes = false;
+    rekey_sockets_reopen();
+  }
+
+  if (!ALL_SOCKETS_OPEN) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: failed to open sockets\n");
+    return;
+  }
+
+  if (!peer->rekey_ping_timer) {
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: trigger rekey\n");
+    peer->rekey_ping_count = 0;
+    peer->rekey_ok = 0;
+    peer->rekey_ok_ping_rx = 0;
+    peer->rekey_ping_timer = srv_add_timeout_with_jitter(ctx, cfg->conf->rekey_ping_timeout * MSEC_PER_USEC, ping_tx,
+        peer, cfg->conf->rekey_ping_jitter * MSEC_PER_USEC);
+    if (!peer->rekey_ping_timer) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: failed to schedule ping timer\n");
+    }
+  }
+}

--- a/rekey.c
+++ b/rekey.c
@@ -456,6 +456,7 @@ static void ping_tx(timerid id, void *data) {
 
     /* check whether we can do another reauth */
     if (peer->rekey_reauth_count < cfg->conf->rekey_reauth_count_max) {
+      rekey_reopen_sockets();
       peer->rekey_reauth_count++;
       sae_debug(SAE_DEBUG_PROTOCOL_MSG, "rekey: reauthentication #%u for %02x:%02x:%02x:%02x:%02x:%02x\n",
           peer->rekey_reauth_count, EXPLODE_MAC(peer->peer_mac));

--- a/rekey.c
+++ b/rekey.c
@@ -248,7 +248,7 @@ static void pong_rx(int sock, void *data) {
 
     struct candidate *peer = find_peer(packet->pong.pong_mac, 1);
     if (!peer) {
-      sae_debug(SAE_DEBUG_ERR, "rekey: pong from %s sent unknown peer MAC %u:%u:%u:%u:%u:%u, ignored\n",
+      sae_debug(SAE_DEBUG_ERR, "rekey: pong from %s sent unknown peer MAC %02x:%02x:%02x:%02x:%02x:%02x, ignored\n",
           inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
           EXPLODE_MAC(packet->pong.pong_mac));
       return;
@@ -350,7 +350,8 @@ static void ping_rx(int sock, void *data) {
     }
 
     if (memcmp(packet->ping.ping_mac, my_mac, sizeof(my_mac))) {
-      sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent MAC %u:%u:%u:%u:%u:%u instead of %u:%u:%u:%u:%u:%u, ignored\n",
+      sae_debug(SAE_DEBUG_ERR,
+          "rekey: ping from %s sent MAC %02x:%02x:%02x:%02x:%02x:%02x instead of %02x:%02x:%02x:%02x:%02x:%02x, ignored\n",
           inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
           EXPLODE_MAC(packet->ping.ping_mac), EXPLODE_MAC(my_mac));
       return;
@@ -358,7 +359,7 @@ static void ping_rx(int sock, void *data) {
 
     struct candidate *peer = find_peer(packet->ping.pong_mac, 1);
     if (!peer) {
-      sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent unknown peer MAC %u:%u:%u:%u:%u:%u, ignored\n",
+      sae_debug(SAE_DEBUG_ERR, "rekey: ping from %s sent unknown peer MAC %02x:%02x:%02x:%02x:%02x:%02x, ignored\n",
           inet_ntop(src.sa_family, get_socket_address_ip((struct sockaddr *) &src), str, sizeof(str)),
           EXPLODE_MAC(packet->ping.ping_mac));
       return;

--- a/rekey.h
+++ b/rekey.h
@@ -59,6 +59,6 @@ void rekey_init(service_context srvctx, struct mesh_node *mesh);
 void rekey_close(void);
 
 void rekey_verify_peer(struct candidate *peer);
-void rekey_ip_changes(void);
+void rekey_reopen_sockets(void);
 
 #endif  /* _SAE_REKEY_H_ */

--- a/rekey.h
+++ b/rekey.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Dan Harkins, 2008, 2009, 2010
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2016
  *
  *  Copyright holder grants permission for redistribution and use in source
  *  and binary forms, with or without modification, provided that the
@@ -15,7 +16,7 @@
  *	  or use of this software must display the following acknowledgement:
  *
  *        "This product includes software written by
- *         Dan Harkins (dharkins at lounge dot org)"
+ *         Jesse Jones (jjones at cococorp dot com)"
  *
  *  "DISCLAIMER OF LIABILITY
  *
@@ -36,43 +37,28 @@
  * license (including the GNU public license).
  */
 
-#ifndef _SAE_H_
-#define _SAE_H_
+#ifndef _SAE_REKEY_H_
+#define _SAE_REKEY_H_
 
-#include <libconfig.h>
-
-#include "ieee802_11.h"
+#include "ampe.h"
 #include "peers.h"
+#include "service.h"
 
-#define    SAE_MAX_EC_GROUPS    10
-#define    SAE_MAX_PASSWORD_LEN 80
+#define REKEY_ENABLE_DEF                   (false)
+#define REKEY_MULTICAST_GROUP_FAMILY_DEF   (AF_INET)
+#define REKEY_MULTICAST_GROUP_ADDRESS_DEF  (htonl(0xE00000C8)) /* 224.0.0.200 */
+#define REKEY_PING_PORT_DEF                (4875)
+#define REKEY_PONG_PORT_DEF                (4876)
+#define REKEY_PING_COUNT_MAX_DEF           (20)
+#define REKEY_PING_TIMEOUT_MSECS_DEF       (500)
+#define REKEY_PING_JITTER_MSECS_DEF        (100)
+#define REKEY_REAUTH_COUNT_MAX_DEF         (4)
+#define REKEY_OK_PING_COUNT_MAX_DEF        (4)
 
-struct sae_config {
-    int group[SAE_MAX_EC_GROUPS];
-    int num_groups;
-    char pwd[SAE_MAX_PASSWORD_LEN];
-    int debug;
-    int retrans;
-    int pmk_expiry;
-    int open_threshold;
-    int blacklist_timeout;
-    int giveup_threshold;
-};
+void rekey_init(service_context srvctx, struct mesh_node *mesh);
+void rekey_close(void);
 
-/* You may choose not to call sae_parse_config and
- * populate sae_config in some other way before
- * invoking sae_initialize() */
-int sae_parse_config(char* confdir, struct sae_config *config);
-int sae_parse_libconfig (struct config_setting_t *sae_section, struct sae_config* config);
-int sae_initialize(char *ssid, struct sae_config *config);
-int process_mgmt_frame(struct ieee80211_mgmt_frame *frame, int len,
-                       unsigned char *local_mac_addr, void *cookie);
-void sae_read_config(int signal);
-void sae_dump_db (int signal);
-int prf (unsigned char *key, int keylen, unsigned char *label, int labellen,
-     unsigned char *context, int contextlen,
-     unsigned char *result, int resultbitlen);
+void rekey_verify_peer(struct candidate *peer);
+void rekey_ip_changes(void);
 
-void do_reauth(struct candidate *peer);
-
-#endif  /* _SAE_H_ */
+#endif  /* _SAE_REKEY_H_ */

--- a/sae.c
+++ b/sae.c
@@ -241,6 +241,8 @@ delete_peer (struct candidate **delme)
             peer->t1 = 0;
             srv_rem_timeout(srvctx, peer->t2);     /*      ditto         */
             peer->t2 = 0;
+            srv_rem_timeout(srvctx, peer->rekey_ping_timer);
+            peer->rekey_ping_timer = 0;
             TAILQ_REMOVE(&peers, peer, entry);
             /*
              * PWE, the private value, the PMK and KCK are all secret so


### PR DESCRIPTION

    meshd-nl80211: add re-key support
    
    Re-key checks that the peer-to-peer link encryption keys have been
    programmed correctly on both sides of the link.
    
    This is needed for chips/drivers that have problems with new peer-to-peer
    link encryption keys being programmed. Especially ath9k is relevant
    since it has exactly this problem when it's under load.
    
    When a peer node has been authenticated (the peer-to-peer link encryption
    keys have been programmed), then the re-key process is started:
    - An UDP packet containing the peer's MAC address, the node's MAC address,
      IP address and UDP reply port is sent to a multicast address.
    - This UDP packet is received by all neighbours and only the peer node
      with the same MAC address as the peer MAC address as in the UDP packet
      replies with an UDP packet to the IP address and UDP port combination
      as in the received UDP packet.
    - The node that started the re-key process receives that UDP packet and
      conclude that the peer-to-peer link encryption keys have been installed
      correctly.
    
    The sending of the UDP packets to the multicast address is retried a few
    times when no reply is received from the correct node within a certain
    timeout.
    
    When the maximum number of retries has been exceeded then the node
    concludes that the peer-to-peer link encryption keys have not been
    installed correctly and therefore restarts the authentication process
    for the peer.
    
    When the node has concluded that the peer-to-peer link encryption keys
    have been installed correctly, but it's still receiving UDP packets on
    the multicast address from the corresponding peer node, then the other
    side of the link has not installed the peer-to-peer link encryption keys
    correctly and the node therefore restarts the authentication process for
    the peer.
    
    This patch was originally written by Alexis Green and then further
    adjusted by me.
    
    Originally-by: Alexis Green <agreen@cococorp.com>
    Signed-off-by: Ferry Huberts <ferry.huberts@pelagic.nl>
