### PR TITLE
Add option to selectivity enable/disable linux targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,8 @@ install(FILES
 )
 
 #####################################################################
-IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+OPTION(ENABLE_LINUX_TARGETS "enable building linux specific targets" ON)
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND ${ENABLE_LINUX_TARGETS})
 	ADD_SUBDIRECTORY(linux)
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 


### PR DESCRIPTION
Test Plan: built using cmake with the option set to OFF. This disabled
building the linux targets