### PR TITLE
add a test case for pmf=1 networks

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -523,6 +523,7 @@ static int check_frame_protection(struct candidate *cand, struct ieee80211_mgmt_
         igtkdata += 2 + 6;
         memcpy(cand->igtk, igtkdata, sizeof(cand->igtk));
         cand->has_igtk = true;
+        sae_hexdump(AMPE_DEBUG_KEYS, "Received igtk: ", cand->igtk, sizeof(cand->igtk));
     }
     free(clear_ampe_ie);
     return -1;

--- a/tests/include.sh
+++ b/tests/include.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+CONFIG=/tmp/authsae.cfg
+
+load_hwsim() {
+    local nradios=$1
+    sudo modprobe -r mac80211-hwsim &> /dev/null
+    sudo modprobe mac80211-hwsim radios=$nradios
+}
+
+get_hwsim_radios() {
+    local radios=""
+    for dev in /sys/devices/virtual/mac80211_hwsim/*; do
+        phy=$(basename $dev/ieee80211/*)
+        radios="$radios $phy"
+    done
+    echo $radios
+}
+
+set_default_config() {
+    cat > ${CONFIG} <<EOF
+authsae:
+{
+ sae:
+  {
+    debug = 480;
+    password = "thisisreallysecret";
+    group = [19, 26, 21, 25, 20];
+    blacklist = 5;
+    thresh = 5;
+    lifetime = 3600;
+  };
+ meshd:
+  {
+    meshid = "byteme";
+    interface = "mesh0";
+    band = "11g";
+    channel = 1;
+    htmode = "none";
+    mcast-rate = 12;
+  };
+};
+EOF
+}
+
+start_meshd() {
+    local i=0
+    read -a radios <<<"$@"
+
+    IFACES=()
+    LOGS=()
+
+    sudo rfkill unblock all
+    for radio in ${radios[@]}; do
+        iface="smesh$i"
+        log=/tmp/authsae-$i.log
+
+        sudo iw phy $radio interface add $iface type mesh
+        sudo ip link set $iface up
+
+        MESHD=$(dirname $(realpath $0))/../build/linux/meshd-nl80211
+        [ -x "${MESHD}" ] || err_exit "${MESHD} not found."
+
+        let i=$((i+1))
+        sudo rm -f $log
+        sudo ${MESHD} -i $iface -c ${CONFIG} -o $log -B
+
+        IFACES+=($iface)
+        LOGS+=($log)
+    done
+    wait
+}
+
+
+err_exit() {
+    echo $1
+    exit 1
+}

--- a/tests/test001.sh
+++ b/tests/test001.sh
@@ -9,7 +9,7 @@
 
 cleanup() {
     sudo killall meshd-nl80211
-    rm -fr "${TMP1}" "${TMP2}"
+    rm -fr "${TMP0}" "${TMP1}"
     exit 0
 }
 

--- a/tests/test002.sh
+++ b/tests/test002.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#! /bin/bash
 #
-# Minimal test established a peer link between two meshd instances over hwsim
+# Test exchange with IGTKs
 #
 
 . `dirname $0`/include.sh
@@ -18,6 +18,8 @@ trap cleanup SIGINT
 nradios=2
 load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
 set_default_config
+# enable PMF
+sed -i 's/meshid/pmf=1;&/' $CONFIG
 start_meshd $(get_hwsim_radios) || exit 2
 
 # Wait for peer link establishment
@@ -56,6 +58,19 @@ cat ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
 cat ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "FAIL: mgtk exchange failed"; cat ${TMP0} ${TMP1}; exit 1; }
+
+# igtk exchange in both directions
+cat ${LOG0} | grep ^igtk -A 1 | tail -1 > ${TMP0}
+cat ${LOG1} | grep "Received igtk:" -A 1 | tail -1 > ${TMP1}
+
+[ -s $TMP0 ] || err_exit "FAIL: no igtk received"
+
+diff ${TMP0} ${TMP1} || { echo "FAIL: igtk exchange failed"; cat ${TMP0} ${TMP1}; exit 1; }
+
+cat ${LOG0} | grep "Received igtk:" -A 1 | tail -1 > ${TMP0}
+cat ${LOG1} | grep ^igtk -A 1 | tail -1 > ${TMP1}
+
+diff ${TMP0} ${TMP1} || { echo "FAIL: igtk exchange failed"; cat ${TMP0} ${TMP1}; exit 1; }
 
 echo PASS
 cleanup

--- a/tests/test002.sh
+++ b/tests/test002.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 #
 # Test exchange with IGTKs
 #
@@ -9,7 +9,7 @@
 
 cleanup() {
     sudo killall meshd-nl80211
-    rm -fr "${TMP1}" "${TMP2}"
+    rm -fr "${TMP0}" "${TMP1}"
     exit 0
 }
 


### PR DESCRIPTION
Refactor the existing test a bit to share some common functionality,
and add a new test for networks that have protected management frames.