### PR TITLE
Remove `timerid` paramter from `timercb` callback function prototype

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -240,7 +240,7 @@ static void peer_ampe_init(struct ampe_config *aconf,
 	return;
 }
 
-static void plink_timer(timerid id, void *data)
+static void plink_timer(void *data)
 {
 	le16 reason;
     struct candidate *cand;

--- a/rekey.c
+++ b/rekey.c
@@ -487,7 +487,7 @@ static void ping_socket_create_rx(const char* iface, int af) {
 
 static int ping_socket_tx = -1;
 
-static void ping_tx(timerid id, void *data) {
+static void ping_tx(void *data) {
   if (!data || !cfg) {
     return;
   }

--- a/sae.c
+++ b/sae.c
@@ -97,7 +97,7 @@ extern service_context srvctx;
 /*
  * forward declarations
  */
-static void reauth(timerid id, void *data);
+static void reauth(void *data);
 
 /*
  * global variables
@@ -205,7 +205,7 @@ prf (unsigned char *key, int keylen, unsigned char *label, int labellen,
 }
 
 static void
-remove_from_blacklist (timerid id, void *data)
+remove_from_blacklist (void *data)
 {
     struct candidate *peer, *delme;
 
@@ -286,7 +286,7 @@ delete_peer (struct candidate **delme)
  * a callback-able version of delete peer
  */
 static void
-destroy_peer (timerid id, void *data)
+destroy_peer (void *data)
 {
     struct candidate *peer = (struct candidate *)data;
 
@@ -1314,7 +1314,7 @@ fail:
 }
 
 static void
-retransmit_peer (timerid id, void *data)
+retransmit_peer (void *data)
 {
     struct candidate *peer;
 
@@ -1458,7 +1458,7 @@ do_reauth (struct candidate *peer)
 }
 
 static void
-reauth (timerid id, void *data)
+reauth (void *data)
 {
     struct candidate *peer = (struct candidate *)data;
     do_reauth(peer);

--- a/service.c
+++ b/service.c
@@ -359,7 +359,6 @@ static void
 check_timers (service_context sc)
 {
     struct timespec right_now, tdiff;
-    timerid tid;
 
     if (sc->ntimers) {
 	/*
@@ -382,9 +381,8 @@ check_timers (service_context sc)
         clock_gettime(CLOCK_MONOTONIC, &right_now);
         tdiff = sc->timers[0].to;
         while (cmp_time(&tdiff, &right_now) < 1) {
-            tid = sc->timers[0].id;
             sc->timers[0].id = 0;
-            (*sc->timers[0].proc)(tid, sc->timers[0].data);
+            (*sc->timers[0].proc)(sc->timers[0].data);
             sc->timers[0].to.tv_sec = sc->timers[0].to.tv_nsec = 0;
             qsort(sc->timers, sc->ntimers, sizeof(struct timer),
                   (int (*)())cmp_timers);

--- a/service.h
+++ b/service.h
@@ -57,7 +57,7 @@ typedef unsigned long long microseconds;
  * input callbacks and timer callbacks
  */
 typedef void (*fdcb)(int fd, void *data);
-typedef void (*timercb)(timerid id, void *data);
+typedef void (*timercb)(void *data);
 typedef void (*dumpcb)(timerid id, int num, int secs, int usecs, char *msg);
 
 /*


### PR DESCRIPTION
The current `timercb` callback function prototype includes a `timerid` parameter, but that argument is not used in any actual callback function implementations.

Since the `timerid` is intended as an opaque timer identifier, it does not have a compelling use in the callback function, so this PR removes it.