### PR TITLE
Delete peer if it sends a COMMIT after already ACCEPTED

### DIFF
--- a/sae.c
+++ b/sae.c
@@ -1763,6 +1763,9 @@ process_authentication_frame (struct candidate *peer, struct ieee80211_mgmt_fram
                     /*
                      * something stinks in state machine land...
                      */
+                    sae_debug(SAE_DEBUG_STATE_MACHINE, "got a COMMIT from " MACSTR " when already ACCEPTED, deleting to start over\n",
+                              MAC2STR(peer->peer_mac));
+                    return ERR_FATAL;
                     break;
                 case SAE_AUTH_CONFIRM:
                     if (peer->sync > giveup_threshold) {


### PR DESCRIPTION
If a peer is already in ACCEPTED, we currently ignore any further COMMITs that may come from it, per the 802.11 spec. However, this means that if it crashes and reboots, it will not be able to reauthenticate until `t1` (PMK lifetime timer) runs out, which may be set very high.

With this change we will now delete any peers that send us a COMMIT after already being in ACCEPTED state. This mirrors the behaviour of wpa_supplicant.