### PR TITLE
fix bad format specifiers in logging

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -404,7 +404,7 @@ static int protect_frame(struct candidate *cand, struct ieee80211_mgmt_frame *mg
 
     sae_debug(AMPE_DEBUG_KEYS, "Protecting frame from " MACSTR " to " MACSTR "\n",
             MAC2STR(cand->my_mac), MAC2STR(cand->peer_mac));
-    sae_debug(AMPE_DEBUG_KEYS, "Checking tricky lengths of protected frame %d, %d\n",
+    sae_debug(AMPE_DEBUG_KEYS, "Checking tricky lengths of protected frame %d, %zu\n",
             cat_to_mic_len, ampe_ie_len + 2);
 
     sae_hexdump(AMPE_DEBUG_KEYS, "SIV- Put AAD[3]: ", (unsigned char *) &mgmt->action, cat_to_mic_len);

--- a/common.h
+++ b/common.h
@@ -62,7 +62,8 @@ int parse_buffer(char *, char **);
 #define AMPE_DEBUG_ERR         0x200
 #define SAE_DEBUG_REKEY        0x400
 extern unsigned int sae_debug_mask;
-void sae_debug (int level, const char *fmt, ...);
+void sae_debug (int level, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
 void sae_hexdump(int level, const char *label, const unsigned char *start, int
         len);
 

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -804,7 +804,7 @@ static int event_handler(struct nl_msg *msg, void *arg)
             break;
         case NL80211_CMD_FRAME:
             if (tb[NL80211_ATTR_FRAME] && nla_len(tb[NL80211_ATTR_FRAME])) {
-                sae_debug(MESHD_DEBUG, "NL80211_CMD_FRAME (%d.%d)\n", now.tv_sec, now.tv_usec);
+                sae_debug(MESHD_DEBUG, "NL80211_CMD_FRAME (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
                 frame = nla_data(tb[NL80211_ATTR_FRAME]);
                 frame_len = nla_len(tb[NL80211_ATTR_FRAME]);
                 frame_control = ieee_order(frame->frame_control);
@@ -816,18 +816,18 @@ static int event_handler(struct nl_msg *msg, void *arg)
                     if (process_mgmt_frame(frame, frame_len, mesh.mymacaddr, &nlcfg))
                         fprintf(stderr, "libsae: process_mgmt_frame failed\n");
                 } else
-                    sae_debug(MESHD_DEBUG, "got unexpected frame (%d.%d)\n", now.tv_sec, now.tv_usec);
+                    sae_debug(MESHD_DEBUG, "got unexpected frame (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
             }
             break;
         case NL80211_CMD_NEW_STATION:
-            sae_debug(MESHD_DEBUG, "NL80211_CMD_NEW_STATION (%d.%d)\n", now.tv_sec, now.tv_usec);
+            sae_debug(MESHD_DEBUG, "NL80211_CMD_NEW_STATION (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
             break;
         case NL80211_CMD_NEW_PEER_CANDIDATE:
-            sae_debug(MESHD_DEBUG, "NL80211_CMD_NEW_PEER_CANDIDATE(%d.%d)\n", now.tv_sec, now.tv_usec);
+            sae_debug(MESHD_DEBUG, "NL80211_CMD_NEW_PEER_CANDIDATE(%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
             new_candidate_handler(msg, arg);
             break;
         case NL80211_CMD_FRAME_TX_STATUS:
-            sae_debug(MESHD_DEBUG, "NL80211_CMD_TX_STATUS (%d.%d)\n", now.tv_sec, now.tv_usec);
+            sae_debug(MESHD_DEBUG, "NL80211_CMD_TX_STATUS (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
             if (!tb[NL80211_ATTR_ACK] || !tb[NL80211_ATTR_FRAME])
                 sae_debug(MESHD_DEBUG, "tx frame failed!");
             break;

--- a/rekey.c
+++ b/rekey.c
@@ -198,8 +198,8 @@ static void pong_tx(struct candidate *peer, struct sockaddr_storage *src, in_por
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: pong to   " MACSTR " (%s) sent %d bytes instead of %d\n", MAC2STR(peer->peer_mac),
-      bytes, inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)), sizeof(packet.pong));
+  sae_debug(SAE_DEBUG_REKEY, "rekey: pong to   " MACSTR " (%s) sent %d bytes instead of %zu\n", MAC2STR(peer->peer_mac),
+      inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)), bytes, sizeof(packet.pong));
 }
 
 static void pong_rx(int sock, void *data) {
@@ -260,7 +260,7 @@ static void pong_rx(int sock, void *data) {
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent %d bytes instead of %d\n",
+  sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent %d bytes instead of %zu\n",
       inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), bytes, sizeof(packet->pong));
 }
 
@@ -384,7 +384,7 @@ static void ping_rx(int sock, void *data) {
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent %d bytes instead of %d\n",
+  sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent %d bytes instead of %zu\n",
       inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), bytes, sizeof(packet->ping));
 }
 
@@ -569,7 +569,7 @@ static void ping_tx(void *data) {
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: ping %u to " MACSTR " sent %d bytes instead of %d\n", peer->rekey_ping_count,
+  sae_debug(SAE_DEBUG_REKEY, "rekey: ping %u to " MACSTR " sent %d bytes instead of %zu\n", peer->rekey_ping_count,
       MAC2STR(peer->peer_mac), bytes, sizeof(packet.ping));
 }
 

--- a/sae.c
+++ b/sae.c
@@ -602,7 +602,7 @@ confirm_to_peer (struct candidate *peer)
 
     len += SHA256_DIGEST_LENGTH;
 
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, MACSTR " in %s, sending %s (sc=%d), len %d\n",
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, MACSTR " in %s, sending %s (sc=%d), len %zu\n",
               MAC2STR(peer->peer_mac),
               state_to_string(peer->state),
               seq_to_string(ieee_order(frame->authenticate.auth_seq)),
@@ -641,7 +641,7 @@ process_commit (struct candidate *peer, struct ieee80211_mgmt_frame *frame, int 
      */
     if (len < (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
                 (2 * BN_num_bytes(peer->grp_def->prime)) + BN_num_bytes(peer->grp_def->order))) {
-        sae_debug(SAE_DEBUG_ERR, "invalid size for commit message (%d < %d+%d+(2*%d)+%d = %d))\n", len,
+        sae_debug(SAE_DEBUG_ERR, "invalid size for commit message (%d < %d+%zu+(2*%d)+%d = %zu))\n", len,
                   IEEE802_11_HDR_LEN, sizeof(frame->authenticate), BN_num_bytes(peer->grp_def->prime),
                   BN_num_bytes(peer->grp_def->order),
                   (IEEE802_11_HDR_LEN+sizeof(frame->authenticate)+
@@ -926,7 +926,7 @@ commit_to_peer (struct candidate *peer, unsigned char *token, int token_len)
 
     len += (2 * BN_num_bytes(peer->grp_def->prime));
 
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "peer " MACSTR " in %s, sending %s (%s token), len %d, group %d\n",
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "peer " MACSTR " in %s, sending %s (%s token), len %zu, group %d\n",
               MAC2STR(peer->peer_mac),
               state_to_string(peer->state),
               seq_to_string(ieee_order(frame->authenticate.auth_seq)),
@@ -1321,7 +1321,7 @@ retransmit_peer (void *data)
     struct candidate *peer;
 
     peer = (struct candidate *)data;
-    sae_debug(SAE_DEBUG_STATE_MACHINE, "timer %d fired! retrans = %d, incrementing\n", peer->t0, peer->sync);
+    sae_debug(SAE_DEBUG_STATE_MACHINE, "timer %llu fired! retrans = %d, incrementing\n", peer->t0, peer->sync);
     if (peer->sync > giveup_threshold) {
         sae_debug(SAE_DEBUG_STATE_MACHINE, "peer not listening!\n");
         if (peer->state == SAE_COMMITTED) {
@@ -1555,7 +1555,7 @@ process_authentication_frame (struct candidate *peer, struct ieee80211_mgmt_fram
                      */
                     if (status == WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED) {
                         sae_debug(SAE_DEBUG_STATE_MACHINE,
-                                  "received a token request, add a token, length %d, and resend commit\n",
+                                  "received a token request, add a token, length %zu, and resend commit\n",
                                   (len - (IEEE802_11_HDR_LEN + sizeof(frame->authenticate))));
                         commit_to_peer(peer, frame->authenticate.u.var8,
                                        (len - (IEEE802_11_HDR_LEN + sizeof(frame->authenticate))));
@@ -1745,7 +1745,7 @@ process_authentication_frame (struct candidate *peer, struct ieee80211_mgmt_fram
                         }
                         fin(WLAN_STATUS_SUCCESSFUL, peer->peer_mac, peer->pmk, SHA256_DIGEST_LENGTH, peer->cookie);
                     }
-                    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "setting reauth timer for %d seconds\n", pmk_expiry);
+                    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "setting reauth timer for %lu seconds\n", pmk_expiry);
                     if (peer->t1)
                         srv_rem_timeout(srvctx, peer->t1);
                     peer->t1 = srv_add_timeout_with_jitter(srvctx, SRV_SEC(pmk_expiry), reauth, peer, SRV_SEC(REAUTH_JITTER));
@@ -1874,7 +1874,7 @@ have_token (struct ieee80211_mgmt_frame *frame, int len, unsigned char *me)
                     SHA256_DIGEST_LENGTH + BN_num_bytes(group_def->order) +
                     (2 * BN_num_bytes(group_def->prime)))) {
             sae_debug(SAE_DEBUG_PROTOCOL_MSG,
-                      "checking for token in offer of group %d but length is wrong: %d vs. %d\n",
+                      "checking for token in offer of group %d but length is wrong: %d vs. %zu\n",
                       group_def->group_num, len,
                       (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) + sizeof(unsigned short) +
                        SHA256_DIGEST_LENGTH + BN_num_bytes(group_def->order) +


### PR DESCRIPTION
It was reported that the value printed for retransmission
counter was always zero on some platforms, but it was obviously
being updated because it would properly handle unresponsive
peers.

The root cause is that for this printf format string, and lots
of others, the type arguments didn't match the format specifiers.

Add type-checking for sae_debug, and fix up all of the issues it
found.