### PR TITLE
meshd-nl80211: add re-key support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ LIST(APPEND libsae_sources
 	common.c
 	sae.c
 	service.c
+	rekey.c
 	ampe.c
 	crypto/aes_siv.c
 )

--- a/ampe.c
+++ b/ampe.c
@@ -37,6 +37,7 @@
 
 #include "os_glue.h"
 #include "peers.h"
+#include "rekey.h"
 #include "sae.h"
 
 /* Peer link cancel reasons */
@@ -814,6 +815,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event)
             changed |= mesh_set_ht_op_mode(cand->conf->mesh);
             sae_debug(AMPE_DEBUG_FSM, "mesh plink with "
                     MACSTR " established\n", MAC2STR(cand->peer_mac));
+            rekey_verify_peer(cand);
 			break;
 		default:
 			break;
@@ -852,6 +854,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event)
 			sae_debug(AMPE_DEBUG_FSM, "Mesh plink with "
                     MACSTR " ESTABLISHED\n", MAC2STR(cand->peer_mac));
 			plink_frame_tx(cand, PLINK_CONFIRM, 0);
+			rekey_verify_peer(cand);
 			break;
 		default:
 			break;

--- a/ampe.h
+++ b/ampe.h
@@ -2,6 +2,7 @@
 #define _SAE_AMPE_H_
 
 #include <net/if.h>
+#include <netinet/in.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -52,6 +53,11 @@ struct ieee80211_supported_band {
 	struct local_ht_caps ht_cap;
 };
 
+typedef union {
+    struct in_addr v4; /* in network byte order */
+    struct in6_addr v6; /* in network byte order */
+} ip_address;
+
 /* mesh configuration parameters. Our bss_conf */
 struct meshd_config {
     char interface[IFNAMSIZ + 1];
@@ -79,6 +85,18 @@ struct meshd_config {
     int hwmp_rann_interval;
     int hwmp_active_path_to_root_timeout;
     int hwmp_root_interval;
+
+    int rekey_enable;
+    char bridge[IFNAMSIZ];
+    int rekey_multicast_group_family;
+    ip_address rekey_multicast_group_address; /* in network byte order */
+    int rekey_ping_port; /* in network byte order */
+    int rekey_pong_port; /* in network byte order */
+    int rekey_ping_count_max;
+    int rekey_ping_timeout; /* in msec */
+    int rekey_ping_jitter; /* in msec */
+    int rekey_reauth_count_max;
+    int rekey_ok_ping_count_max;
 };
 
 /* the single global interface and mesh node info we're handling.

--- a/common.h
+++ b/common.h
@@ -60,6 +60,7 @@ int parse_buffer(char *, char **);
 #define AMPE_DEBUG_FSM          0x80
 #define AMPE_DEBUG_KEYS        0x100
 #define AMPE_DEBUG_ERR         0x200
+#define SAE_DEBUG_REKEY        0x400
 extern unsigned int sae_debug_mask;
 void sae_debug (int level, const char *fmt, ...);
 void sae_hexdump(int level, const char *label, const unsigned char *start, int

--- a/config/authsae.sample.cfg
+++ b/config/authsae.sample.cfg
@@ -18,5 +18,77 @@ authsae:
     channel = 1;
     htmode = "none";
     mcast-rate = 12;
+
+
+    /*
+     * Re-keying
+     *
+     * Restarts authentication when a peer does not respond to a multicast
+     * UDP packet (ping) with a unicast UDP packet (pong) after authentication.
+     */
+
+    /*
+     * A non-zero value enables re-keying.
+     * Default: 0
+     */
+    rekey_enable = 0;
+
+    /* The following parameters are only relevant re-keying is enabled */
+
+    /*
+     * Must be set when 'interface' is part of a bridge.
+     * Default: <empty>
+     */
+    bridge = "";
+
+    /*
+     * The multicast IP address (IPv4 or IPv6) to send the ping to
+     * Default: 224.0.0.200
+     */
+    rekey_multicast_group = "224.0.0.200";
+
+    /*
+     * The port to send the ping to.
+     * Default: 4875
+     */
+    rekey_ping_port = 4875;
+
+    /*
+     * The port to receive the pong on.
+     * Default: 4876
+     */
+    rekey_pong_port = 4876;
+
+    /*
+     * The maximum number of pings to try before a re-authentication is initiated.
+     * Default: 32
+     */
+    rekey_ping_count_max = 32;
+
+    /*
+     * The ping timeout (msec).
+     * Default: 500
+     */
+    rekey_ping_timeout = 500;
+
+    /*
+     * The jitter of the first ping timeout (msec).
+     * Default: 100
+     */
+    rekey_ping_jitter = 100;
+
+    /*
+     * The maximum number of re-authentications to try for a peer.
+     * Default: 8
+     */
+    rekey_reauth_count_max = 8;
+
+    /*
+     * The maximum number of pings to accept from a peer - for which the keys
+     * are considered to be installed correctly - after which a
+     * re-authentication is initiated.
+     * Default: 16
+     */
+    rekey_ok_ping_count_max = 16;
   };
 };

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -90,6 +90,7 @@ LIST(APPEND meshd_sources
 	../common.c
 	../service.c
 	../ampe.c
+	../rekey.c
 	../crypto/aes_siv.c
 )
 
@@ -101,11 +102,14 @@ INSTALL(TARGETS meshd DESTINATION bin)
 MESSAGE(STATUS "")
 MESSAGE(STATUS "Configuring meshd-nl80211 ...")
 
+FIND_PACKAGE(Threads REQUIRED)
+
 LIST(APPEND meshd_nl80211_libs
 	${LIBCONFIG_LIBRARIES}
 	${LIBCRYPTO_LIBRARIES}
 	${LIBNL_LIBRARIES}
 	${LIBNL_GENL_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
 	sae
 )
 
@@ -118,6 +122,7 @@ ENDIF(LIBRT)
 LIST(APPEND meshd_nl80211_sources
 	meshd-nl80211.c
 	nlutils.c
+	watch_ips.c
 )
 
 ADD_EXECUTABLE(meshd-nl80211 ${meshd_nl80211_sources})

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1307,29 +1307,29 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
         config->meshid_len = strlen(config->meshid);
     }
 
-#define CONFIG_LOOKUP(name, config_val) \
+#define CONFIG_LOOKUP(name, config_val, dflt) \
     if (CONFIG_FALSE == config_setting_lookup_int(meshd_section, #name, (config_int_t *)&config->config_val)) \
-        config->config_val = -1;
+        config->config_val = dflt;
 
-    CONFIG_LOOKUP(channel, channel);
-    CONFIG_LOOKUP(mcast-rate, mcast_rate);
-    CONFIG_LOOKUP(beacon-interval,beacon_interval);
+    CONFIG_LOOKUP(channel, channel, -1);
+    CONFIG_LOOKUP(mcast-rate, mcast_rate, -1);
+    CONFIG_LOOKUP(beacon-interval,beacon_interval, -1);
 
     config_setting_lookup_int(meshd_section, "pmf",
             (config_int_t *) &config->pmf);
 
     /* Get mesh parameter */
-    CONFIG_LOOKUP(path-refresh-time,path_refresh_time);
-    CONFIG_LOOKUP(min-discovery-timeout,min_discovery_timeout);
-    CONFIG_LOOKUP(gate-announcements,gate_announcements);
-    CONFIG_LOOKUP(hwmp-active-path-timeout,hwmp_active_path_timeout);
+    CONFIG_LOOKUP(path-refresh-time,path_refresh_time, -1);
+    CONFIG_LOOKUP(min-discovery-timeout,min_discovery_timeout, -1);
+    CONFIG_LOOKUP(gate-announcements,gate_announcements, -1);
+    CONFIG_LOOKUP(hwmp-active-path-timeout,hwmp_active_path_timeout, -1);
     CONFIG_LOOKUP(hwmp-net-diameter-traversal-time,
-            hwmp_net_diameter_traversal_time);
-    CONFIG_LOOKUP(hwmp-rootmode,hwmp_rootmode);
-    CONFIG_LOOKUP(hwmp-rann-interval,hwmp_rann_interval);
+            hwmp_net_diameter_traversal_time, -1);
+    CONFIG_LOOKUP(hwmp-rootmode,hwmp_rootmode, -1);
+    CONFIG_LOOKUP(hwmp-rann-interval,hwmp_rann_interval, -1);
     CONFIG_LOOKUP(hwmp-active-path-to-root-timeout,
-            hwmp_active_path_to_root_timeout);
-    CONFIG_LOOKUP(hwmp-root-interval,hwmp_root_interval);
+            hwmp_active_path_to_root_timeout, -1);
+    CONFIG_LOOKUP(hwmp-root-interval,hwmp_root_interval, -1);
 #undef CONFIG_LOOKUP
 
     config->band = MESHD_11b;

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -38,6 +38,7 @@
  * license (including the GNU public license).
  */
 
+#include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
 #include <netlink/genl/genl.h>
@@ -54,8 +55,10 @@
 #include "nl80211-copy.h"
 #include "nlutils.h"
 #include "peers.h"
+#include "rekey.h"
 #include "sae.h"
 #include "service.h"
+#include "watch_ips.h"
 
 #define CIPHER_CCMP 0x000FAC04
 #define CIPHER_AES_CMAC 0x000FAC06
@@ -1278,6 +1281,11 @@ static void segv_handle(int sig) {
 }
 #endif /* defined(__linux__) && !defined(__ANDROID__) */
 
+void hup_handle(int i)
+{
+    rekey_reopen_sockets();
+}
+
 /* TODO: This config stuff should be in a common file to be shared by other
  * meshd implementations
  */
@@ -1330,7 +1338,6 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
     CONFIG_LOOKUP(hwmp-active-path-to-root-timeout,
             hwmp_active_path_to_root_timeout, -1);
     CONFIG_LOOKUP(hwmp-root-interval,hwmp_root_interval, -1);
-#undef CONFIG_LOOKUP
 
     config->band = MESHD_11b;
 
@@ -1360,6 +1367,84 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
             sae_debug(MESHD_DEBUG, "unknown HT mode \"%s\", disabling\n", str);
         }
     }
+
+    CONFIG_LOOKUP(rekey_enable, rekey_enable, REKEY_ENABLE_DEF);
+    config->rekey_enable = (config->rekey_enable != 0);
+
+    if (config_setting_lookup_string(meshd_section, "bridge", (const char **) &str)) {
+      strncpy(config->bridge, str, sizeof(config->bridge));
+      if (config->bridge[sizeof(config->bridge) - 1]) {
+        fprintf(stderr, "Bridge name is too long\n");
+        return -1;
+      }
+    }
+
+    config->rekey_multicast_group_family = REKEY_MULTICAST_GROUP_FAMILY_DEF;
+    config->rekey_multicast_group_address.v4.s_addr = REKEY_MULTICAST_GROUP_ADDRESS_DEF;
+    bool groupValid = true;
+
+    if (config_setting_lookup_string(meshd_section, "rekey_multicast_group", (const char **) &str)) {
+      if (inet_pton(AF_INET, str, &config->rekey_multicast_group_address.v4)) {
+        config->rekey_multicast_group_family = AF_INET;
+        groupValid = IN_MULTICAST(ntohl(config->rekey_multicast_group_address.v4.s_addr));
+      } else if (inet_pton(AF_INET6, str, &config->rekey_multicast_group_address.v6)) {
+        config->rekey_multicast_group_family = AF_INET6;
+        groupValid = IN6_IS_ADDR_MULTICAST(&config->rekey_multicast_group_address.v6);
+      } else {
+        groupValid = false;
+      }
+    }
+
+    if (!groupValid) {
+      fprintf(stderr, "Invalid rekey multicast group '%s'\n", str);
+      return -1;
+    }
+
+    CONFIG_LOOKUP(rekey_ping_port, rekey_ping_port, REKEY_PING_PORT_DEF);
+    if ((config->rekey_ping_port <= 0) || (config->rekey_ping_port >= 65536)) {
+      fprintf(stderr, "Invalid rekey ping port %d\n", config->rekey_ping_port);
+      return -1;
+    }
+    config->rekey_ping_port = htons(config->rekey_ping_port);
+
+    CONFIG_LOOKUP(rekey_pong_port, rekey_pong_port, REKEY_PONG_PORT_DEF);
+    if ((config->rekey_pong_port <= 0) || (config->rekey_pong_port >= 65536)) {
+      fprintf(stderr, "Invalid rekey pong port %d\n", config->rekey_pong_port);
+      return -1;
+    }
+    config->rekey_pong_port = htons(config->rekey_pong_port);
+
+    CONFIG_LOOKUP(rekey_ping_count_max, rekey_ping_count_max, REKEY_PING_COUNT_MAX_DEF);
+    if (config->rekey_ping_count_max <= 0) {
+      fprintf(stderr, "Invalid rekey ping count maximum %d\n", config->rekey_ping_count_max);
+      return -1;
+    }
+
+    CONFIG_LOOKUP(rekey_ping_timeout, rekey_ping_timeout, REKEY_PING_TIMEOUT_MSECS_DEF);
+    if (config->rekey_ping_timeout <= 0) {
+      fprintf(stderr, "Invalid rekey ping timeout %d\n", config->rekey_ping_timeout);
+      return -1;
+    }
+
+    CONFIG_LOOKUP(rekey_ping_jitter, rekey_ping_jitter, REKEY_PING_JITTER_MSECS_DEF);
+    if (config->rekey_ping_jitter <= 0) {
+      fprintf(stderr, "Invalid rekey ping jitter %d\n", config->rekey_ping_jitter);
+      return -1;
+    }
+
+    CONFIG_LOOKUP(rekey_reauth_count_max, rekey_reauth_count_max, REKEY_REAUTH_COUNT_MAX_DEF);
+    if (config->rekey_reauth_count_max <= 0) {
+      fprintf(stderr, "Invalid rekey reauthorisation count maximum %d\n", config->rekey_reauth_count_max);
+      return -1;
+    }
+
+    CONFIG_LOOKUP(rekey_ok_ping_count_max, rekey_ok_ping_count_max, REKEY_OK_PING_COUNT_MAX_DEF);
+    if (config->rekey_ok_ping_count_max <= 0) {
+      fprintf(stderr, "Invalid rekey ok ping count maximum %d\n", config->rekey_ok_ping_count_max);
+      return -1;
+    }
+
+#undef CONFIG_LOOKUP
 
     return 0;
 }
@@ -1450,6 +1535,7 @@ int main(int argc, char *argv[])
     signal(SIGTERM, term_handle);
     signal(SIGINT, term_handle);
     signal(SIGSEGV, segv_handle);
+    signal(SIGHUP, hup_handle);
 
     memset(&nlcfg, 0, sizeof(nlcfg));
 
@@ -1594,6 +1680,9 @@ int main(int argc, char *argv[])
         goto out;
     }
 
+    rekey_init(srvctx, &mesh);
+    watch_ips_init(&mesh);
+
     /* Add netlink sockets to our event loop */
     nlsock = nlcfg.nl_sock;
     srv_add_input(srvctx, nl_socket_get_fd(nlsock), nlsock,
@@ -1607,5 +1696,7 @@ int main(int argc, char *argv[])
     srv_main_loop(srvctx);
     leave_mesh(&nlcfg);
 out:
+    watch_ips_close();
+    rekey_close();
     return exitcode;
 }

--- a/linux/watch_ips.c
+++ b/linux/watch_ips.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2017
+ *
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
+ *  following conditions are met:
+ *     1. Redistribution of source code must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in all source files.
+ *     2. Redistribution in binary form must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *     3. All advertising materials and documentation mentioning features
+ *	  or use of this software must display the following acknowledgement:
+ *
+ *        "This product includes software written by
+ *         Jesse Jones (jjones at cococorp dot com)"
+ *
+ *  "DISCLAIMER OF LIABILITY
+ *
+ *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE."
+ *
+ * This license and distribution terms cannot be changed. In other words,
+ * this code cannot simply be copied and put under a different distribution
+ * license (including the GNU public license).
+ */
+#include "watch_ips.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "rekey.h"
+
+static struct mesh_node *cfg = NULL;
+static volatile bool run = true;
+static int sock = -1;
+
+/*
+ * helpers
+ */
+
+static bool open_socket(int af) {
+  if (sock != -1) {
+    return true;
+  }
+
+  sock = socket(PF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+  if (sock == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: error creating the netlink socket for the address monitoring thread: %s\n",
+        strerror(errno));
+    return false;
+  }
+
+  struct sockaddr_nl addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.nl_family = AF_NETLINK;
+  addr.nl_groups = (af == AF_INET) ? RTMGRP_IPV4_IFADDR : RTMGRP_IPV6_IFADDR;
+
+  bool r = !bind(sock, (struct sockaddr *) &addr, sizeof(addr));
+  if (!r) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: error binding the netlink socket for the address monitoring thread: %s\n",
+        strerror(errno));
+    close(sock);
+    sock = -1;
+  }
+
+  return r;
+}
+
+static void close_socket(void) {
+  if (sock == -1) {
+    return;
+  }
+
+  shutdown(sock, SHUT_WR);
+  close(sock);
+  sock = -1;
+}
+
+/*
+ * thread
+ */
+
+static void *monitor_interface_addresses(void *arg) {
+  static char buffer[4096];
+
+  ssize_t len = 0;
+
+  while (run) {
+    while ((len = recv(sock, buffer, sizeof(buffer), 0)) > 0) {
+      if (!run) {
+        goto out;
+      }
+
+      int idx = !cfg ? 0 : if_nametoindex(cfg->conf->bridge[0] ? cfg->conf->bridge : cfg->conf->interface);
+      bool changed = false;
+
+      struct nlmsghdr *nlh = (struct nlmsghdr *) buffer;
+      while (!changed && NLMSG_OK(nlh, len) && (nlh->nlmsg_type != NLMSG_DONE)) {
+        if ((nlh->nlmsg_type == RTM_NEWADDR) || (nlh->nlmsg_type == RTM_DELADDR)) {
+          struct ifaddrmsg *ifa = (struct ifaddrmsg *) NLMSG_DATA(nlh);
+          struct rtattr *rth = IFA_RTA(ifa);
+          int rtl = IFA_PAYLOAD(nlh);
+
+          while (!changed && rtl && RTA_OK(rth, rtl)) {
+            if ((rth->rta_type == IFA_LOCAL) && (!cfg || (ifa->ifa_family == cfg->conf->rekey_multicast_group_family))
+                && (!idx || (idx == ifa->ifa_index))) {
+              char name[IF_NAMESIZE];
+              sae_debug(SAE_DEBUG_REKEY, "rekey: an IP address changed on interface '%s'\n",
+                  if_indextoname(ifa->ifa_index, name));
+              changed = true;
+            }
+            rth = RTA_NEXT(rth, rtl);
+          }
+        }
+        nlh = NLMSG_NEXT(nlh, len);
+      }
+
+      if (!run) {
+        goto out;
+      }
+
+      if (changed) {
+        rekey_reopen_sockets();
+      }
+    }
+
+    if (!run) {
+      goto out;
+    }
+
+    if (len == -1) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: read error in the address monitoring thread: %s\n", strerror(errno));
+    }
+  }
+
+  out: return NULL;
+}
+
+/*
+ * lifecycle
+ */
+
+static pthread_t thread = 0;
+
+void watch_ips_init(struct mesh_node *config) {
+  if (thread) {
+    return;
+  }
+
+  assert(config);
+
+  cfg = config;
+  run = true;
+
+  if (!open_socket(cfg->conf->rekey_multicast_group_family)) {
+    goto err;
+  }
+
+  if (pthread_create(&thread, NULL, monitor_interface_addresses, NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: error creating the address monitoring thread: %s\n", strerror(errno));
+    goto err;
+  }
+
+  return;
+
+  err: thread = 0;
+  close_socket();
+  run = false;
+  cfg = NULL;
+}
+
+void watch_ips_close() {
+  if (!thread) {
+    return;
+  }
+
+  run = false;
+  (void) pthread_cancel(thread);
+
+  (void) pthread_join(thread, NULL);
+  thread = 0;
+
+  close_socket();
+
+  cfg = NULL;
+}

--- a/linux/watch_ips.h
+++ b/linux/watch_ips.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Dan Harkins, 2008, 2009, 2010
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2017
  *
  *  Copyright holder grants permission for redistribution and use in source
  *  and binary forms, with or without modification, provided that the
@@ -15,7 +16,7 @@
  *	  or use of this software must display the following acknowledgement:
  *
  *        "This product includes software written by
- *         Dan Harkins (dharkins at lounge dot org)"
+ *         Jesse Jones (jjones at cococorp dot com)"
  *
  *  "DISCLAIMER OF LIABILITY
  *
@@ -36,43 +37,12 @@
  * license (including the GNU public license).
  */
 
-#ifndef _SAE_H_
-#define _SAE_H_
+#ifndef _SAE_WATCH_IPS_H_
+#define _SAE_WATCH_IPS_H_
 
-#include <libconfig.h>
+#include "ampe.h"
 
-#include "ieee802_11.h"
-#include "peers.h"
+void watch_ips_init(struct mesh_node *config);
+void watch_ips_close();
 
-#define    SAE_MAX_EC_GROUPS    10
-#define    SAE_MAX_PASSWORD_LEN 80
-
-struct sae_config {
-    int group[SAE_MAX_EC_GROUPS];
-    int num_groups;
-    char pwd[SAE_MAX_PASSWORD_LEN];
-    int debug;
-    int retrans;
-    int pmk_expiry;
-    int open_threshold;
-    int blacklist_timeout;
-    int giveup_threshold;
-};
-
-/* You may choose not to call sae_parse_config and
- * populate sae_config in some other way before
- * invoking sae_initialize() */
-int sae_parse_config(char* confdir, struct sae_config *config);
-int sae_parse_libconfig (struct config_setting_t *sae_section, struct sae_config* config);
-int sae_initialize(char *ssid, struct sae_config *config);
-int process_mgmt_frame(struct ieee80211_mgmt_frame *frame, int len,
-                       unsigned char *local_mac_addr, void *cookie);
-void sae_read_config(int signal);
-void sae_dump_db (int signal);
-int prf (unsigned char *key, int keylen, unsigned char *label, int labellen,
-     unsigned char *context, int contextlen,
-     unsigned char *result, int resultbitlen);
-
-void do_reauth(struct candidate *peer);
-
-#endif  /* _SAE_H_ */
+#endif  /* _SAE_WATCH_IPS_H_ */

--- a/peers.h
+++ b/peers.h
@@ -71,6 +71,12 @@ struct candidate {
     struct ampe_config *conf;
     unsigned int ch_type; /* nl80211_channel_type */
     int candidate_id;
+
+    timerid rekey_ping_timer;
+    unsigned int rekey_ping_count;
+    unsigned int rekey_reauth_count;
+    unsigned int rekey_ok;
+    unsigned int rekey_ok_ping_rx;
 };
 
 struct candidate *find_peer(unsigned char *mac, int accept);

--- a/rekey.c
+++ b/rekey.c
@@ -1,0 +1,726 @@
+/*
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2017
+ *
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
+ *  following conditions are met:
+ *     1. Redistribution of source code must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in all source files.
+ *     2. Redistribution in binary form must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *     3. All advertising materials and documentation mentioning features
+ *	  or use of this software must display the following acknowledgement:
+ *
+ *        "This product includes software written by
+ *         Jesse Jones (jjones at cococorp dot com)"
+ *
+ *  "DISCLAIMER OF LIABILITY
+ *
+ *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE."
+ *
+ * This license and distribution terms cannot be changed. In other words,
+ * this code cannot simply be copied and put under a different distribution
+ * license (including the GNU public license).
+ */
+
+#include "rekey.h"
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/ip.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "ieee802_11.h"
+#include "sae.h"
+
+#define PACKET_TYPE_PING    (0x01)
+#define PACKET_TYPE_PONG    (0x02)
+
+#define PACKET_VERSION_PING (0x01)
+#define PACKET_VERSION_PONG (0x01)
+
+typedef struct {
+  uint8_t type;
+  uint8_t version;
+}__attribute__((packed)) packet_header;
+
+typedef struct {
+  packet_header header;
+  uint8_t dst_mac[ETH_ALEN];
+  uint8_t src_mac[ETH_ALEN];
+  in_port_t src_port;
+}__attribute__((packed)) packet_ping;
+
+typedef struct {
+  packet_header header;
+  uint8_t dst_mac[ETH_ALEN];
+  uint8_t src_mac[ETH_ALEN];
+}__attribute__((packed)) packet_pong;
+
+typedef union {
+  packet_ping ping;
+  packet_pong pong;
+}__attribute__((packed)) packet_struct;
+
+static service_context ctx = NULL;
+static struct mesh_node *cfg = NULL;
+
+#define IPPROTO(af)   ((af == AF_INET) ? IPPROTO_IP : IPPROTO_IPV6)
+#define IPMCLOOP(af)  ((af == AF_INET) ? IP_MULTICAST_LOOP : IPV6_MULTICAST_LOOP)
+#define IPMCTTL(af)   ((af == AF_INET) ? IP_MULTICAST_TTL : IPV6_MULTICAST_HOPS)
+#define IPMCJOIN(af)  ((af == AF_INET) ? IP_ADD_MEMBERSHIP : IPV6_ADD_MEMBERSHIP)
+#define IPMCLEAVE(af) ((af == AF_INET) ? IP_DROP_MEMBERSHIP : IPV6_DROP_MEMBERSHIP)
+
+/*
+ * helpers
+ */
+
+static void *get_socket_address_ip(struct sockaddr_storage *sa) {
+  if (sa->ss_family == AF_INET) {
+    return &(((struct sockaddr_in*) sa)->sin_addr);
+  }
+
+  return &(((struct sockaddr_in6*) sa)->sin6_addr);
+}
+
+static bool bind_socket_to_interface(int sock, const char* iface) {
+  if (!iface) {
+    return false;
+  }
+
+  struct ifreq ifr;
+  memset(&ifr, 0, sizeof(ifr));
+  strncpy(ifr.ifr_name, iface, sizeof(ifr.ifr_name));
+  ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+
+  return !setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, (void *) &ifr, sizeof(ifr));
+}
+
+static bool bind_socket_to_ip_and_port(int sock, int af, ip_address *ip, in_port_t port) {
+  struct sockaddr_storage addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.ss_family = af;
+
+  if (af == AF_INET) {
+    struct sockaddr_in *addr4 = (struct sockaddr_in *) &addr;
+    addr4->sin_addr = ip->v4;
+    addr4->sin_port = port;
+  } else {
+    struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *) &addr;
+    addr6->sin6_addr = ip->v6;
+    addr6->sin6_port = port;
+  }
+
+  return !bind(sock, (struct sockaddr *) &addr, sizeof(addr));
+}
+
+static int create_dgram_socket(int af) {
+  int sock = socket(af, SOCK_DGRAM, 0);
+  if (sock == -1) {
+    return -1;
+  }
+
+  int reuse = 1;
+  if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse))) {
+    close(sock);
+    return -1;
+  }
+
+  return sock;
+}
+
+/*
+ * pong send & receive
+ */
+
+static int pong_socket = -1;
+
+static void pong_tx(struct candidate *peer, struct sockaddr_storage *src, in_port_t port) {
+  if (!peer || !src || !port || (pong_socket == -1)) {
+    return;
+  }
+
+  packet_struct packet;
+  packet.pong.header.type = PACKET_TYPE_PONG;
+  packet.pong.header.version = PACKET_VERSION_PONG;
+  memcpy(packet.pong.dst_mac, peer->peer_mac, sizeof(packet.pong.dst_mac));
+  memcpy(packet.pong.src_mac, peer->my_mac, sizeof(packet.pong.src_mac));
+
+  struct sockaddr_storage dst;
+  memset(&dst, 0, sizeof(dst));
+  dst.ss_family = src->ss_family;
+  if (dst.ss_family == AF_INET) {
+    struct sockaddr_in *src4 = (struct sockaddr_in *) src;
+    struct sockaddr_in *dst4 = (struct sockaddr_in *) &dst;
+    dst4->sin_addr = src4->sin_addr;
+    dst4->sin_port = port;
+  } else {
+    struct sockaddr_in6 *src6 = (struct sockaddr_in6 *) src;
+    struct sockaddr_in6 *dst6 = (struct sockaddr_in6 *) &dst;
+    dst6->sin6_addr = src6->sin6_addr;
+    dst6->sin6_port = port;
+  }
+
+  char str[INET6_ADDRSTRLEN];
+  sae_debug(SAE_DEBUG_REKEY, "rekey: pong to   " MACSTR " (%s)\n", MAC2STR(peer->peer_mac),
+      inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)));
+
+  int bytes = sendto(pong_socket, &packet.pong, sizeof(packet.pong), 0, (struct sockaddr *) &dst, sizeof(dst));
+
+  if (bytes == sizeof(packet.pong)) {
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: pong to   " MACSTR " (%s) failed: %s\n", MAC2STR(peer->peer_mac),
+        inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)), strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_REKEY, "rekey: pong to   " MACSTR " (%s) sent %d bytes instead of %d\n", MAC2STR(peer->peer_mac),
+      bytes, inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)), sizeof(packet.pong));
+}
+
+static void pong_rx(int sock, void *data) {
+  char str[INET6_ADDRSTRLEN];
+  uint8_t buffer[sizeof(packet_struct) + 1];
+  packet_struct *packet = (packet_struct *) buffer;
+  struct sockaddr_storage src;
+  socklen_t src_len = sizeof(src);
+
+  int bytes = recvfrom(sock, buffer, sizeof(buffer), 0, (struct sockaddr *) &src, &src_len);
+
+  if (bytes == sizeof(packet->pong)) {
+    if (packet->pong.header.type != PACKET_TYPE_PONG) {
+      sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent type %u instead of %u, ignored\n",
+          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->pong.header.type,
+          PACKET_TYPE_PONG);
+      return;
+    }
+
+    if (packet->pong.header.version != PACKET_VERSION_PONG) {
+      sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent version %u instead of %u, ignored\n",
+          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->pong.header.version,
+          PACKET_VERSION_PONG);
+      return;
+    }
+
+    struct candidate *peer = find_peer(packet->pong.src_mac, 1);
+    if (!peer) {
+      sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent unknown accepted peer " MACSTR ", ignored\n",
+          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), MAC2STR(packet->pong.src_mac));
+      return;
+    }
+
+    if (memcmp(packet->pong.dst_mac, peer->my_mac, sizeof(packet->pong.dst_mac))) {
+      sae_debug(SAE_DEBUG_REKEY,
+          "rekey: pong from " MACSTR " (%s) sent 'me' " MACSTR " instead of " MACSTR ", ignored\n",
+          MAC2STR(packet->pong.src_mac), inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          MAC2STR(packet->pong.dst_mac), MAC2STR(peer->my_mac));
+      return;
+    }
+
+    /* keys are installed correctly */
+
+    sae_debug(SAE_DEBUG_REKEY, "rekey: pong from " MACSTR " (%s): keys are installed correctly\n",
+        MAC2STR(packet->pong.src_mac), inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
+
+    srv_rem_timeout(ctx, peer->rekey_ping_timer);
+    peer->rekey_ping_timer = 0;
+    peer->rekey_ping_count = 0;
+    peer->rekey_reauth_count = 0;
+    peer->rekey_ok = 1;
+    peer->rekey_ok_ping_rx = 0;
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: pong rx failed: %s\n", strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent %d bytes instead of %d\n",
+      inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), bytes, sizeof(packet->pong));
+}
+
+static void pong_socket_close(void) {
+  if (pong_socket == -1) {
+    return;
+  }
+
+  srv_rem_input(ctx, pong_socket);
+
+  close(pong_socket);
+  pong_socket = -1;
+}
+
+static void pong_socket_create(const char* iface, int af) {
+  if (pong_socket != -1) {
+    return;
+  }
+
+  pong_socket = create_dgram_socket(af);
+  if (pong_socket == -1) {
+    goto err;
+  }
+
+  if (!bind_socket_to_interface(pong_socket, iface)) {
+    goto err;
+  }
+
+  ip_address bind_ip;
+  memset(&bind_ip, 0, sizeof(bind_ip));
+  if (af == AF_INET) {
+    bind_ip.v4.s_addr = htonl(INADDR_ANY);
+  } else {
+    bind_ip.v6 = in6addr_any;
+  }
+
+  if (!bind_socket_to_ip_and_port(pong_socket, af, &bind_ip, cfg->conf->rekey_pong_port)) {
+    goto err;
+  }
+
+  if (fcntl(pong_socket, F_SETFL, O_NDELAY)) {
+    goto err;
+  }
+
+  if (srv_add_input(ctx, pong_socket, NULL, pong_rx)) {
+    goto err;
+  }
+
+  return;
+
+  err: pong_socket_close();
+}
+
+/*
+ * ping receive
+ */
+
+static int ping_socket_rx_af = AF_INET;
+static int ping_socket_rx_ifindex = 0;
+static int ping_socket_rx = -1;
+
+static void ping_rx(int sock, void *data) {
+  char str[INET6_ADDRSTRLEN];
+  uint8_t buffer[sizeof(packet_struct) + 1];
+  packet_struct *packet = (packet_struct *) buffer;
+  struct sockaddr_storage src;
+  socklen_t src_len = sizeof(src);
+
+  int bytes = recvfrom(sock, buffer, sizeof(buffer), 0, (struct sockaddr *) &src, &src_len);
+
+  if (bytes == sizeof(packet->ping)) {
+    if (packet->ping.header.type != PACKET_TYPE_PING) {
+      sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent type %u instead of %u, ignored\n",
+          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->ping.header.type,
+          PACKET_TYPE_PING);
+      return;
+    }
+
+    if (packet->ping.header.version != PACKET_VERSION_PING) {
+      sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent version %u instead of %u, ignored\n",
+          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->ping.header.version,
+          PACKET_VERSION_PING);
+      return;
+    }
+
+    struct candidate *peer = find_peer(packet->ping.src_mac, 1);
+    if (!peer) {
+      sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent unknown accepted peer " MACSTR ", ignored\n",
+          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), MAC2STR(packet->ping.src_mac));
+      return;
+    }
+
+    if (memcmp(packet->ping.dst_mac, peer->my_mac, sizeof(packet->ping.dst_mac))) {
+      /* not meant for me */
+      return;
+    }
+
+    sae_debug(SAE_DEBUG_REKEY, "rekey: ping from " MACSTR " (%s)\n", MAC2STR(packet->ping.src_mac),
+        inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
+
+    /* re-authenticate when we concluded that keys are installed correctly but we are still receiving pings */
+    if (peer->rekey_ok) {
+      peer->rekey_ok_ping_rx++;
+      if (peer->rekey_ok_ping_rx > cfg->conf->rekey_ok_ping_count_max) {
+        sae_debug(SAE_DEBUG_REKEY,
+            "rekey: too many pings (%u) from " MACSTR " (%s) while considering keys correctly installed,"
+            " doing reauthentication\n", peer->rekey_ok_ping_rx, MAC2STR(packet->ping.src_mac),
+            inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
+        peer->rekey_ok_ping_rx = 0;
+        do_reauth(peer);
+        return;
+      }
+    }
+
+    pong_tx(peer, &src, packet->ping.src_port);
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: ping rx failed: %s\n", strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent %d bytes instead of %d\n",
+      inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), bytes, sizeof(packet->ping));
+}
+
+static void ping_socket_close_rx(void) {
+  if (ping_socket_rx == -1) {
+    return;
+  }
+
+  srv_rem_input(ctx, ping_socket_rx);
+
+  if (ping_socket_rx_ifindex) {
+    if (ping_socket_rx_af == AF_INET) {
+      struct ip_mreq mreq;
+      memset(&mreq, 0, sizeof(mreq));
+      mreq.imr_multiaddr.s_addr = cfg->conf->rekey_multicast_group_address.v4.s_addr;
+      mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+      (void) setsockopt(ping_socket_rx, IPPROTO(ping_socket_rx_af), IPMCLEAVE(ping_socket_rx_af), &mreq, sizeof(mreq));
+    } else {
+      struct ipv6_mreq mreq;
+      memset(&mreq, 0, sizeof(mreq));
+      mreq.ipv6mr_multiaddr = cfg->conf->rekey_multicast_group_address.v6;
+      mreq.ipv6mr_interface = ping_socket_rx_ifindex;
+      (void) setsockopt(ping_socket_rx, IPPROTO(ping_socket_rx_af), IPMCLEAVE(ping_socket_rx_af), &mreq, sizeof(mreq));
+    }
+  }
+
+  close(ping_socket_rx);
+  ping_socket_rx = -1;
+  ping_socket_rx_ifindex = 0;
+}
+
+static void ping_socket_create_rx(const char* iface, int af) {
+  if (ping_socket_rx != -1) {
+    return;
+  }
+
+  ping_socket_rx_af = af;
+
+  ping_socket_rx_ifindex = if_nametoindex(iface);
+  if (!ping_socket_rx_ifindex) {
+    goto err;
+  }
+
+  ping_socket_rx = create_dgram_socket(af);
+  if (ping_socket_rx == -1) {
+    goto err;
+  }
+
+  if (!bind_socket_to_interface(ping_socket_rx, iface)) {
+    goto err;
+  }
+
+  ip_address bind_ip;
+  memset(&bind_ip, 0, sizeof(bind_ip));
+  if (af == AF_INET) {
+    bind_ip.v4.s_addr = htonl(INADDR_ANY);
+  } else {
+    bind_ip.v6 = in6addr_any;
+  }
+
+  if (!bind_socket_to_ip_and_port(ping_socket_rx, af, &bind_ip, cfg->conf->rekey_ping_port)) {
+    goto err;
+  }
+
+  uint8_t loopback = 0;
+  if (setsockopt(ping_socket_rx, IPPROTO(af), IPMCLOOP(af), &loopback, sizeof(loopback)) == -1) {
+    goto err;
+  }
+
+  if (af == AF_INET) {
+    struct ip_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    mreq.imr_multiaddr = cfg->conf->rekey_multicast_group_address.v4;
+    mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+    if (setsockopt(ping_socket_rx, IPPROTO(af), IPMCJOIN(af), &mreq, sizeof(mreq)) == -1) {
+      goto err;
+    }
+  } else {
+    struct ipv6_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    mreq.ipv6mr_multiaddr = cfg->conf->rekey_multicast_group_address.v6;
+    mreq.ipv6mr_interface = ping_socket_rx_ifindex;
+    if (setsockopt(ping_socket_rx, IPPROTO(af), IPMCJOIN(af), &mreq, sizeof(mreq)) == -1) {
+      goto err;
+    }
+  }
+
+  if (srv_add_input(ctx, ping_socket_rx, NULL, ping_rx)) {
+    goto err;
+  }
+
+  return;
+
+  err: ping_socket_close_rx();
+}
+
+/*
+ * ping send
+ */
+
+static int ping_socket_tx = -1;
+
+static void ping_tx(timerid id, void *data) {
+  if (!data || !cfg) {
+    return;
+  }
+
+  struct candidate *peer = (struct candidate *) data;
+
+  peer->rekey_ping_count++;
+
+  /* check whether we sent too many pings */
+  if (peer->rekey_ping_count > cfg->conf->rekey_ping_count_max) {
+    sae_debug(SAE_DEBUG_REKEY, "rekey: too many pings (%u) to " MACSTR "\n", peer->rekey_ping_count,
+        MAC2STR(peer->peer_mac));
+
+    srv_rem_timeout(ctx, peer->rekey_ping_timer);
+    peer->rekey_ping_timer = 0;
+    peer->rekey_ping_count = 0;
+
+    /* check whether we can do another reauthentication */
+    if (peer->rekey_reauth_count < cfg->conf->rekey_reauth_count_max) {
+      rekey_reopen_sockets();
+      peer->rekey_reauth_count++;
+      sae_debug(SAE_DEBUG_REKEY, "rekey: reauthentication %u with " MACSTR "\n", peer->rekey_reauth_count,
+          MAC2STR(peer->peer_mac));
+      do_reauth(peer);
+      return;
+    }
+
+    sae_debug(SAE_DEBUG_REKEY, "rekey: too many reauthentications (%u) with " MACSTR "\n", peer->rekey_reauth_count,
+        MAC2STR(peer->peer_mac));
+
+    return;
+  }
+
+  /* ping */
+
+  packet_struct packet;
+  memset(&packet, 0, sizeof(packet));
+  packet.ping.header.type = PACKET_TYPE_PING;
+  packet.ping.header.version = PACKET_VERSION_PING;
+  memcpy(packet.ping.dst_mac, peer->peer_mac, sizeof(packet.ping.dst_mac));
+  memcpy(packet.ping.src_mac, peer->my_mac, sizeof(packet.ping.src_mac));
+  packet.ping.src_port = cfg->conf->rekey_pong_port;
+
+  struct sockaddr_storage dst;
+  memset(&dst, 0, sizeof(dst));
+  dst.ss_family = cfg->conf->rekey_multicast_group_family;
+  void * dst_addr;
+  if (dst.ss_family == AF_INET) {
+    struct sockaddr_in *dst4 = (struct sockaddr_in *) &dst;
+    dst4->sin_addr = cfg->conf->rekey_multicast_group_address.v4;
+    dst4->sin_port = cfg->conf->rekey_ping_port;
+    dst_addr = &dst4->sin_addr;
+  } else {
+    struct sockaddr_in6 *dst6 = (struct sockaddr_in6 *) &dst;
+    dst6->sin6_addr = cfg->conf->rekey_multicast_group_address.v6;
+    dst6->sin6_port = cfg->conf->rekey_ping_port;
+    dst_addr = &dst6->sin6_addr;
+  }
+
+  char str[INET6_ADDRSTRLEN];
+  sae_debug(SAE_DEBUG_REKEY, "rekey: ping %u to " MACSTR " (%s)\n", peer->rekey_ping_count, MAC2STR(peer->peer_mac),
+      inet_ntop(dst.ss_family, dst_addr, str, sizeof(str)));
+
+  int bytes = sendto(ping_socket_tx, &packet.ping, sizeof(packet.ping), 0, (struct sockaddr *) &dst, sizeof(dst));
+
+  if (bytes == sizeof(packet.ping)) {
+    srv_rem_timeout(ctx, peer->rekey_ping_timer);
+    peer->rekey_ping_timer = srv_add_timeout(ctx, SRV_MSEC(cfg->conf->rekey_ping_timeout), ping_tx, peer);
+    if (!peer->rekey_ping_timer) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: ping %u to " MACSTR " failed to reschedule its ping timeout\n",
+          peer->rekey_ping_count, MAC2STR(peer->peer_mac));
+    }
+    return;
+  }
+
+  if (bytes == -1) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: ping %u to " MACSTR " failed: %s\n", peer->rekey_ping_count,
+        MAC2STR(peer->peer_mac), strerror(errno));
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_REKEY, "rekey: ping %u to " MACSTR " sent %d bytes instead of %d\n", peer->rekey_ping_count,
+      MAC2STR(peer->peer_mac), bytes, sizeof(packet.ping));
+}
+
+static void ping_socket_close_tx(void) {
+  if (ping_socket_tx == -1) {
+    return;
+  }
+
+  close(ping_socket_tx);
+  ping_socket_tx = -1;
+}
+
+static void ping_socket_create_tx(const char* iface, int af) {
+  if (ping_socket_tx != -1) {
+    return;
+  }
+
+  ping_socket_tx = create_dgram_socket(af);
+  if (ping_socket_tx == -1) {
+    goto err;
+  }
+
+  if (!bind_socket_to_interface(ping_socket_tx, iface)) {
+    goto err;
+  }
+
+  uint8_t loopback = 0;
+  if (setsockopt(ping_socket_tx, IPPROTO(af), IPMCLOOP(af), &loopback, sizeof(loopback)) == -1) {
+    goto err;
+  }
+
+  int ttl = 1;
+  if (setsockopt(ping_socket_tx, IPPROTO(af), IPMCTTL(af), &ttl, sizeof(ttl))) {
+    goto err;
+  }
+
+  if (fcntl(ping_socket_tx, F_SETFL, O_NDELAY)) {
+    goto err;
+  }
+
+  return;
+
+  err: ping_socket_close_tx();
+}
+
+/*
+ * sockets
+ */
+
+#define ALL_SOCKETS_OPEN ((ping_socket_tx != -1) && (ping_socket_rx != -1) && (pong_socket != -1))
+
+static void rekey_sockets_close(void) {
+  sae_debug(SAE_DEBUG_REKEY, "rekey: closing sockets\n");
+
+  ping_socket_close_tx();
+  ping_socket_close_rx();
+  pong_socket_close();
+}
+
+static void rekey_sockets_reopen(void) {
+  if (!cfg) {
+    return;
+  }
+
+  sae_debug(SAE_DEBUG_REKEY, "rekey: reopening sockets\n");
+
+  int af = cfg->conf->rekey_multicast_group_family;
+
+  char *iface;
+  if (cfg->conf->bridge[0]) {
+    iface = cfg->conf->bridge;
+  } else {
+    iface = cfg->conf->interface;
+  }
+
+  pong_socket_create(iface, af);
+  ping_socket_create_rx(iface, af);
+  ping_socket_create_tx(iface, af);
+}
+
+/*
+ * interfaces
+ */
+
+/* volatile because it is accessed from multiple threads */
+static volatile bool reopen_sockets = true;
+
+void rekey_reopen_sockets(void) {
+  sae_debug(SAE_DEBUG_REKEY, "rekey: requesting reopening sockets\n");
+  reopen_sockets = true;
+}
+
+void rekey_verify_peer(struct candidate *peer) {
+  if (reopen_sockets) {
+    reopen_sockets = false;
+    rekey_sockets_close();
+  }
+
+  if (!ALL_SOCKETS_OPEN) {
+    rekey_sockets_reopen();
+  }
+
+  if (!ALL_SOCKETS_OPEN) {
+    sae_debug(SAE_DEBUG_ERR, "rekey: error reopening sockets\n");
+    return;
+  }
+
+  if (!cfg || !cfg->conf->rekey_enable || !peer) {
+    return;
+  }
+
+  if (!peer->rekey_ping_timer) {
+    sae_debug(SAE_DEBUG_REKEY, "rekey: start rekey for " MACSTR "\n", MAC2STR(peer->peer_mac));
+    peer->rekey_ping_count = 0;
+    peer->rekey_ok = 0;
+    peer->rekey_ok_ping_rx = 0;
+    peer->rekey_ping_timer = srv_add_timeout_with_jitter(ctx, SRV_MSEC(cfg->conf->rekey_ping_timeout), ping_tx, peer,
+        SRV_MSEC(cfg->conf->rekey_ping_jitter));
+    if (!peer->rekey_ping_timer) {
+      sae_debug(SAE_DEBUG_ERR, "rekey: failed to schedule ping timeout for " MACSTR "\n", MAC2STR(peer->peer_mac));
+    }
+  } else {
+    sae_debug(SAE_DEBUG_REKEY, "rekey: rekey already running for " MACSTR "\n", MAC2STR(peer->peer_mac));
+  }
+}
+
+/*
+ * lifecycle
+ */
+
+void rekey_init(service_context context, struct mesh_node *config) {
+  if (cfg) {
+    return;
+  }
+
+  assert(context);
+  assert(config);
+
+  ctx = context;
+  cfg = config;
+
+  rekey_reopen_sockets();
+}
+
+void rekey_close(void) {
+  if (!cfg) {
+    return;
+  }
+
+  rekey_sockets_close();
+
+  cfg = NULL;
+  ctx = NULL;
+}

--- a/rekey.h
+++ b/rekey.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Dan Harkins, 2008, 2009, 2010
+ * Copyright (c) CoCo Communications, 2015
+ * Copyright (c) Pelagic, 2017
  *
  *  Copyright holder grants permission for redistribution and use in source
  *  and binary forms, with or without modification, provided that the
@@ -15,7 +16,7 @@
  *	  or use of this software must display the following acknowledgement:
  *
  *        "This product includes software written by
- *         Dan Harkins (dharkins at lounge dot org)"
+ *         Jesse Jones (jjones at cococorp dot com)"
  *
  *  "DISCLAIMER OF LIABILITY
  *
@@ -36,43 +37,30 @@
  * license (including the GNU public license).
  */
 
-#ifndef _SAE_H_
-#define _SAE_H_
+#ifndef _SAE_REKEY_H_
+#define _SAE_REKEY_H_
 
-#include <libconfig.h>
+#include <netinet/in.h>
 
-#include "ieee802_11.h"
+#include "ampe.h"
 #include "peers.h"
+#include "service.h"
 
-#define    SAE_MAX_EC_GROUPS    10
-#define    SAE_MAX_PASSWORD_LEN 80
+#define REKEY_ENABLE_DEF                   (false)
+#define REKEY_MULTICAST_GROUP_FAMILY_DEF   (AF_INET)
+#define REKEY_MULTICAST_GROUP_ADDRESS_DEF  (htonl(0xE00000C8)) /* 224.0.0.200 */
+#define REKEY_PING_PORT_DEF                (4875)
+#define REKEY_PONG_PORT_DEF                (4876)
+#define REKEY_PING_COUNT_MAX_DEF           (32)
+#define REKEY_PING_TIMEOUT_MSECS_DEF       (500)
+#define REKEY_PING_JITTER_MSECS_DEF        (100)
+#define REKEY_REAUTH_COUNT_MAX_DEF         (8)
+#define REKEY_OK_PING_COUNT_MAX_DEF        (16)
 
-struct sae_config {
-    int group[SAE_MAX_EC_GROUPS];
-    int num_groups;
-    char pwd[SAE_MAX_PASSWORD_LEN];
-    int debug;
-    int retrans;
-    int pmk_expiry;
-    int open_threshold;
-    int blacklist_timeout;
-    int giveup_threshold;
-};
+void rekey_init(service_context srvctx, struct mesh_node *mesh);
+void rekey_close(void);
 
-/* You may choose not to call sae_parse_config and
- * populate sae_config in some other way before
- * invoking sae_initialize() */
-int sae_parse_config(char* confdir, struct sae_config *config);
-int sae_parse_libconfig (struct config_setting_t *sae_section, struct sae_config* config);
-int sae_initialize(char *ssid, struct sae_config *config);
-int process_mgmt_frame(struct ieee80211_mgmt_frame *frame, int len,
-                       unsigned char *local_mac_addr, void *cookie);
-void sae_read_config(int signal);
-void sae_dump_db (int signal);
-int prf (unsigned char *key, int keylen, unsigned char *label, int labellen,
-     unsigned char *context, int contextlen,
-     unsigned char *result, int resultbitlen);
+void rekey_verify_peer(struct candidate *peer);
+void rekey_reopen_sockets(void);
 
-void do_reauth(struct candidate *peer);
-
-#endif  /* _SAE_H_ */
+#endif  /* _SAE_REKEY_H_ */

--- a/sae.c
+++ b/sae.c
@@ -241,6 +241,8 @@ delete_peer (struct candidate **delme)
             peer->t1 = 0;
             srv_rem_timeout(srvctx, peer->t2);     /*      ditto         */
             peer->t2 = 0;
+            srv_rem_timeout(srvctx, peer->rekey_ping_timer);
+            peer->rekey_ping_timer = 0;
             TAILQ_REMOVE(&peers, peer, entry);
             /*
              * PWE, the private value, the PMK and KCK are all secret so


### PR DESCRIPTION
    meshd-nl80211: add re-key support
    
    Re-key checks that the peer-to-peer link encryption keys have been
    programmed correctly on both sides of the link.
    
    This is needed for chips/drivers that have problems with new peer-to-peer
    link encryption keys being programmed. Especially ath9k is relevant
    since it has exactly this problem when it's under load.
    
    When a peer node has been authenticated (the peer-to-peer link encryption
    keys have been programmed), then the re-key process is started:
    - An UDP packet containing the peer's MAC address, the node's MAC address
      and the node's UDP reply port is sent to a multicast address.
    - This UDP packet is received by all neighbours and only the peer node
      with the same MAC address as the peer MAC address in the UDP packet
      replies with an UDP packet to the IP address and UDP port combination
      derived from the received UDP packet.
    - The node that started the re-key process receives that UDP packet and
      conclude that the peer-to-peer link encryption keys have been installed
      correctly.
    
    The sending of the UDP packets to the multicast address is retried a few
    times when no reply is received from the correct node within a certain
    timeout.
    
    When the maximum number of retries has been exceeded then the node
    concludes that the peer-to-peer link encryption keys have not been
    installed correctly and therefore restarts the authentication process
    for the peer.
    
    When the node has concluded that the peer-to-peer link encryption keys
    have been installed correctly, but it's still receiving UDP packets on
    the multicast address from the corresponding peer node, then the other
    side of the link has not installed the peer-to-peer link encryption keys
    correctly and the node therefore restarts the authentication process for
    the peer.
    
    This patch was originally written by Alexis Green and then further
    adjusted by me.


======

I've reworked the patch to now be more compact, and use information already available: the exchange uses MAC addresses already available in the association structure.

I've noticed in our large test network that setting the lifetime to 1 minute is too short; the network will eventually collapse. I've now sett it to 1 hour and everything seems to work fine.