### PR TITLE
Move MGTK array definition out of header to avoid multiple definition

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -74,6 +74,9 @@ static const unsigned char null_nonce[32] = { 0 };
 static unsigned char *sta_fixed_ies;
 static unsigned char sta_fixed_ies_len;
 
+/* Mesh group temporal key */
+unsigned char mgtk_tx[16];
+
 /* global configuration data */
 static struct ampe_config ampe_conf;
 

--- a/ampe.h
+++ b/ampe.h
@@ -9,8 +9,6 @@
 #include "common.h"
 #include "ieee802_11.h"
 
-unsigned char mgtk_tx[16];
-
 enum plink_state {
     PLINK_LISTEN,
     PLINK_OPN_SNT,

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -89,6 +89,9 @@
 static struct netlink_config_s nlcfg;
 service_context srvctx;
 
+/* Mesh group temporal key */
+extern unsigned char mgtk_tx[16];
+
 /* global configuration data */
 static struct meshd_config meshd_conf;
 static struct mesh_node mesh;


### PR DESCRIPTION
Currently there exists an array for the mesh group temporal key (MGTK) which is defined in `ampe.h`. This causes a multiple definition error when used as a library, and variables generally shouldn't be defined in headers.

This change moves the definition of the array into `ampe.c` and an extern declaration to the the one use outside libsae (in meshd).