### PR TITLE
Fix sizes of some netlink attributes

### DIFF
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1023,7 +1023,7 @@ static int join_mesh_rsn(struct netlink_config_s *nlcfg,
     if (!container)
         goto nla_put_failure;
 
-    NLA_PUT_U32(msg, NL80211_MESHCONF_AUTO_OPEN_PLINKS, 0);
+    NLA_PUT_U8(msg, NL80211_MESHCONF_AUTO_OPEN_PLINKS, 0);
     if(mconf->path_refresh_time > 0) {
         NLA_PUT_U32(msg,NL80211_MESHCONF_PATH_REFRESH_TIME,
                 mconf->path_refresh_time);

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -318,7 +318,7 @@ static int set_mesh_conf(struct netlink_config_s *nlcfg,
         goto nla_put_failure;
 
     if (changed & MESH_CONF_CHANGED_HT)
-        NLA_PUT_U32(msg, NL80211_MESHCONF_HT_OPMODE, mesh->conf->ht_prot_mode);
+        NLA_PUT_U16(msg, NL80211_MESHCONF_HT_OPMODE, mesh->conf->ht_prot_mode);
     nla_nest_end(msg, container);
 
     NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);


### PR DESCRIPTION
From the kernel (net/wireless/nl80211.c):
```
	[NL80211_MESHCONF_AUTO_OPEN_PLINKS] = { .type = NLA_U8 },
[...]
	[NL80211_MESHCONF_HT_OPMODE] = { .type = NLA_U16 },
```
Make userspace match.