### PR TITLE
Make libsae and headers available as build output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,19 @@ LIST(APPEND libsae_sources
 
 ADD_LIBRARY(sae STATIC ${libsae_sources})
 TARGET_LINK_LIBRARIES(sae ${libsae_libs})
+install(TARGETS sae DESTINATION lib)
+
+install(FILES
+  ampe.h
+  common.h
+  ieee802_11.h
+  os_glue.h
+  peers.h
+  rekey.h
+  sae.h
+  service.h
+  DESTINATION include/authsae
+)
 
 #####################################################################
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
The SAE and AMPE component of authsae is already largely isolated from the mesh component to allow porting to other OSes. This change makes the component accessible to other users by publishing libsae and the relevant headers from the build.