### PR TITLE
Move IE variables into code file to avoid multiple definition and limit scope

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -69,6 +69,10 @@ static const unsigned char akm_suite_selector[4] = { 0x0, 0xf, 0xac, 0x8 };     
 static const unsigned char pw_suite_selector[4] = { 0x0, 0xf, 0xac, 0x4 };     /*  CCMP  */
 static const unsigned char null_nonce[32] = { 0 };
 
+/* IEs */
+static unsigned char *sta_fixed_ies;
+static unsigned char sta_fixed_ies_len;
+
 /* global configuration data */
 static struct ampe_config ampe_conf;
 

--- a/ampe.h
+++ b/ampe.h
@@ -10,8 +10,6 @@
 #include "ieee802_11.h"
 
 unsigned char mgtk_tx[16];
-unsigned char *sta_fixed_ies;
-unsigned char sta_fixed_ies_len;
 
 enum plink_state {
     PLINK_LISTEN,


### PR DESCRIPTION
Currently AMPE uses two variables to keep track of static IEs, and they are defined in `ampe.h`. This gives them unnecessarily large scope (they are only used in `ampe.c`), and causes multiple definition issues when authsae is used as a library.

This change moves the two variables to `ampe.c` to solve both problems.