### PR TITLE
Remove #define-d type alias that may conflict when using libsae with other libraries

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -125,7 +125,7 @@ static int plink_free_count() {
     return 99;
 }
 
-static inline u8* start_of_ies(struct ieee80211_mgmt_frame *frame,
+static inline unsigned char* start_of_ies(struct ieee80211_mgmt_frame *frame,
     int len, u16 *ie_len)
 {
     int offset=0;
@@ -318,7 +318,7 @@ static int protect_frame(struct candidate *cand, struct ieee80211_mgmt_frame *mg
     unsigned short cat_to_mic_len;
     struct mesh_node *mesh = cand->conf->mesh;
     size_t ampe_ie_len;
-    u8 ftype = mgmt->action.action_code;
+    unsigned char ftype = mgmt->action.action_code;
     le16 igtk_keyid;
 
     assert(mic_start && cand && mgmt && len);
@@ -414,8 +414,8 @@ static int check_frame_protection(struct candidate *cand, struct ieee80211_mgmt_
     unsigned short ampe_ie_len, cat_to_mic_len;
     int r;
     unsigned int* key_expiration_p;
-    u8 ftype = mgmt->action.action_code;
-    u8 *gtkdata, *igtkdata;
+    unsigned char ftype = mgmt->action.action_code;
+    unsigned char *gtkdata, *igtkdata;
 
     assert(len && cand && mgmt);
 

--- a/common.h
+++ b/common.h
@@ -66,9 +66,6 @@ void sae_debug (int level, const char *fmt, ...);
 void sae_hexdump(int level, const char *label, const unsigned char *start, int
         len);
 
-#ifndef u8
-#define u8 unsigned char
-#endif
 #ifndef le16
 #define le16 unsigned short
 #endif


### PR DESCRIPTION
Currently authsae contains an unbounded #define to use `u8` in place of `unsigned char`. When using libsae in conjunction with other libraries, this can cause a type conflict.

Since this is a very small difference and only used in four places in the code, I propose eliminating the alias and instead using the `unsigned char` type directly.