### PR TITLE
Publish missing headers necessary for libsae

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,12 @@ install(FILES
   DESTINATION include/authsae
 )
 
+install(FILES
+  crypto/aes_locl.h
+  crypto/siv.h
+  DESTINATION include/authsae/crypto
+)
+
 #####################################################################
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	ADD_SUBDIRECTORY(linux)


### PR DESCRIPTION
In [PR 62](https://github.com/cozybit/authsae/pull/62), the makefile was modified to generate a static lib (libsae), as well as to publish necessary headers for this library. However, in that PR, the headers within `/crypto` were not published, but they are necessary due to transitive includes.

This change adds them to the list of published headers.