### PR TITLE
Change `timerid` type from `unsigned int` to `unsigned long long` for 64-bit compatibility

### DIFF
--- a/service.h
+++ b/service.h
@@ -43,7 +43,7 @@
 #include <sys/select.h>
 #include <time.h>
 
-typedef unsigned int timerid;
+typedef unsigned long long timerid;
 
 /* On 32-bit platforms an unsigned long only gives us:
  * 4294967295 us = 4294967 ms = 4294 s = 71 min


### PR DESCRIPTION
The `timerid` type is currently a typedef of `unsigned int` (32-bit). For increased compatibility with [ZmqEventLoop](https://github.com/facebook/fbzmq/blob/master/fbzmq/async/ZmqEventLoop.h) and other software that provides 64-bit timer/timeout IDs, this change modifies it to instead be a typedef of `unsigned long long`.