### PR TITLE
Implement support for assigning AID to new peers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ LIST(APPEND libsae_libs
 )
 
 LIST(APPEND libsae_sources
+    aid.c
 	common.c
 	sae.c
 	service.c
@@ -74,6 +75,7 @@ TARGET_LINK_LIBRARIES(sae ${libsae_libs})
 install(TARGETS sae DESTINATION lib)
 
 install(FILES
+  aid.h
   ampe.h
   common.h
   ieee802_11.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ LIST(APPEND libsae_libs
 )
 
 LIST(APPEND libsae_sources
-    aid.c
+	aid.c
 	common.c
 	sae.c
 	service.c

--- a/aid.c
+++ b/aid.c
@@ -1,29 +1,26 @@
 /* Copyright (c) Facebook, Inc., 2018
  *
- *  Copyright holder grants permission for redistribution and use in source
- *  and binary forms, with or without modification, provided that the
- *  following conditions are met:
- *     1. Redistribution of source code must retain the above copyright
- *        notice, this list of conditions, and the following disclaimer
- *        in all source files.
- *     2. Redistribution in binary form must retain the above copyright
- *        notice, this list of conditions, and the following disclaimer
- *        in the documentation and/or other materials provided with the
- *        distribution.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *  "DISCLAIMER OF LIABILITY
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
- *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
- *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- *  SUCH DAMAGE."
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  */
 
@@ -60,7 +57,7 @@ void init_aidmap() {
   aidmap_initialized = 1;
 }
 
-void set_aid(uint16_t aid, uint8_t in_use) {
+void aid_set(uint16_t aid, uint8_t mark_used) {
   // On first access we need to initialise the bitmap
   if (!aidmap_initialized) {
     init_aidmap();
@@ -74,7 +71,7 @@ void set_aid(uint16_t aid, uint8_t in_use) {
   int word_index = aid >> AID_WORD_SHIFT;
   int bit = aid & AID_WORD_MASK;
 
-  if (in_use) {
+  if (mark_used) {
     // Claim by setting the bit to 0
     aidmap[word_index] &= ~BIT(bit);
   } else {
@@ -83,11 +80,11 @@ void set_aid(uint16_t aid, uint8_t in_use) {
   }
 }
 
-void release_aid(uint16_t aid) {
-  set_aid(aid, /* in_use */ 0);
+void aid_free(uint16_t aid) {
+  aid_set(aid, /* mark_used */ 0);
 }
 
-uint16_t get_free_aid() {
+uint16_t aid_alloc() {
   // On first access we need to initialise the bitmap
   if (!aidmap_initialized) {
     init_aidmap();
@@ -101,7 +98,7 @@ uint16_t get_free_aid() {
         return 0;
       }
 
-      set_aid(aid, /* in_use */ 1);
+      aid_set(aid, /* mark_used */ 1);
       return aid;
     }
   }

--- a/aid.c
+++ b/aid.c
@@ -47,7 +47,7 @@
 static uint8_t aidmap_initialized;
 static uint32_t aidmap[AID_BITMAP_LEN];
 
-void init_aidmap() {
+static void aid_initmap() {
   // A value of 1 indicates "free"
   memset(aidmap, 0xff, sizeof(aidmap));
 
@@ -57,10 +57,10 @@ void init_aidmap() {
   aidmap_initialized = 1;
 }
 
-void aid_set(uint16_t aid, uint8_t mark_used) {
+static void aid_set(uint16_t aid, uint8_t mark_used) {
   // On first access we need to initialise the bitmap
   if (!aidmap_initialized) {
-    init_aidmap();
+    aid_initmap();
   }
 
   // 0 is an invalid AID, we never modify it
@@ -87,7 +87,7 @@ void aid_free(uint16_t aid) {
 uint16_t aid_alloc() {
   // On first access we need to initialise the bitmap
   if (!aidmap_initialized) {
-    init_aidmap();
+    aid_initmap();
   }
 
   for (uint32_t word = 0; word < AID_BITMAP_LEN; word++) {

--- a/aid.c
+++ b/aid.c
@@ -1,0 +1,111 @@
+/* Copyright (c) Facebook, Inc., 2018
+ *
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
+ *  following conditions are met:
+ *     1. Redistribution of source code must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in all source files.
+ *     2. Redistribution in binary form must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *
+ *  "DISCLAIMER OF LIABILITY
+ *
+ *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE."
+ *
+ */
+
+#include "aid.h"
+
+#include <string.h>
+
+// See 802.11-2016 section 9.4.1.8 AID field
+#define MAX_AID 2007
+
+#define DIV_ROUND_UP(x, y) ((x) + (y)-1) / (y)
+#define BIT(x) (1UL << (x))
+
+#define AID_BITMAP_LEN DIV_ROUND_UP(MAX_AID + 1, sizeof(uint32_t) * 8)
+
+// MSB bits of the AID specify a word in the bitmap, LSB bits of the AID specify
+// a bit in a word in the bitmap. This is the distance to shift to get the split
+// between MSB and LSB.
+#define AID_WORD_SHIFT (ffs(sizeof(uint32_t) * 8) - 1)
+
+// These LSB bits specify a bit in a word in the bitmap
+#define AID_WORD_MASK (BIT(AID_WORD_SHIFT) - 1)
+
+static uint8_t aidmap_initialized;
+static uint32_t aidmap[AID_BITMAP_LEN];
+
+void init_aidmap() {
+  // A value of 1 indicates "free"
+  memset(aidmap, 0xff, sizeof(aidmap));
+
+  // 0 is an invalid AID, mark it as "in use"
+  aidmap[0] &= ~1;
+
+  aidmap_initialized = 1;
+}
+
+void set_aid(uint16_t aid, uint8_t in_use) {
+  // On first access we need to initialise the bitmap
+  if (!aidmap_initialized) {
+    init_aidmap();
+  }
+
+  // 0 is an invalid AID, we never modify it
+  if (aid == 0) {
+    return;
+  }
+
+  int word_index = aid >> AID_WORD_SHIFT;
+  int bit = aid & AID_WORD_MASK;
+
+  if (in_use) {
+    // Claim by setting the bit to 0
+    aidmap[word_index] &= ~BIT(bit);
+  } else {
+    // Release by setting the bit to 1
+    aidmap[word_index] |= BIT(bit);
+  }
+}
+
+void release_aid(uint16_t aid) {
+  set_aid(aid, /* in_use */ 0);
+}
+
+uint16_t get_free_aid() {
+  // On first access we need to initialise the bitmap
+  if (!aidmap_initialized) {
+    init_aidmap();
+  }
+
+  for (uint32_t word = 0; word < AID_BITMAP_LEN; word++) {
+    int bit = ffs(aidmap[word]);
+    if (bit) {
+      uint16_t aid = word * sizeof(uint32_t) * 8 + (bit - 1);
+      if (aid > MAX_AID) {
+        return 0;
+      }
+
+      set_aid(aid, /* in_use */ 1);
+      return aid;
+    }
+  }
+
+  // Out of AIDs
+  return 0;
+}

--- a/aid.h
+++ b/aid.h
@@ -1,0 +1,44 @@
+/* Copyright (c) Facebook, Inc., 2018
+ *
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
+ *  following conditions are met:
+ *     1. Redistribution of source code must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in all source files.
+ *     2. Redistribution in binary form must retain the above copyright
+ *        notice, this list of conditions, and the following disclaimer
+ *        in the documentation and/or other materials provided with the
+ *        distribution.
+ *
+ *  "DISCLAIMER OF LIABILITY
+ *
+ *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *  SUCH DAMAGE."
+ *
+ */
+
+#ifndef _SAE_AID_H_
+#define _SAE_AID_H_
+
+#include <stdint.h>
+
+// This file contains helpers associated with the association ID (AID; see
+// 802.11-2016 section 9.4.1.8 AID field) that is assigned to peers
+
+// Get a free AID that can be used for a new peer
+uint16_t get_free_aid();
+
+// Release an AID that is no longer in use and can be allocated to a new peer
+void release_aid(uint16_t aid);
+
+#endif /* _SAE_AID_H_ */

--- a/aid.h
+++ b/aid.h
@@ -1,29 +1,26 @@
 /* Copyright (c) Facebook, Inc., 2018
  *
- *  Copyright holder grants permission for redistribution and use in source
- *  and binary forms, with or without modification, provided that the
- *  following conditions are met:
- *     1. Redistribution of source code must retain the above copyright
- *        notice, this list of conditions, and the following disclaimer
- *        in all source files.
- *     2. Redistribution in binary form must retain the above copyright
- *        notice, this list of conditions, and the following disclaimer
- *        in the documentation and/or other materials provided with the
- *        distribution.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *  "DISCLAIMER OF LIABILITY
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
  *
- *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
- *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- *  SUCH DAMAGE."
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  */
 
@@ -35,10 +32,10 @@
 // This file contains helpers associated with the association ID (AID; see
 // 802.11-2016 section 9.4.1.8 AID field) that is assigned to peers
 
-// Get a free AID that can be used for a new peer
-uint16_t get_free_aid();
+// Allocate a unique AID that can be used for a new peer
+uint16_t aid_alloc();
 
-// Release an AID that is no longer in use and can be allocated to a new peer
-void release_aid(uint16_t aid);
+// Free an AID that is no longer in use and can be allocated to a new peer
+void aid_free(uint16_t aid);
 
 #endif /* _SAE_AID_H_ */

--- a/ampe.c
+++ b/ampe.c
@@ -573,7 +573,7 @@ static int plink_frame_tx(struct candidate *cand, enum plink_action_code action,
             if (action == PLINK_CONFIRM) {
                 /* AID */
                 uint16_t* aid = (uint16_t*)pos;
-                *aid = cand->association_id;
+                *aid = ieee_order(cand->association_id);
                 pos += 2;
             }
         }

--- a/ampe.c
+++ b/ampe.c
@@ -572,7 +572,8 @@ static int plink_frame_tx(struct candidate *cand, enum plink_action_code action,
             *pos++ = 0;
             if (action == PLINK_CONFIRM) {
                 /* AID */
-                memset(pos, 0, 2);
+                uint16_t* aid = (uint16_t*)pos;
+                *aid = cand->association_id;
                 pos += 2;
             }
         }

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -467,8 +467,9 @@ static int add_unauthenticated_sta(struct netlink_config_s *nlcfg,
 
     NLA_PUT(msg, NL80211_ATTR_STA_FLAGS2, sizeof(flags), &flags);
 
-    /* FIXME: generate AID */
-    NLA_PUT_U16(msg, NL80211_ATTR_STA_AID, 1);
+    uint16_t peerAid = find_peer(peer, /* accept */ 0)->association_id;
+    NLA_PUT_U16(msg, NL80211_ATTR_STA_AID, peerAid);
+
     NLA_PUT_U16(msg, NL80211_ATTR_STA_LISTEN_INTERVAL, 100);
 
     /* unset 20/40mhz in ht_cap if ht op ie indicates this is a 20mhz STA */

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -467,8 +467,8 @@ static int add_unauthenticated_sta(struct netlink_config_s *nlcfg,
 
     NLA_PUT(msg, NL80211_ATTR_STA_FLAGS2, sizeof(flags), &flags);
 
-    uint16_t peerAid = find_peer(peer, /* accept */ 0)->association_id;
-    NLA_PUT_U16(msg, NL80211_ATTR_STA_AID, peerAid);
+    uint16_t peer_aid = find_peer(peer, /* accept */ 0)->association_id;
+    NLA_PUT_U16(msg, NL80211_ATTR_STA_AID, peer_aid);
 
     NLA_PUT_U16(msg, NL80211_ATTR_STA_LISTEN_INTERVAL, 100);
 

--- a/peers.h
+++ b/peers.h
@@ -73,7 +73,7 @@ struct candidate {
     void *cookie;
     struct ampe_config *conf;
     unsigned int ch_type; /* nl80211_channel_type */
-    int candidate_id;
+    unsigned short association_id;
 
     timerid rekey_ping_timer;
     unsigned int rekey_ping_count;

--- a/sae.c
+++ b/sae.c
@@ -43,6 +43,7 @@
 #include <openssl/rand.h>
 #include <string.h>
 
+#include "aid.h"
 #include "os_glue.h"
 #include "peer_lists.h"
 #include "peers.h"
@@ -274,6 +275,7 @@ delete_peer (struct candidate **delme)
             EC_POINT_free(peer->peer_element);
             BN_free(peer->my_scalar);
             EC_POINT_free(peer->my_element);
+            release_aid(peer->association_id);
             free(*delme);
             *delme = NULL;
             return;
@@ -1349,8 +1351,6 @@ retransmit_peer (void *data)
     }
 }
 
-static int next_candidate_id = 0;
-
 struct candidate *
 create_candidate (unsigned char *her_mac, unsigned char *my_mac, unsigned short got_token, void *cookie)
 {
@@ -1376,7 +1376,7 @@ create_candidate (unsigned char *her_mac, unsigned char *my_mac, unsigned short 
     TAILQ_INSERT_TAIL(&peers, peer, entry);
     peer->state = SAE_NOTHING;
     peer->cookie = cookie;
-    peer->candidate_id = next_candidate_id++;
+    peer->association_id = get_free_aid();
     curr_open++;
 
     peer_created(her_mac);

--- a/sae.c
+++ b/sae.c
@@ -275,7 +275,7 @@ delete_peer (struct candidate **delme)
             EC_POINT_free(peer->peer_element);
             BN_free(peer->my_scalar);
             EC_POINT_free(peer->my_element);
-            release_aid(peer->association_id);
+            aid_free(peer->association_id);
             free(*delme);
             *delme = NULL;
             return;
@@ -1376,7 +1376,7 @@ create_candidate (unsigned char *her_mac, unsigned char *my_mac, unsigned short 
     TAILQ_INSERT_TAIL(&peers, peer, entry);
     peer->state = SAE_NOTHING;
     peer->cookie = cookie;
-    peer->association_id = get_free_aid();
+    peer->association_id = aid_alloc();
     curr_open++;
 
     peer_created(her_mac);


### PR DESCRIPTION
This change fixes a TODO related to creation of new peers.

A peer must have a unique association ID (AID) allocated to it (see _802.11-2016 section 9.4.1.8 AID field_). This is sent in mesh peering confirm frames, as well as reported to the kernel/driver when creating a new station.

- Previously, we always reported the AID to be either 0 (mesh peering confirm frames) or 1 (to the kernel/driver).
- Now, we use a bitmap to keep track of which AIDs have already been allocated to peers. Utility functions are added to easily get an unallocated AID to allocate to a peer, and to free allocated AIDs when a peer is deleted (e.g. due to a failed peering).