### PR TITLE
Warn if mesh ID is being truncated to fit the maximum length

### DIFF
--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1334,7 +1334,7 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
     }
 
     if (config_setting_lookup_string(meshd_section, "meshid", (const char **)&str)) {
-        strncpy(config->meshid, str, MESHD_MAX_SSID_LEN);
+        strncpy(config->meshid, str, MESHD_MAX_SSID_LEN + 1);
         if (config->meshid[MESHD_MAX_SSID_LEN] != 0) {
             fprintf(stderr, "WARNING: Truncating meshid\n");
             config->meshid[MESHD_MAX_SSID_LEN] = 0;


### PR DESCRIPTION
Currently there exists an off-by-one error when determining whether a mesh ID is too long.

We always copy a string up to length `MESHD_MAX_SSID_LEN` into an array of length `MESHD_MAX_SSID_LEN + 1`, and then validate that the `MESHD_MAX_SSID_LEN`th position is null. This will always be true, even if we truncate the string.

We should actually copy up to `MESHD_MAX_SSID_LEN + 1` characters prior to checking the `MESHD_MAX_SSID_LEN`th position.