### PR TITLE
Move lists of peers into a separate header to avoid multiple definition when used as a library

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -36,6 +36,7 @@
 #include <string.h>
 
 #include "os_glue.h"
+#include "peer_lists.h"
 #include "peers.h"
 #include "rekey.h"
 #include "sae.h"

--- a/peer_lists.h
+++ b/peer_lists.h
@@ -1,0 +1,14 @@
+#ifndef _SAE_PEER_LISTS_H_
+#define _SAE_PEER_LISTS_H_
+
+#include <sys/queue.h>
+
+#include "peers.h"
+
+TAILQ_HEAD(blacklist, candidate) blacklist;
+TAILQ_HEAD(peers, candidate) peers;
+
+#define for_each_peer(peer) \
+    TAILQ_FOREACH(peer, &peers, entry)
+
+#endif /* _SAE_PEER_LISTS_H_ */

--- a/peers.h
+++ b/peers.h
@@ -82,10 +82,4 @@ struct candidate {
 struct candidate *find_peer(unsigned char *mac, int accept);
 void delete_peer(struct candidate **peer);
 
-TAILQ_HEAD(fubar, candidate) blacklist;
-TAILQ_HEAD(blah, candidate) peers;
-
-#define for_each_peer(peer) \
-	TAILQ_FOREACH(peer, &peers, entry)
-
 #endif /* _SAE_PEERS_H_ */

--- a/sae.c
+++ b/sae.c
@@ -43,6 +43,7 @@
 #include <string.h>
 
 #include "os_glue.h"
+#include "peer_lists.h"
 #include "peers.h"
 #include "service.h"
 


### PR DESCRIPTION
Currently two lists of peers (`peers` and `blacklist`) are declared and defined in `peers.h`. When authsae is used as a library, this causes problems – `peers.h` is included by other headers that must be included by users of libsae, and this causes multiple definition of the two lists.

This change resolves this by moving the definition of the lists into a new header that is intended to be private to the library.