### PR TITLE
Flush buffer after printing log message in sae_debug()

### DIFF
--- a/common.c
+++ b/common.c
@@ -90,6 +90,7 @@ void sae_debug (int level, const char *fmt, ...)
     if (sae_debug_mask & level) {
         va_start(argptr, fmt);
         vfprintf(stdout, fmt, argptr);
+        fflush(stdout);
         va_end(argptr);
     }
 }


### PR DESCRIPTION
Without flushing the buffer in `sae_debug()`, a case can exist where the log doesn't line up correctly with external callers' logs when using libsae. This adds a flush to help make sure logs are printed immediately.