### PR TITLE
Keying fixes

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -237,7 +237,10 @@ static void peer_ampe_init(struct ampe_config *aconf,
     cand->conf = aconf;
     derive_aek(cand);
     siv_init(&cand->sivctx, cand->aek, SIV_256);
-	return;
+    memset(cand->mtk, 0, sizeof(cand->mtk));
+    memset(cand->mgtk, 0, sizeof(cand->mgtk));
+    memset(cand->igtk, 0, sizeof(cand->igtk));
+    cand->has_igtk = false;
 }
 
 static void plink_timer(void *data)

--- a/ampe.c
+++ b/ampe.c
@@ -855,6 +855,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event)
 			break;
 		case OPN_ACPT:
 			set_link_state(cand, PLINK_ESTAB);
+            derive_mtk(cand);
             estab_peer_link(cand->peer_mac,
                     cand->mtk, sizeof(cand->mtk),
                     cand->mgtk, sizeof(cand->mgtk),


### PR DESCRIPTION
A fix to a possible bug in AMPE in authsae.  It passes the existing test cases but at the moment I don't have a good way to test this case precisely.