### PR TITLE
clang-format all of authsae

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,86 @@
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ FOR_EACH, FOR_EACH_ENUMERATE, FOR_EACH_KV, FOR_EACH_R, FOR_EACH_RANGE, FOR_EACH_RANGE_R, ]
+IncludeCategories:
+  - Regex:           '^<.*\.h(pp)?>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+PointerBindsToType: false
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...

--- a/ampe.c
+++ b/ampe.c
@@ -41,33 +41,39 @@
 #include "sae.h"
 
 /* Peer link cancel reasons */
-#define MESH_LINK_CANCELLED                     52
-#define MESH_MAX_NEIGHBORS                      53
-#define MESH_CAPABILITY_POLICY_VIOLATION        54
-#define MESH_CLOSE_RCVD                         55
-#define MESH_MAX_RETRIES                        56
-#define MESH_CONFIRM_TIMEOUT                    57
-#define MESH_SECURITY_INVALID_GTK               58
-#define MESH_SECURITY_INCONSISTENT_PARAMS       59
-#define MESH_SECURITY_INVALID_CAPABILITY        60
+#define MESH_LINK_CANCELLED 52
+#define MESH_MAX_NEIGHBORS 53
+#define MESH_CAPABILITY_POLICY_VIOLATION 54
+#define MESH_CLOSE_RCVD 55
+#define MESH_MAX_RETRIES 56
+#define MESH_CONFIRM_TIMEOUT 57
+#define MESH_SECURITY_INVALID_GTK 58
+#define MESH_SECURITY_INCONSISTENT_PARAMS 59
+#define MESH_SECURITY_INVALID_CAPABILITY 60
 
 /* Mesh protocol identifiers */
-#define MESH_CONFIG_PP_HWMP                     1
-#define MESH_CONFIG_PM_ALM                      1
-#define MESH_CONFIG_CC_NONE                     0
-#define MESH_CONFIG_SP_NEIGHBOR_OFFSET          1
-#define MESH_CONFIG_AUTH_SAE                    1
+#define MESH_CONFIG_PP_HWMP 1
+#define MESH_CONFIG_PM_ALM 1
+#define MESH_CONFIG_CC_NONE 0
+#define MESH_CONFIG_SP_NEIGHBOR_OFFSET 1
+#define MESH_CONFIG_AUTH_SAE 1
 
 #ifndef BIT
 #define BIT(x) (1UL << (x))
 #endif
 
-#define MESH_CAPA_ACCEPT_PEERINGS               BIT(0)
-#define MESH_CAPA_FORWARDING                    BIT(3)
+#define MESH_CAPA_ACCEPT_PEERINGS BIT(0)
+#define MESH_CAPA_FORWARDING BIT(3)
 
-static const unsigned char akm_suite_selector[4] = { 0x0, 0xf, 0xac, 0x8 };     /*  SAE  */
-static const unsigned char pw_suite_selector[4] = { 0x0, 0xf, 0xac, 0x4 };     /*  CCMP  */
-static const unsigned char null_nonce[32] = { 0 };
+static const unsigned char akm_suite_selector[4] = {0x0,
+                                                    0xf,
+                                                    0xac,
+                                                    0x8}; /*  SAE  */
+static const unsigned char pw_suite_selector[4] = {0x0,
+                                                   0xf,
+                                                   0xac,
+                                                   0x4}; /*  CCMP  */
+static const unsigned char null_nonce[32] = {0};
 
 static struct ampe_cb *cb;
 
@@ -82,155 +88,157 @@ unsigned char mgtk_tx[KEY_LEN_AES_CCMP];
 static struct ampe_config ampe_conf;
 
 /*  For debugging use */
-static const char *mplstates[] = {
-    [PLINK_LISTEN] = "LISTEN",
-    [PLINK_OPN_SNT] = "OPN-SNT",
-    [PLINK_OPN_RCVD] = "OPN-RCVD",
-    [PLINK_CNF_RCVD] = "CNF_RCVD",
-    [PLINK_ESTAB] = "ESTAB",
-    [PLINK_HOLDING] = "HOLDING",
-    [PLINK_BLOCKED] = "BLOCKED"
-};
+static const char *mplstates[] = {[PLINK_LISTEN] = "LISTEN",
+                                  [PLINK_OPN_SNT] = "OPN-SNT",
+                                  [PLINK_OPN_RCVD] = "OPN-RCVD",
+                                  [PLINK_CNF_RCVD] = "CNF_RCVD",
+                                  [PLINK_ESTAB] = "ESTAB",
+                                  [PLINK_HOLDING] = "HOLDING",
+                                  [PLINK_BLOCKED] = "BLOCKED"};
 
+static int plink_frame_tx(
+    struct candidate *cand,
+    enum plink_action_code action,
+    unsigned short reason);
 
-static int plink_frame_tx(struct candidate *cand, enum
-        plink_action_code action, unsigned short reason);
-
-static inline void set_link_state(struct candidate *cand, enum plink_state state)
-{
-	cand->link_state = state;
-	cb->set_plink_state(cand->peer_mac, state, cand->cookie);
+static inline void set_link_state(
+    struct candidate *cand,
+    enum plink_state state) {
+  cand->link_state = state;
+  cb->set_plink_state(cand->peer_mac, state, cand->cookie);
 }
 
 enum plink_event {
-        PLINK_UNDEFINED,
-        OPN_ACPT,
-        OPN_RJCT,
-        OPN_IGNR,
-        CNF_ACPT,
-        CNF_RJCT,
-        CNF_IGNR,
-        CLS_ACPT,
-        CLS_IGNR
+  PLINK_UNDEFINED,
+  OPN_ACPT,
+  OPN_RJCT,
+  OPN_IGNR,
+  CNF_ACPT,
+  CNF_RJCT,
+  CNF_IGNR,
+  CLS_ACPT,
+  CLS_IGNR
 };
 
 static int plink_free_count() {
-    sae_debug(AMPE_DEBUG_FSM, "TODO: return available peer link slots\n");
-    return 99;
+  sae_debug(AMPE_DEBUG_FSM, "TODO: return available peer link slots\n");
+  return 99;
 }
 
-static inline unsigned char* start_of_ies(struct ieee80211_mgmt_frame *frame,
-    int len, u16 *ie_len)
-{
-    int offset=0;
-    switch(frame->action.action_code) {
-        case PLINK_OPEN:
-            offset = 2;
-            break;
-        case PLINK_CONFIRM:
-            offset = 4;
-            break;
-        case PLINK_CLOSE:
-            offset = 0;
-    }
-    if (ie_len)
-        *ie_len = len - 24 - sizeof(frame->action) - offset;
-    return (frame->action.u.var8 + offset);
+static inline unsigned char *
+start_of_ies(struct ieee80211_mgmt_frame *frame, int len, u16 *ie_len) {
+  int offset = 0;
+  switch (frame->action.action_code) {
+    case PLINK_OPEN:
+      offset = 2;
+      break;
+    case PLINK_CONFIRM:
+      offset = 4;
+      break;
+    case PLINK_CLOSE:
+      offset = 0;
+  }
+  if (ie_len)
+    *ie_len = len - 24 - sizeof(frame->action) - offset;
+  return (frame->action.u.var8 + offset);
 }
 
-static void derive_aek(struct candidate *cand)
-{
-    unsigned char context[AES_BLOCK_SIZE];
+static void derive_aek(struct candidate *cand) {
+  unsigned char context[AES_BLOCK_SIZE];
 
-    memcpy(context, akm_suite_selector, 4);
-    if (memcmp(cand->my_mac, cand->peer_mac, ETH_ALEN) < 0) {
-        memcpy(context + 4, cand->my_mac, ETH_ALEN);
-        memcpy(context + 10, cand->peer_mac, ETH_ALEN);
-    } else {
-        memcpy(context + 4, cand->peer_mac, ETH_ALEN);
-        memcpy(context + 10, cand->my_mac, ETH_ALEN);
-    }
+  memcpy(context, akm_suite_selector, 4);
+  if (memcmp(cand->my_mac, cand->peer_mac, ETH_ALEN) < 0) {
+    memcpy(context + 4, cand->my_mac, ETH_ALEN);
+    memcpy(context + 10, cand->peer_mac, ETH_ALEN);
+  } else {
+    memcpy(context + 4, cand->peer_mac, ETH_ALEN);
+    memcpy(context + 10, cand->my_mac, ETH_ALEN);
+  }
 
-    prf(cand->pmk, SHA256_DIGEST_LENGTH,
-        (unsigned char *)"AEK Derivation", strlen("AEK Derivation"),
-        context, sizeof(context),
-        cand->aek, SHA256_DIGEST_LENGTH * 8);
+  prf(cand->pmk,
+      SHA256_DIGEST_LENGTH,
+      (unsigned char *)"AEK Derivation",
+      strlen("AEK Derivation"),
+      context,
+      sizeof(context),
+      cand->aek,
+      SHA256_DIGEST_LENGTH * 8);
 
-    sae_hexdump(AMPE_DEBUG_KEYS, "aek context: ", context, sizeof(context));
-    sae_hexdump(AMPE_DEBUG_KEYS, "aek: ", cand->aek, sizeof(cand->aek));
+  sae_hexdump(AMPE_DEBUG_KEYS, "aek context: ", context, sizeof(context));
+  sae_hexdump(AMPE_DEBUG_KEYS, "aek: ", cand->aek, sizeof(cand->aek));
 }
 
 /* determine and set the correct ht operation mode for all established peers
  * according to 802.11mb 9.23.3. Return MESH_CONF_CHANGED_HT bit if a new
  * operation mode was selected */
-static uint32_t mesh_set_ht_op_mode(struct mesh_node *mesh)
-{
-    struct candidate *peer;
-    uint32_t changed = 0;
-    unsigned int ht_opmode;
-    bool no_ht = false, ht20 = false;
+static uint32_t mesh_set_ht_op_mode(struct mesh_node *mesh) {
+  struct candidate *peer;
+  uint32_t changed = 0;
+  unsigned int ht_opmode;
+  bool no_ht = false, ht20 = false;
 
-    if (mesh->conf->channel_type == CHAN_NO_HT)
-        return 0;
+  if (mesh->conf->channel_type == CHAN_NO_HT)
+    return 0;
 
-    for_each_peer(peer) {
-        if (peer->link_state != PLINK_ESTAB)
-            continue;
+  for_each_peer(peer) {
+    if (peer->link_state != PLINK_ESTAB)
+      continue;
 
-        switch (peer->ch_type) {
-        case CHAN_NO_HT:
-            no_ht = true;
-            goto out;
-        case CHAN_HT20:
-            ht20 = true;
-            break;
-        default:
-            break;
-        }
+    switch (peer->ch_type) {
+      case CHAN_NO_HT:
+        no_ht = true;
+        goto out;
+      case CHAN_HT20:
+        ht20 = true;
+        break;
+      default:
+        break;
     }
+  }
 
 out:
-    if (no_ht)
-        ht_opmode = IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED;
-    else if (ht20 && mesh->conf->channel_type > CHAN_HT20)
-        ht_opmode = IEEE80211_HT_OP_MODE_PROTECTION_20MHZ;
-    else
-        ht_opmode = IEEE80211_HT_OP_MODE_PROTECTION_NONE;
+  if (no_ht)
+    ht_opmode = IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED;
+  else if (ht20 && mesh->conf->channel_type > CHAN_HT20)
+    ht_opmode = IEEE80211_HT_OP_MODE_PROTECTION_20MHZ;
+  else
+    ht_opmode = IEEE80211_HT_OP_MODE_PROTECTION_NONE;
 
-    if (ht_opmode != mesh->conf->ht_prot_mode) {
-        sae_debug(MESHD_DEBUG, "changing ht protection mode to: %d\n", ht_opmode);
-        mesh->conf->ht_prot_mode = ht_opmode;
-        changed = MESH_CONF_CHANGED_HT;
-    }
+  if (ht_opmode != mesh->conf->ht_prot_mode) {
+    sae_debug(MESHD_DEBUG, "changing ht protection mode to: %d\n", ht_opmode);
+    mesh->conf->ht_prot_mode = ht_opmode;
+    changed = MESH_CONF_CHANGED_HT;
+  }
 
-    return changed;
+  return changed;
 }
 
-static void peer_ampe_init(struct ampe_config *aconf,
-                           struct candidate *cand, void *cookie)
-{
-    le16 llid;
+static void peer_ampe_init(
+    struct ampe_config *aconf,
+    struct candidate *cand,
+    void *cookie) {
+  le16 llid;
 
-    assert(cand);
+  assert(cand);
 
-    RAND_bytes((unsigned char *) &llid, sizeof(llid));
-    RAND_bytes(cand->my_nonce, sizeof(cand->my_nonce));
-    cand->cookie = cookie;
-    cand->my_lid = llid;
-    cand->peer_lid = 0;
-    set_link_state(cand, PLINK_LISTEN);
-    cand->timeout = aconf->retry_timeout_ms;
-    cand->conf = aconf;
+  RAND_bytes((unsigned char *)&llid, sizeof(llid));
+  RAND_bytes(cand->my_nonce, sizeof(cand->my_nonce));
+  cand->cookie = cookie;
+  cand->my_lid = llid;
+  cand->peer_lid = 0;
+  set_link_state(cand, PLINK_LISTEN);
+  cand->timeout = aconf->retry_timeout_ms;
+  cand->conf = aconf;
 
-    memset(cand->mtk, 0, sizeof(cand->mtk));
-    memset(cand->mgtk, 0, sizeof(cand->mgtk));
-    memset(cand->igtk, 0, sizeof(cand->igtk));
-    cand->has_igtk = false;
+  memset(cand->mtk, 0, sizeof(cand->mtk));
+  memset(cand->mgtk, 0, sizeof(cand->mgtk));
+  memset(cand->igtk, 0, sizeof(cand->igtk));
+  cand->has_igtk = false;
 
-    if (aconf->mesh->conf->is_secure) {
-        derive_aek(cand);
-        siv_init(&cand->sivctx, cand->aek, SIV_256);
-    }
+  if (aconf->mesh->conf->is_secure) {
+    derive_aek(cand);
+    siv_init(&cand->sivctx, cand->aek, SIV_256);
+  }
 }
 
 /**
@@ -239,725 +247,799 @@ static void peer_ampe_init(struct ampe_config *aconf,
  * @cand: mesh peer link to restart
  *
  * */
-static inline void fsm_restart(struct candidate *cand)
-{
-    peer_ampe_init(&ampe_conf, cand, cand->cookie);
+static inline void fsm_restart(struct candidate *cand) {
+  peer_ampe_init(&ampe_conf, cand, cand->cookie);
 }
 
+static void plink_timer(void *data) {
+  le16 reason;
+  struct candidate *cand;
 
-static void plink_timer(void *data)
-{
-	le16 reason;
-    struct candidate *cand;
+  cand = (struct candidate *)data;
 
-	cand = (struct candidate *)data;
+  assert(cand);
 
-    assert(cand);
+  sae_debug(
+      AMPE_DEBUG_FSM,
+      "Mesh plink timer for " MACSTR " fired on state %s\n",
+      MAC2STR(cand->peer_mac),
+      mplstates[(cand->link_state > PLINK_BLOCKED) ? PLINK_UNDEFINED
+                                                   : cand->link_state]);
 
-    sae_debug(AMPE_DEBUG_FSM, "Mesh plink timer for " MACSTR
-            " fired on state %s\n", MAC2STR(cand->peer_mac),
-		    mplstates[(cand->link_state > PLINK_BLOCKED) ? PLINK_UNDEFINED : cand->link_state]);
+  reason = 0;
 
-	reason = 0;
-
-	switch (cand->link_state) {
-	case PLINK_OPN_RCVD:
-	case PLINK_OPN_SNT:
-		/* retry timer */
-        sae_debug(AMPE_DEBUG_FSM, "Mesh plink:retries %d of %d\n", cand->retries,
-                  cand->conf->max_retries);
-		if (cand->retries < cand->conf->max_retries) {
-			unsigned int rand;
-            sae_debug(AMPE_DEBUG_FSM, "Mesh plink for " MACSTR
-                    " (retry, timeout): %d %d\n", MAC2STR(cand->peer_mac),
-                    cand->retries, cand->timeout);
-			RAND_bytes((unsigned char *) &rand, sizeof(rand));
-            if (!cand->timeout) {
-                cand->timeout = cand->conf->retry_timeout_ms;
-                sae_debug(AMPE_DEBUG_ERR, "WARN: cand " MACSTR
-                    " had a timeout of 0ms.  Reset to %d\n",
-                    MAC2STR(cand->peer_mac),cand->timeout);
-            }
-            cand->timeout += rand % cand->timeout;
-			++cand->retries;
-            cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer,
-                    cand);
-			plink_frame_tx(cand, PLINK_OPEN, 0);
-			break;
-		}
-		reason = htole16(MESH_MAX_RETRIES);
-		/* no break / fall through on else */
-	case PLINK_CNF_RCVD:
-		/* confirm timer */
-		if (!reason)
-			reason = htole16(MESH_CONFIRM_TIMEOUT);
-		set_link_state(cand, PLINK_HOLDING);
-        cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->conf->holding_timeout_ms), plink_timer,
-                    cand);
-		plink_frame_tx(cand, PLINK_CLOSE, reason);
-		break;
-	case PLINK_HOLDING:
-		/* holding timer */
-		fsm_restart(cand);
-		break;
-	case PLINK_ESTAB:
-		/* nothing to do */
-		break;
-	default:
-        sae_debug(AMPE_DEBUG_FSM, "Timeout for peer " MACSTR
-                " in state %d\n", MAC2STR(cand->peer_mac),
-                cand->link_state);
-		break;
-	}
+  switch (cand->link_state) {
+    case PLINK_OPN_RCVD:
+    case PLINK_OPN_SNT:
+      /* retry timer */
+      sae_debug(
+          AMPE_DEBUG_FSM,
+          "Mesh plink:retries %d of %d\n",
+          cand->retries,
+          cand->conf->max_retries);
+      if (cand->retries < cand->conf->max_retries) {
+        unsigned int rand;
+        sae_debug(
+            AMPE_DEBUG_FSM,
+            "Mesh plink for " MACSTR " (retry, timeout): %d %d\n",
+            MAC2STR(cand->peer_mac),
+            cand->retries,
+            cand->timeout);
+        RAND_bytes((unsigned char *)&rand, sizeof(rand));
+        if (!cand->timeout) {
+          cand->timeout = cand->conf->retry_timeout_ms;
+          sae_debug(
+              AMPE_DEBUG_ERR,
+              "WARN: cand " MACSTR " had a timeout of 0ms.  Reset to %d\n",
+              MAC2STR(cand->peer_mac),
+              cand->timeout);
+        }
+        cand->timeout += rand % cand->timeout;
+        ++cand->retries;
+        cand->t2 =
+            cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+        plink_frame_tx(cand, PLINK_OPEN, 0);
+        break;
+      }
+      reason = htole16(MESH_MAX_RETRIES);
+    /* no break / fall through on else */
+    case PLINK_CNF_RCVD:
+      /* confirm timer */
+      if (!reason)
+        reason = htole16(MESH_CONFIRM_TIMEOUT);
+      set_link_state(cand, PLINK_HOLDING);
+      cand->t2 = cb->evl->add_timeout(
+          SRV_MSEC(cand->conf->holding_timeout_ms), plink_timer, cand);
+      plink_frame_tx(cand, PLINK_CLOSE, reason);
+      break;
+    case PLINK_HOLDING:
+      /* holding timer */
+      fsm_restart(cand);
+      break;
+    case PLINK_ESTAB:
+      /* nothing to do */
+      break;
+    default:
+      sae_debug(
+          AMPE_DEBUG_FSM,
+          "Timeout for peer " MACSTR " in state %d\n",
+          MAC2STR(cand->peer_mac),
+          cand->link_state);
+      break;
+  }
 }
-
 
 /**
  * protect_frame - add in-place the MIC and the (encrypted) AMPE ie to a frame
  * @cand:       The candidate this frame is destined for
- * @mgmt:       The frame, populated with all the information elements  up to where the MIC information element should go
- * @mic_start:  Pointer to where the mic and AMPE ies are to be written.  Should point to the start of the IE, not the IE body.
- * @len:        On input, the total buffer size that contains this frame.  On output, the actual lenght of the frame
+ * @mgmt:       The frame, populated with all the information elements  up to
+ * where the MIC information element should go
+ * @mic_start:  Pointer to where the mic and AMPE ies are to be written.  Should
+ * point to the start of the IE, not the IE body.
+ * @len:        On input, the total buffer size that contains this frame.  On
+ * output, the actual lenght of the frame
  *              including the two information elements added by this function.
  *
  * Returns: The zero on success, or some error.
  */
-static int protect_frame(struct candidate *cand, struct ieee80211_mgmt_frame *mgmt, unsigned char *mic_start, int *len)
-{
-    unsigned char *clear_ampe_ie;
-    unsigned char *ie;
-    unsigned short cat_to_mic_len;
-    struct mesh_node *mesh = cand->conf->mesh;
-    size_t ampe_ie_len;
-    unsigned char ftype = mgmt->action.action_code;
-    le16 igtk_keyid;
+static int protect_frame(
+    struct candidate *cand,
+    struct ieee80211_mgmt_frame *mgmt,
+    unsigned char *mic_start,
+    int *len) {
+  unsigned char *clear_ampe_ie;
+  unsigned char *ie;
+  unsigned short cat_to_mic_len;
+  struct mesh_node *mesh = cand->conf->mesh;
+  size_t ampe_ie_len;
+  unsigned char ftype = mgmt->action.action_code;
+  le16 igtk_keyid;
 
-    assert(mic_start && cand && mgmt && len);
+  assert(mic_start && cand && mgmt && len);
 
-#define MIC_IE_BODY_SIZE     AES_BLOCK_SIZE
+#define MIC_IE_BODY_SIZE AES_BLOCK_SIZE
 
-    ampe_ie_len = sizeof(struct ampe_ie);
+  ampe_ie_len = sizeof(struct ampe_ie);
 
-    if (ftype != PLINK_CLOSE) {
-        /* MGTK + RSC + Exp */
-        ampe_ie_len += 16 + 8 + 4;
+  if (ftype != PLINK_CLOSE) {
+    /* MGTK + RSC + Exp */
+    ampe_ie_len += 16 + 8 + 4;
 
-        if (mesh->conf->pmf) {
-            /* IGTK KeyId + IPN + IGTK */
-            ampe_ie_len += 2 + 6 + 16;
-        }
+    if (mesh->conf->pmf) {
+      /* IGTK KeyId + IPN + IGTK */
+      ampe_ie_len += 2 + 6 + 16;
     }
+  }
 
-    if (mic_start + MIC_IE_BODY_SIZE + 2 +
-        2 + ampe_ie_len - (unsigned char *) mgmt > *len) {
-		sae_debug(AMPE_DEBUG_KEYS, "protect frame: buffer too small\n");
-        return -EINVAL;
-    }
+  if (mic_start + MIC_IE_BODY_SIZE + 2 + 2 + ampe_ie_len -
+          (unsigned char *)mgmt >
+      *len) {
+    sae_debug(AMPE_DEBUG_KEYS, "protect frame: buffer too small\n");
+    return -EINVAL;
+  }
 
-    clear_ampe_ie = malloc(ampe_ie_len + 2);
-    if (!clear_ampe_ie) {
-		sae_debug(AMPE_DEBUG_KEYS, "protect frame: out of memory\n");
-        return -ENOMEM;
-    }
+  clear_ampe_ie = malloc(ampe_ie_len + 2);
+  if (!clear_ampe_ie) {
+    sae_debug(AMPE_DEBUG_KEYS, "protect frame: out of memory\n");
+    return -ENOMEM;
+  }
 
-    /*  IE: AMPE */
-    ie = clear_ampe_ie;
-    *ie++ = IEEE80211_EID_AMPE;
-    *ie++ = ampe_ie_len;
-    memcpy(ie, pw_suite_selector, 4);
+  /*  IE: AMPE */
+  ie = clear_ampe_ie;
+  *ie++ = IEEE80211_EID_AMPE;
+  *ie++ = ampe_ie_len;
+  memcpy(ie, pw_suite_selector, 4);
+  ie += 4;
+  memcpy(ie, cand->my_nonce, 32);
+  ie += 32;
+  memcpy(ie, cand->peer_nonce, 32);
+  ie += 32;
+
+  if (ftype != PLINK_CLOSE) {
+    memcpy(ie, mgtk_tx, 16);
+    ie += 16;
+    memset(ie, 0, 8); /*  TODO: Populate Key RSC */
+    ie += 8;
+    memset(ie, 0xff, 4); /*  expire in 13 decades or so */
     ie += 4;
-    memcpy(ie, cand->my_nonce, 32);
-    ie += 32;
-    memcpy(ie, cand->peer_nonce, 32);
-    ie += 32;
 
-    if (ftype != PLINK_CLOSE) {
-        memcpy(ie, mgtk_tx, 16);
-        ie += 16;
-        memset(ie, 0, 8);           /*  TODO: Populate Key RSC */
-        ie += 8;
-        memset(ie, 0xff, 4);        /*  expire in 13 decades or so */
-        ie += 4;
-
-        if (mesh->conf->pmf) {
-            igtk_keyid = htole16(mesh->igtk_keyid);
-            memcpy(ie, &igtk_keyid, 2);
-            ie += 2;
-            memcpy(ie, mesh->igtk_ipn, 6);
-            ie += 6;
-            memcpy(ie, mesh->igtk_tx, 16);
-            ie += 16;
-        }
+    if (mesh->conf->pmf) {
+      igtk_keyid = htole16(mesh->igtk_keyid);
+      memcpy(ie, &igtk_keyid, 2);
+      ie += 2;
+      memcpy(ie, mesh->igtk_ipn, 6);
+      ie += 6;
+      memcpy(ie, mesh->igtk_tx, 16);
+      ie += 16;
     }
+  }
 
-    /* IE: MIC */
-    ie = mic_start;
-    *ie++ = IEEE80211_EID_MIC;
-    *ie++ = MIC_IE_BODY_SIZE;
+  /* IE: MIC */
+  ie = mic_start;
+  *ie++ = IEEE80211_EID_MIC;
+  *ie++ = MIC_IE_BODY_SIZE;
 
-    cat_to_mic_len = mic_start - (unsigned char *) &mgmt->action;
-    siv_encrypt(&cand->sivctx, clear_ampe_ie, ie + MIC_IE_BODY_SIZE,
-            ampe_ie_len + 2,
-            ie, 3,
-            cand->my_mac, ETH_ALEN,
-            cand->peer_mac, ETH_ALEN,
-            &mgmt->action, cat_to_mic_len);
+  cat_to_mic_len = mic_start - (unsigned char *)&mgmt->action;
+  siv_encrypt(
+      &cand->sivctx,
+      clear_ampe_ie,
+      ie + MIC_IE_BODY_SIZE,
+      ampe_ie_len + 2,
+      ie,
+      3,
+      cand->my_mac,
+      ETH_ALEN,
+      cand->peer_mac,
+      ETH_ALEN,
+      &mgmt->action,
+      cat_to_mic_len);
 
-    *len = mic_start - (unsigned char *) mgmt + ampe_ie_len + 2 + MIC_IE_BODY_SIZE + 2;
+  *len = mic_start - (unsigned char *)mgmt + ampe_ie_len + 2 +
+      MIC_IE_BODY_SIZE + 2;
 
-    sae_debug(AMPE_DEBUG_KEYS, "Protecting frame from " MACSTR " to " MACSTR "\n",
-            MAC2STR(cand->my_mac), MAC2STR(cand->peer_mac));
-    sae_debug(AMPE_DEBUG_KEYS, "Checking tricky lengths of protected frame %d, %zu\n",
-            cat_to_mic_len, ampe_ie_len + 2);
+  sae_debug(
+      AMPE_DEBUG_KEYS,
+      "Protecting frame from " MACSTR " to " MACSTR "\n",
+      MAC2STR(cand->my_mac),
+      MAC2STR(cand->peer_mac));
+  sae_debug(
+      AMPE_DEBUG_KEYS,
+      "Checking tricky lengths of protected frame %d, %zu\n",
+      cat_to_mic_len,
+      ampe_ie_len + 2);
 
-    sae_hexdump(AMPE_DEBUG_KEYS, "SIV- Put AAD[3]: ", (unsigned char *) &mgmt->action, cat_to_mic_len);
+  sae_hexdump(
+      AMPE_DEBUG_KEYS,
+      "SIV- Put AAD[3]: ",
+      (unsigned char *)&mgmt->action,
+      cat_to_mic_len);
 
-    free(clear_ampe_ie);
+  free(clear_ampe_ie);
 
-    return 0;
+  return 0;
 }
 
-static int check_frame_protection(struct candidate *cand, struct ieee80211_mgmt_frame *mgmt, int len, struct info_elems *elems)
-{
-    unsigned char *clear_ampe_ie;
-    struct info_elems ies_parsed;
-    struct mesh_node *mesh = cand->conf->mesh;
-    unsigned short ampe_ie_len, cat_to_mic_len;
-    int r;
-    unsigned int* key_expiration_p;
-    unsigned char ftype = mgmt->action.action_code;
-    unsigned char *gtkdata, *igtkdata;
+static int check_frame_protection(
+    struct candidate *cand,
+    struct ieee80211_mgmt_frame *mgmt,
+    int len,
+    struct info_elems *elems) {
+  unsigned char *clear_ampe_ie;
+  struct info_elems ies_parsed;
+  struct mesh_node *mesh = cand->conf->mesh;
+  unsigned short ampe_ie_len, cat_to_mic_len;
+  int r;
+  unsigned int *key_expiration_p;
+  unsigned char ftype = mgmt->action.action_code;
+  unsigned char *gtkdata, *igtkdata;
 
-    assert(len && cand && mgmt);
+  assert(len && cand && mgmt);
 
-    if (!mesh->conf->is_secure)
-        return 0;
+  if (!mesh->conf->is_secure)
+    return 0;
 
-    if (!elems->mic || elems->mic_len != MIC_IE_BODY_SIZE) {
-		sae_debug(AMPE_DEBUG_KEYS, "Verify frame: invalid MIC\n");
-        return -1;
+  if (!elems->mic || elems->mic_len != MIC_IE_BODY_SIZE) {
+    sae_debug(AMPE_DEBUG_KEYS, "Verify frame: invalid MIC\n");
+    return -1;
+  }
+
+  /*
+   *  ampe_ie_len is the length of the ciphertext (the encrypted
+   *  AMPE IE) and it needs to be inferred from the total frame
+   *  size
+   */
+  ampe_ie_len = len - (elems->mic + elems->mic_len - (unsigned char *)mgmt);
+
+  /* expect at least MGTK + RSC + expiry for open/confirm */
+  if (ftype != PLINK_CLOSE &&
+      ampe_ie_len < 2 + sizeof(struct ampe_ie) + 16 + 8 + 4) {
+    sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE too small\n");
+    return -1;
+  }
+
+  /* if PMF, then we also need IGTKData */
+  if (mesh->conf->pmf) {
+    if (ampe_ie_len <
+        2 + sizeof(struct ampe_ie) + 16 + 8 + 4 + 2 + 6 + 16 /* IGTKData */) {
+      sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE missing IGTK\n");
+      return -1;
     }
+  }
 
-    /*
-     *  ampe_ie_len is the length of the ciphertext (the encrypted
-     *  AMPE IE) and it needs to be inferred from the total frame
-     *  size
-     */
-    ampe_ie_len = len -
-                (elems->mic + elems->mic_len - (unsigned char *)mgmt);
+  clear_ampe_ie = malloc(ampe_ie_len);
+  if (!clear_ampe_ie) {
+    sae_debug(AMPE_DEBUG_KEYS, "Verify frame: out of memory\n");
+    return -1;
+  }
 
-    /* expect at least MGTK + RSC + expiry for open/confirm */
-    if (ftype != PLINK_CLOSE &&
-        ampe_ie_len < 2 + sizeof(struct ampe_ie) + 16 + 8 + 4) {
-		sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE too small\n");
-        return -1;
-    }
+  /*
+   *  cat_to_mic_len is the length of the contents of the frame
+   *  from the category (inclusive) to the mic (exclusive)
+   */
+  cat_to_mic_len = elems->mic - 2 - (unsigned char *)&mgmt->action;
+  r = siv_decrypt(
+      &cand->sivctx,
+      elems->mic + elems->mic_len,
+      clear_ampe_ie,
+      ampe_ie_len,
+      elems->mic,
+      3,
+      cand->peer_mac,
+      ETH_ALEN,
+      cand->my_mac,
+      ETH_ALEN,
+      &mgmt->action,
+      cat_to_mic_len);
 
-    /* if PMF, then we also need IGTKData */
-    if (mesh->conf->pmf) {
-        if (ampe_ie_len < 2 + sizeof(struct ampe_ie) + 16 + 8 + 4 +
-                          2 + 6 + 16 /* IGTKData */) {
-            sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE missing IGTK\n");
-            return -1;
-        }
-    }
+  sae_debug(
+      AMPE_DEBUG_KEYS,
+      "Checking protection to " MACSTR " from " MACSTR "\n",
+      MAC2STR(cand->my_mac),
+      MAC2STR(cand->peer_mac));
 
-    clear_ampe_ie = malloc(ampe_ie_len);
-    if (!clear_ampe_ie) {
-		sae_debug(AMPE_DEBUG_KEYS, "Verify frame: out of memory\n");
-        return -1;
-    }
+  sae_debug(
+      AMPE_DEBUG_KEYS,
+      "Len checking cat-to-mic len:%d ampe ie full length: %d\n",
+      cat_to_mic_len,
+      ampe_ie_len);
 
-    /*
-     *  cat_to_mic_len is the length of the contents of the frame
-     *  from the category (inclusive) to the mic (exclusive)
-     */
-    cat_to_mic_len = elems->mic - 2 - (unsigned char *) &mgmt->action;
-    r = siv_decrypt(&cand->sivctx, elems->mic + elems->mic_len,
-            clear_ampe_ie,
-            ampe_ie_len,
-            elems->mic, 3,
-            cand->peer_mac, ETH_ALEN,
-            cand->my_mac, ETH_ALEN,
-            &mgmt->action, cat_to_mic_len);
+  sae_hexdump(
+      AMPE_DEBUG_KEYS,
+      "SIV- Got AAD[3]: ",
+      (unsigned char *)&mgmt->action,
+      cat_to_mic_len);
 
-    sae_debug(AMPE_DEBUG_KEYS, "Checking protection to " MACSTR " from " MACSTR "\n",
-            MAC2STR(cand->my_mac), MAC2STR(cand->peer_mac));
-
-    sae_debug(AMPE_DEBUG_KEYS, "Len checking cat-to-mic len:%d ampe ie full length: %d\n",
-            cat_to_mic_len, ampe_ie_len);
-
-    sae_hexdump(AMPE_DEBUG_KEYS, "SIV- Got AAD[3]: ", (unsigned char *) &mgmt->action,
-            cat_to_mic_len);
-
-    if (r != 1) {
-        sae_debug(AMPE_DEBUG_KEYS, "Protection check failed\n");
-        free(clear_ampe_ie);
-        return -1;
-    }
-
-    if (ampe_ie_len != clear_ampe_ie[1] + 2) {
-        sae_debug(AMPE_DEBUG_KEYS, "AMPE -Invalid length (expected %d, got %d)\n",
-            ampe_ie_len, clear_ampe_ie[1] + 2);
-        free(clear_ampe_ie);
-        return -1;
-    }
-
-    sae_hexdump(AMPE_DEBUG_KEYS, "AMPE IE: ", clear_ampe_ie, ampe_ie_len);
-
-    parse_ies(clear_ampe_ie, ampe_ie_len, &ies_parsed);
-
-    if (memcmp(ies_parsed.ampe->peer_nonce, null_nonce, 32) != 0 &&
-        memcmp(ies_parsed.ampe->peer_nonce, cand->my_nonce, 32) != 0) {
-        sae_hexdump(AMPE_DEBUG_KEYS, "IE peer_nonce ", ies_parsed.ampe->peer_nonce, 32);
-        sae_debug(AMPE_DEBUG_KEYS, "Unexpected nonce\n");
-        free(clear_ampe_ie);
-        return -1;
-    }
-    memcpy(cand->peer_nonce, ies_parsed.ampe->local_nonce, 32);
-
-    gtkdata = ies_parsed.ampe->variable;
-
-    memcpy(cand->mgtk, gtkdata, sizeof(cand->mgtk));
-    sae_hexdump(AMPE_DEBUG_KEYS, "Received mgtk: ", cand->mgtk, sizeof(cand->mgtk));
-    key_expiration_p = (unsigned int *) (gtkdata + 16 + 8);
-    cand->mgtk_expiration = le32toh(*key_expiration_p);
-
-    igtkdata = gtkdata + 16 + 8 + 4;
-    if (mesh->conf->pmf) {
-        cand->igtk_keyid = le16toh(*(u16 *) igtkdata);
-        igtkdata += 2 + 6;
-        memcpy(cand->igtk, igtkdata, sizeof(cand->igtk));
-        cand->has_igtk = true;
-        sae_hexdump(AMPE_DEBUG_KEYS, "Received igtk: ", cand->igtk, sizeof(cand->igtk));
-    }
+  if (r != 1) {
+    sae_debug(AMPE_DEBUG_KEYS, "Protection check failed\n");
     free(clear_ampe_ie);
     return -1;
+  }
+
+  if (ampe_ie_len != clear_ampe_ie[1] + 2) {
+    sae_debug(
+        AMPE_DEBUG_KEYS,
+        "AMPE -Invalid length (expected %d, got %d)\n",
+        ampe_ie_len,
+        clear_ampe_ie[1] + 2);
+    free(clear_ampe_ie);
+    return -1;
+  }
+
+  sae_hexdump(AMPE_DEBUG_KEYS, "AMPE IE: ", clear_ampe_ie, ampe_ie_len);
+
+  parse_ies(clear_ampe_ie, ampe_ie_len, &ies_parsed);
+
+  if (memcmp(ies_parsed.ampe->peer_nonce, null_nonce, 32) != 0 &&
+      memcmp(ies_parsed.ampe->peer_nonce, cand->my_nonce, 32) != 0) {
+    sae_hexdump(
+        AMPE_DEBUG_KEYS, "IE peer_nonce ", ies_parsed.ampe->peer_nonce, 32);
+    sae_debug(AMPE_DEBUG_KEYS, "Unexpected nonce\n");
+    free(clear_ampe_ie);
+    return -1;
+  }
+  memcpy(cand->peer_nonce, ies_parsed.ampe->local_nonce, 32);
+
+  gtkdata = ies_parsed.ampe->variable;
+
+  memcpy(cand->mgtk, gtkdata, sizeof(cand->mgtk));
+  sae_hexdump(
+      AMPE_DEBUG_KEYS, "Received mgtk: ", cand->mgtk, sizeof(cand->mgtk));
+  key_expiration_p = (unsigned int *)(gtkdata + 16 + 8);
+  cand->mgtk_expiration = le32toh(*key_expiration_p);
+
+  igtkdata = gtkdata + 16 + 8 + 4;
+  if (mesh->conf->pmf) {
+    cand->igtk_keyid = le16toh(*(u16 *)igtkdata);
+    igtkdata += 2 + 6;
+    memcpy(cand->igtk, igtkdata, sizeof(cand->igtk));
+    cand->has_igtk = true;
+    sae_hexdump(
+        AMPE_DEBUG_KEYS, "Received igtk: ", cand->igtk, sizeof(cand->igtk));
+  }
+  free(clear_ampe_ie);
+  return -1;
 #undef MIC_IE_BODY_SIZE
 }
 
-static int plink_frame_tx(struct candidate *cand, enum plink_action_code action,
-                          unsigned short reason)
-{
-        unsigned char *buf;
-        struct ieee80211_mgmt_frame *mgmt;
-        struct mesh_node *mesh = cand->conf->mesh;
-        struct ieee80211_supported_band *sband = &mesh->bands[mesh->band];
-        struct ht_cap_ie *ht_cap;
-        struct ht_op_ie *ht_op;
-        unsigned char ie_len;
-        int len;
-        int ret;
-        unsigned char *ies;
-        unsigned char *pos;
-        u16 peering_proto = htole16(0x0001);    /* AMPE */
+static int plink_frame_tx(
+    struct candidate *cand,
+    enum plink_action_code action,
+    unsigned short reason) {
+  unsigned char *buf;
+  struct ieee80211_mgmt_frame *mgmt;
+  struct mesh_node *mesh = cand->conf->mesh;
+  struct ieee80211_supported_band *sband = &mesh->bands[mesh->band];
+  struct ht_cap_ie *ht_cap;
+  struct ht_op_ie *ht_op;
+  unsigned char ie_len;
+  int len;
+  int ret;
+  unsigned char *ies;
+  unsigned char *pos;
+  u16 peering_proto = htole16(0x0001); /* AMPE */
 
-        assert(cand);
+  assert(cand);
 
 #define LARGE_FRAME 1500;
-        len = LARGE_FRAME;
-        buf = calloc(1, len);
+  len = LARGE_FRAME;
+  buf = calloc(1, len);
 #undef LARGE_FRAME
-        if (!buf)
-                return -1;
+  if (!buf)
+    return -1;
 
-        sae_debug(AMPE_DEBUG_FSM, "Mesh plink: Sending plink action %d\n", action);
+  sae_debug(AMPE_DEBUG_FSM, "Mesh plink: Sending plink action %d\n", action);
 
-        mgmt = (struct ieee80211_mgmt_frame *) buf;
-        mgmt->frame_control = htole16((IEEE802_11_FC_TYPE_MGMT << 2 |
-                                    IEEE802_11_FC_STYPE_ACTION << 4));
+  mgmt = (struct ieee80211_mgmt_frame *)buf;
+  mgmt->frame_control =
+      htole16((IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_ACTION << 4));
 
-        memcpy(mgmt->da, cand->peer_mac, ETH_ALEN);
-        memcpy(mgmt->sa, cand->my_mac, ETH_ALEN);
-        memcpy(mgmt->bssid, cand->my_mac, ETH_ALEN);
-        mgmt->action.category = IEEE80211_CATEGORY_SELF_PROTECTED;
-        mgmt->action.action_code = action;
-        pos = mgmt->action.u.var8;
+  memcpy(mgmt->da, cand->peer_mac, ETH_ALEN);
+  memcpy(mgmt->sa, cand->my_mac, ETH_ALEN);
+  memcpy(mgmt->bssid, cand->my_mac, ETH_ALEN);
+  mgmt->action.category = IEEE80211_CATEGORY_SELF_PROTECTED;
+  mgmt->action.action_code = action;
+  pos = mgmt->action.u.var8;
 
-        if (action != PLINK_CLOSE) {
-            /* capability info */
-            *pos++ = (mesh->conf->is_secure) ? 0x10: 0;
-            *pos++ = 0;
-            if (action == PLINK_CONFIRM) {
-                /* AID */
-                uint16_t* aid = (uint16_t*)pos;
-                *aid = ieee_order(cand->association_id);
-                pos += 2;
-            }
-        }
+  if (action != PLINK_CLOSE) {
+    /* capability info */
+    *pos++ = (mesh->conf->is_secure) ? 0x10 : 0;
+    *pos++ = 0;
+    if (action == PLINK_CONFIRM) {
+      /* AID */
+      uint16_t *aid = (uint16_t *)pos;
+      *aid = ieee_order(cand->association_id);
+      pos += 2;
+    }
+  }
 
-	    ies = start_of_ies(mgmt, len, NULL);
+  ies = start_of_ies(mgmt, len, NULL);
 
-        /* IE: All the static IEs */
-        memcpy(ies, sta_fixed_ies, sta_fixed_ies_len);
-        ies += sta_fixed_ies_len;
+  /* IE: All the static IEs */
+  memcpy(ies, sta_fixed_ies, sta_fixed_ies_len);
+  ies += sta_fixed_ies_len;
 
-        /* IE: Mesh ID element */
-        *ies++ = IEEE80211_EID_MESH_ID;
-        *ies++ = mesh->conf->meshid_len;
-        memcpy((char *) ies, mesh->conf->meshid, mesh->conf->meshid_len);
-        ies += mesh->conf->meshid_len;
+  /* IE: Mesh ID element */
+  *ies++ = IEEE80211_EID_MESH_ID;
+  *ies++ = mesh->conf->meshid_len;
+  memcpy((char *)ies, mesh->conf->meshid, mesh->conf->meshid_len);
+  ies += mesh->conf->meshid_len;
 
-        /* IE: mesh config */
-        *ies++ = IEEE80211_EID_MESH_CONFIG;
-        *ies++ = 7;
-        *ies++ = MESH_CONFIG_PP_HWMP;
-        *ies++ = MESH_CONFIG_PM_ALM;
-        *ies++ = MESH_CONFIG_CC_NONE;
-        *ies++ = MESH_CONFIG_SP_NEIGHBOR_OFFSET;
+  /* IE: mesh config */
+  *ies++ = IEEE80211_EID_MESH_CONFIG;
+  *ies++ = 7;
+  *ies++ = MESH_CONFIG_PP_HWMP;
+  *ies++ = MESH_CONFIG_PM_ALM;
+  *ies++ = MESH_CONFIG_CC_NONE;
+  *ies++ = MESH_CONFIG_SP_NEIGHBOR_OFFSET;
 
-        if (mesh->conf->is_secure) {
-            *ies++ = MESH_CONFIG_AUTH_SAE;
-        } else {
-            *ies++ = 0;
-        }
+  if (mesh->conf->is_secure) {
+    *ies++ = MESH_CONFIG_AUTH_SAE;
+  } else {
+    *ies++ = 0;
+  }
 
-        *ies++ = 0; /* TODO formation info */
-        *ies++ = MESH_CAPA_ACCEPT_PEERINGS | MESH_CAPA_FORWARDING;
+  *ies++ = 0; /* TODO formation info */
+  *ies++ = MESH_CAPA_ACCEPT_PEERINGS | MESH_CAPA_FORWARDING;
 
-        ie_len = 4;
-        if (mesh->conf->is_secure) {
-            ie_len += sizeof(cand->pmkid);
-        }
+  ie_len = 4;
+  if (mesh->conf->is_secure) {
+    ie_len += sizeof(cand->pmkid);
+  }
 
-        /* IE: Mesh Peering Management element */
-        switch (action) {
-            case PLINK_OPEN:
-                break;
-            case PLINK_CONFIRM:
-                ie_len += 2;
-                break;
-            case PLINK_CLOSE:
-                if (&cand->peer_lid) {
-                    ie_len += 2;
-                }
-                ie_len += 2;	/* reason code */
-                break;
-            default:
-                free(buf);
-                return -EINVAL;
-        }
+  /* IE: Mesh Peering Management element */
+  switch (action) {
+    case PLINK_OPEN:
+      break;
+    case PLINK_CONFIRM:
+      ie_len += 2;
+      break;
+    case PLINK_CLOSE:
+      if (&cand->peer_lid) {
+        ie_len += 2;
+      }
+      ie_len += 2; /* reason code */
+      break;
+    default:
+      free(buf);
+      return -EINVAL;
+  }
 
-        *ies++ = IEEE80211_EID_MESH_PEERING;
-        *ies++ = ie_len;
-        memcpy(ies, &peering_proto, 2);
-        ies += 2;
-        memcpy(ies, &cand->my_lid, 2);
-        ies += 2;
-        if (cand->peer_lid && (action != PLINK_OPEN)) {
-            memcpy(ies, &cand->peer_lid, 2);
-            ies += 2;
-        }
-        if (action == PLINK_CLOSE) {
-            memcpy(ies, &cand->reason, 2);
-            ies += 2;
-        }
+  *ies++ = IEEE80211_EID_MESH_PEERING;
+  *ies++ = ie_len;
+  memcpy(ies, &peering_proto, 2);
+  ies += 2;
+  memcpy(ies, &cand->my_lid, 2);
+  ies += 2;
+  if (cand->peer_lid && (action != PLINK_OPEN)) {
+    memcpy(ies, &cand->peer_lid, 2);
+    ies += 2;
+  }
+  if (action == PLINK_CLOSE) {
+    memcpy(ies, &cand->reason, 2);
+    ies += 2;
+  }
 
-        if (mesh->conf->is_secure) {
-            memcpy(ies, cand->pmkid, sizeof(cand->pmkid));
-            ies += sizeof(cand->pmkid);
-        }
+  if (mesh->conf->is_secure) {
+    memcpy(ies, cand->pmkid, sizeof(cand->pmkid));
+    ies += sizeof(cand->pmkid);
+  }
 
-        if (mesh->conf->channel_type != CHAN_NO_HT &&
-            sband->ht_cap.ht_supported) {
+  if (mesh->conf->channel_type != CHAN_NO_HT && sband->ht_cap.ht_supported) {
+    /* HT IEs */
+    *ies++ = IEEE80211_EID_HT_CAPABILITY;
+    *ies++ = sizeof(struct ht_cap_ie);
+    ht_cap = (struct ht_cap_ie *)ies;
+    ht_cap->cap_info = htole16(sband->ht_cap.cap);
+    ht_cap->ampdu_params_info =
+        sband->ht_cap.ampdu_factor | (sband->ht_cap.ampdu_density << 2);
+    memcpy(&ht_cap->mcs, &sband->ht_cap.mcs, sizeof(struct mcs_info));
+    /* mac80211 apparently ignores the rest */
+    ies += sizeof(*ht_cap);
 
-            /* HT IEs */
-            *ies++ = IEEE80211_EID_HT_CAPABILITY;
-            *ies++ = sizeof(struct ht_cap_ie);
-            ht_cap = (struct ht_cap_ie *) ies;
-            ht_cap->cap_info = htole16(sband->ht_cap.cap);
-            ht_cap->ampdu_params_info = sband->ht_cap.ampdu_factor |
-                                        (sband->ht_cap.ampdu_density << 2);
-            memcpy(&ht_cap->mcs, &sband->ht_cap.mcs, sizeof(struct mcs_info));
-            /* mac80211 apparently ignores the rest */
-            ies += sizeof(*ht_cap);
+    *ies++ = IEEE80211_EID_HT_OPERATION;
+    *ies++ = sizeof(struct ht_op_ie);
+    ht_op = (struct ht_op_ie *)ies;
+    ht_op->primary_chan = mesh->conf->channel;
+    switch (mesh->conf->channel_type) {
+      case CHAN_HT40MINUS:
+        ht_op->ht_param = IEEE80211_HT_PARAM_CHA_SEC_BELOW;
+        break;
+      case CHAN_HT40PLUS:
+        ht_op->ht_param = IEEE80211_HT_PARAM_CHA_SEC_ABOVE;
+        break;
+      case CHAN_HT20:
+      default:
+        ht_op->ht_param = IEEE80211_HT_PARAM_CHA_SEC_NONE;
+        break;
+    }
+    if ((sband->ht_cap.cap & IEEE80211_HT_CAP_SUP_WIDTH_20_40) &&
+        mesh->conf->channel_type > CHAN_HT20)
+      ht_op->ht_param |= IEEE80211_HT_PARAM_CHAN_WIDTH_ANY;
 
-            *ies++ = IEEE80211_EID_HT_OPERATION;
-            *ies++ = sizeof(struct ht_op_ie);
-            ht_op = (struct ht_op_ie *) ies;
-            ht_op->primary_chan = mesh->conf->channel;
-            switch (mesh->conf->channel_type) {
-            case CHAN_HT40MINUS:
-                ht_op->ht_param = IEEE80211_HT_PARAM_CHA_SEC_BELOW;
-                break;
-            case CHAN_HT40PLUS:
-                ht_op->ht_param = IEEE80211_HT_PARAM_CHA_SEC_ABOVE;
-                break;
-            case CHAN_HT20:
-            default:
-                ht_op->ht_param = IEEE80211_HT_PARAM_CHA_SEC_NONE;
-                break;
-            }
-            if ((sband->ht_cap.cap & IEEE80211_HT_CAP_SUP_WIDTH_20_40) &&
-                mesh->conf->channel_type > CHAN_HT20)
-                    ht_op->ht_param |= IEEE80211_HT_PARAM_CHAN_WIDTH_ANY;
+    ht_op->operation_mode = htole16(mesh->conf->ht_prot_mode);
+    memset(ht_op->basic_set, 0, 16);
+    ht_op->basic_set[0] = 0xff; /* mandatory HT phy rates */
+    ies += sizeof(*ht_op);
+  }
 
-            ht_op->operation_mode = htole16(mesh->conf->ht_prot_mode);
-            memset(ht_op->basic_set, 0, 16);
-            ht_op->basic_set[0] = 0xff; /* mandatory HT phy rates */
-            ies += sizeof(*ht_op);
-        }
+  if (mesh->conf->is_secure) {
+    /* IE: Add MIC and encrypted AMPE */
+    ret = protect_frame(cand, (struct ieee80211_mgmt_frame *)buf, ies, &len);
+    if (ret) {
+      sae_debug(SAE_DEBUG_ERR, "Failed to protect frame\n");
+      free(buf);
+      return ret;
+    }
+  } else {
+    len = ies - buf;
+  }
 
-        if (mesh->conf->is_secure) {
-            /* IE: Add MIC and encrypted AMPE */
-            ret = protect_frame(cand, (struct ieee80211_mgmt_frame *)buf, ies,
-                                &len);
-            if (ret) {
-                sae_debug(SAE_DEBUG_ERR, "Failed to protect frame\n");
-                free(buf);
-                return ret;
-            }
-        } else {
-            len = ies - buf;
-        }
-
-        if (cb->meshd_write_mgmt((char *)buf, len, cand->cookie) != len) {
-            sae_debug(SAE_DEBUG_ERR, "can't send a peering "
-                    "frame to " MACSTR "\n", MAC2STR(cand->peer_mac));
-        }
-        free(buf);
-        return 0;
+  if (cb->meshd_write_mgmt((char *)buf, len, cand->cookie) != len) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "can't send a peering "
+        "frame to " MACSTR "\n",
+        MAC2STR(cand->peer_mac));
+  }
+  free(buf);
+  return 0;
 }
 
-static void derive_mtk(struct candidate *cand)
-{
-    unsigned char context[84];
-    unsigned char *p;
+static void derive_mtk(struct candidate *cand) {
+  unsigned char context[84];
+  unsigned char *p;
 
-    p = context;
-    if (memcmp(cand->my_nonce, cand->peer_nonce, 32) < 0) {
-        memcpy(p, cand->my_nonce, 32);
-        memcpy(p + 32, cand->peer_nonce, 32);
-    } else {
-        memcpy(p, cand->peer_nonce, 32);
-        memcpy(p + 32, cand->my_nonce, 32);
-    }
-    p += 64;
+  p = context;
+  if (memcmp(cand->my_nonce, cand->peer_nonce, 32) < 0) {
+    memcpy(p, cand->my_nonce, 32);
+    memcpy(p + 32, cand->peer_nonce, 32);
+  } else {
+    memcpy(p, cand->peer_nonce, 32);
+    memcpy(p + 32, cand->my_nonce, 32);
+  }
+  p += 64;
 
-    if (le16toh(cand->my_lid) < le16toh(cand->peer_lid)) {
-        memcpy(p, &cand->my_lid, 2);
-        memcpy(p + 2, &cand->peer_lid, 2);
-    } else {
-        memcpy(p, &cand->peer_lid, 2);
-        memcpy(p + 2, &cand->my_lid, 2);
-    }
-    p += 4;
+  if (le16toh(cand->my_lid) < le16toh(cand->peer_lid)) {
+    memcpy(p, &cand->my_lid, 2);
+    memcpy(p + 2, &cand->peer_lid, 2);
+  } else {
+    memcpy(p, &cand->peer_lid, 2);
+    memcpy(p + 2, &cand->my_lid, 2);
+  }
+  p += 4;
 
-    memcpy(p, akm_suite_selector, sizeof(akm_suite_selector));
-    p += sizeof(akm_suite_selector);
+  memcpy(p, akm_suite_selector, sizeof(akm_suite_selector));
+  p += sizeof(akm_suite_selector);
 
-    if (memcmp(cand->my_mac, cand->peer_mac, ETH_ALEN) < 0) {
-        memcpy(p, cand->my_mac, ETH_ALEN);
-        memcpy(p + ETH_ALEN, cand->peer_mac, ETH_ALEN);
-    } else {
-        memcpy(p, cand->peer_mac, ETH_ALEN);
-        memcpy(p + ETH_ALEN, cand->my_mac, ETH_ALEN);
-    }
-    p += 12;
+  if (memcmp(cand->my_mac, cand->peer_mac, ETH_ALEN) < 0) {
+    memcpy(p, cand->my_mac, ETH_ALEN);
+    memcpy(p + ETH_ALEN, cand->peer_mac, ETH_ALEN);
+  } else {
+    memcpy(p, cand->peer_mac, ETH_ALEN);
+    memcpy(p + ETH_ALEN, cand->my_mac, ETH_ALEN);
+  }
+  p += 12;
 
-    assert(p - context <= sizeof(context));
+  assert(p - context <= sizeof(context));
 
-    prf(cand->pmk, SHA256_DIGEST_LENGTH,
-        (unsigned char *)"Temporal Key Derivation", strlen("Temporal Key Derivation"),
-        context, sizeof(context),
-        cand->mtk, 16 * 8);
+  prf(cand->pmk,
+      SHA256_DIGEST_LENGTH,
+      (unsigned char *)"Temporal Key Derivation",
+      strlen("Temporal Key Derivation"),
+      context,
+      sizeof(context),
+      cand->mtk,
+      16 * 8);
 
-    sae_hexdump(AMPE_DEBUG_KEYS, "mtk context: ", context, sizeof(context));
-    sae_hexdump(AMPE_DEBUG_KEYS, "mtk: ", cand->mtk, sizeof(cand->mtk));
+  sae_hexdump(AMPE_DEBUG_KEYS, "mtk context: ", context, sizeof(context));
+  sae_hexdump(AMPE_DEBUG_KEYS, "mtk: ", cand->mtk, sizeof(cand->mtk));
 }
 
+static void fsm_step(struct candidate *cand, enum plink_event event) {
+  struct ampe_config *aconf = cand->conf;
+  unsigned short reason = 0;
+  uint32_t changed = 0;
 
-static void fsm_step(struct candidate *cand, enum plink_event event)
-{
-    struct ampe_config *aconf = cand->conf;
-    unsigned short reason = 0;
-    uint32_t changed = 0;
-
-	switch (cand->link_state) {
-	case PLINK_LISTEN:
-		switch (event) {
-		case CLS_ACPT:
-			fsm_restart(cand);
-			break;
-		case OPN_ACPT:
-            cand->timeout = aconf->retry_timeout_ms;
-            cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
-			set_link_state(cand, PLINK_OPN_RCVD);
-			plink_frame_tx(cand, PLINK_OPEN, 0);
-			plink_frame_tx(cand, PLINK_CONFIRM, 0);
-			break;
-		default:
-			break;
-		}
-		break;
-
-	case PLINK_OPN_SNT:
-		switch (event) {
-		case OPN_RJCT:
-		case CNF_RJCT:
-			reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
-			/* no break */
-		case CLS_ACPT:
-			if (!reason)
-				reason = htole16(MESH_CLOSE_RCVD);
-			cand->reason = reason;
-			set_link_state(cand, PLINK_HOLDING);
-            cand->timeout = aconf->holding_timeout_ms;
-            cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
-			plink_frame_tx(cand, PLINK_CLOSE, reason);
-			break;
-		case OPN_ACPT:
-			/* retry timer is left untouched */
-			set_link_state(cand, PLINK_OPN_RCVD);
-			plink_frame_tx(cand, PLINK_CONFIRM, 0);
-			break;
-		case CNF_ACPT:
-			set_link_state(cand, PLINK_CNF_RCVD);
-            cand->timeout = aconf->confirm_timeout_ms;
-            cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
-			break;
-		default:
-			break;
-		}
-		break;
-
-	case PLINK_OPN_RCVD:
-		switch (event) {
-		case OPN_RJCT:
-		case CNF_RJCT:
-			reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
-			/* no break */
-		case CLS_ACPT:
-			if (!reason)
-				reason = htole16(MESH_CLOSE_RCVD);
-			cand->reason = reason;
-			set_link_state(cand, PLINK_HOLDING);
-            cand->timeout = aconf->holding_timeout_ms;
-            cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
-			plink_frame_tx(cand, PLINK_CLOSE, reason);
-			break;
-		case OPN_ACPT:
-			plink_frame_tx(cand, PLINK_CONFIRM, 0);
-			break;
-		case CNF_ACPT:
-			//del_timer(&cand->plink_timer);
-			//mesh_plink_inc_estab_count(sdata);
-			//ieee80211_bss_info_change_notify(sdata, BSS_CHANGED_BEACON);
-            derive_mtk(cand);
-            cb->estab_peer_link(cand->peer_mac,
-                    cand->mtk, sizeof(cand->mtk),
-                    cand->mgtk, sizeof(cand->mgtk),
-                    cand->mgtk_expiration,
-                    (cand->has_igtk) ? cand->igtk : NULL,
-                    (cand->has_igtk) ? sizeof(cand->igtk) : 0,
-                    cand->igtk_keyid,
-                    cand->sup_rates,
-                    cand->sup_rates_len,
-                    cand->cookie);
-            set_link_state(cand, PLINK_ESTAB);
-            changed |= mesh_set_ht_op_mode(cand->conf->mesh);
-            sae_debug(AMPE_DEBUG_FSM, "mesh plink with "
-                    MACSTR " established\n", MAC2STR(cand->peer_mac));
-            rekey_verify_peer(cand);
-			break;
-		default:
-			break;
-		}
-		break;
-
-	case PLINK_CNF_RCVD:
-		switch (event) {
-		case OPN_RJCT:
-		case CNF_RJCT:
-			reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
-			/* no break */
-		case CLS_ACPT:
-			if (!reason)
-				reason = htole16(MESH_CLOSE_RCVD);
-			cand->reason = reason;
-			set_link_state(cand, PLINK_HOLDING);
-            cand->timeout = aconf->holding_timeout_ms;
-            cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
-			plink_frame_tx(cand, PLINK_CLOSE, reason);
-			break;
+  switch (cand->link_state) {
+    case PLINK_LISTEN:
+      switch (event) {
+        case CLS_ACPT:
+          fsm_restart(cand);
+          break;
         case OPN_ACPT:
-            derive_mtk(cand);
-            cb->estab_peer_link(cand->peer_mac,
-                    cand->mtk, sizeof(cand->mtk),
-                    cand->mgtk, sizeof(cand->mgtk),
-                    cand->mgtk_expiration,
-                    (cand->has_igtk) ? cand->igtk : NULL,
-                    (cand->has_igtk) ? sizeof(cand->igtk) : 0,
-                    cand->igtk_keyid,
-                    cand->sup_rates,
-                    cand->sup_rates_len,
-                    cand->cookie);
-            set_link_state(cand, PLINK_ESTAB);
-            changed |= mesh_set_ht_op_mode(cand->conf->mesh);
-            //TODO: update the number of available peer "slots" in mesh config
-			//mesh_plink_inc_estab_count(sdata);
-			//ieee80211_bss_info_change_notify(sdata, BSS_CHANGED_BEACON);
-			sae_debug(AMPE_DEBUG_FSM, "Mesh plink with "
-                    MACSTR " ESTABLISHED\n", MAC2STR(cand->peer_mac));
-			plink_frame_tx(cand, PLINK_CONFIRM, 0);
-			rekey_verify_peer(cand);
-			break;
-		default:
-			break;
-		}
-		break;
+          cand->timeout = aconf->retry_timeout_ms;
+          cand->t2 =
+              cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+          set_link_state(cand, PLINK_OPN_RCVD);
+          plink_frame_tx(cand, PLINK_OPEN, 0);
+          plink_frame_tx(cand, PLINK_CONFIRM, 0);
+          break;
+        default:
+          break;
+      }
+      break;
 
-	case PLINK_ESTAB:
-		switch (event) {
-		case CLS_ACPT:
-			reason = htole16(MESH_CLOSE_RCVD);
-			cand->reason = reason;
-			set_link_state(cand, PLINK_HOLDING);
-            cand->timeout = aconf->holding_timeout_ms;
-            cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
-            changed |= mesh_set_ht_op_mode(cand->conf->mesh);
-            //TODO: update the number of available peer "slots" in mesh config
-			//if (deactivated)
-		    //	ieee80211_bss_info_change_notify(sdata, BSS_CHANGED_BEACON);
-			plink_frame_tx(cand, PLINK_CLOSE, reason);
-			break;
-		case OPN_ACPT:
-			plink_frame_tx(cand, PLINK_CONFIRM, 0);
-			break;
-		default:
-			break;
-		}
-		break;
-	case PLINK_HOLDING:
-		switch (event) {
-		case CLS_ACPT:
-			//if (del_timer(&cand->plink_timer))
-			//	cand->ignore_plink_timer = 1;
-			fsm_restart(cand);
-			break;
-		case OPN_ACPT:
-		case CNF_ACPT:
-		case OPN_RJCT:
-		case CNF_RJCT:
-			reason = cand->reason;
-			plink_frame_tx(cand, PLINK_CLOSE, reason);
-			break;
-		default:
-            break;
-		}
-		break;
-	default:
-        sae_debug(AMPE_DEBUG_FSM, "Unsupported event transition %d", event);
-		break;
-	}
+    case PLINK_OPN_SNT:
+      switch (event) {
+        case OPN_RJCT:
+        case CNF_RJCT:
+          reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
+        /* no break */
+        case CLS_ACPT:
+          if (!reason)
+            reason = htole16(MESH_CLOSE_RCVD);
+          cand->reason = reason;
+          set_link_state(cand, PLINK_HOLDING);
+          cand->timeout = aconf->holding_timeout_ms;
+          cand->t2 =
+              cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+          plink_frame_tx(cand, PLINK_CLOSE, reason);
+          break;
+        case OPN_ACPT:
+          /* retry timer is left untouched */
+          set_link_state(cand, PLINK_OPN_RCVD);
+          plink_frame_tx(cand, PLINK_CONFIRM, 0);
+          break;
+        case CNF_ACPT:
+          set_link_state(cand, PLINK_CNF_RCVD);
+          cand->timeout = aconf->confirm_timeout_ms;
+          cand->t2 =
+              cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+          break;
+        default:
+          break;
+      }
+      break;
 
-    if (changed)
-        cb->meshd_set_mesh_conf(cand->conf->mesh, changed);
+    case PLINK_OPN_RCVD:
+      switch (event) {
+        case OPN_RJCT:
+        case CNF_RJCT:
+          reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
+        /* no break */
+        case CLS_ACPT:
+          if (!reason)
+            reason = htole16(MESH_CLOSE_RCVD);
+          cand->reason = reason;
+          set_link_state(cand, PLINK_HOLDING);
+          cand->timeout = aconf->holding_timeout_ms;
+          cand->t2 =
+              cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+          plink_frame_tx(cand, PLINK_CLOSE, reason);
+          break;
+        case OPN_ACPT:
+          plink_frame_tx(cand, PLINK_CONFIRM, 0);
+          break;
+        case CNF_ACPT:
+          // del_timer(&cand->plink_timer);
+          // mesh_plink_inc_estab_count(sdata);
+          // ieee80211_bss_info_change_notify(sdata, BSS_CHANGED_BEACON);
+          derive_mtk(cand);
+          cb->estab_peer_link(
+              cand->peer_mac,
+              cand->mtk,
+              sizeof(cand->mtk),
+              cand->mgtk,
+              sizeof(cand->mgtk),
+              cand->mgtk_expiration,
+              (cand->has_igtk) ? cand->igtk : NULL,
+              (cand->has_igtk) ? sizeof(cand->igtk) : 0,
+              cand->igtk_keyid,
+              cand->sup_rates,
+              cand->sup_rates_len,
+              cand->cookie);
+          set_link_state(cand, PLINK_ESTAB);
+          changed |= mesh_set_ht_op_mode(cand->conf->mesh);
+          sae_debug(
+              AMPE_DEBUG_FSM,
+              "mesh plink with " MACSTR " established\n",
+              MAC2STR(cand->peer_mac));
+          rekey_verify_peer(cand);
+          break;
+        default:
+          break;
+      }
+      break;
+
+    case PLINK_CNF_RCVD:
+      switch (event) {
+        case OPN_RJCT:
+        case CNF_RJCT:
+          reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
+        /* no break */
+        case CLS_ACPT:
+          if (!reason)
+            reason = htole16(MESH_CLOSE_RCVD);
+          cand->reason = reason;
+          set_link_state(cand, PLINK_HOLDING);
+          cand->timeout = aconf->holding_timeout_ms;
+          cand->t2 =
+              cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+          plink_frame_tx(cand, PLINK_CLOSE, reason);
+          break;
+        case OPN_ACPT:
+          derive_mtk(cand);
+          cb->estab_peer_link(
+              cand->peer_mac,
+              cand->mtk,
+              sizeof(cand->mtk),
+              cand->mgtk,
+              sizeof(cand->mgtk),
+              cand->mgtk_expiration,
+              (cand->has_igtk) ? cand->igtk : NULL,
+              (cand->has_igtk) ? sizeof(cand->igtk) : 0,
+              cand->igtk_keyid,
+              cand->sup_rates,
+              cand->sup_rates_len,
+              cand->cookie);
+          set_link_state(cand, PLINK_ESTAB);
+          changed |= mesh_set_ht_op_mode(cand->conf->mesh);
+          // TODO: update the number of available peer "slots" in mesh config
+          // mesh_plink_inc_estab_count(sdata);
+          // ieee80211_bss_info_change_notify(sdata, BSS_CHANGED_BEACON);
+          sae_debug(
+              AMPE_DEBUG_FSM,
+              "Mesh plink with " MACSTR " ESTABLISHED\n",
+              MAC2STR(cand->peer_mac));
+          plink_frame_tx(cand, PLINK_CONFIRM, 0);
+          rekey_verify_peer(cand);
+          break;
+        default:
+          break;
+      }
+      break;
+
+    case PLINK_ESTAB:
+      switch (event) {
+        case CLS_ACPT:
+          reason = htole16(MESH_CLOSE_RCVD);
+          cand->reason = reason;
+          set_link_state(cand, PLINK_HOLDING);
+          cand->timeout = aconf->holding_timeout_ms;
+          cand->t2 =
+              cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+          changed |= mesh_set_ht_op_mode(cand->conf->mesh);
+          // TODO: update the number of available peer "slots" in mesh config
+          // if (deactivated)
+          //	ieee80211_bss_info_change_notify(sdata, BSS_CHANGED_BEACON);
+          plink_frame_tx(cand, PLINK_CLOSE, reason);
+          break;
+        case OPN_ACPT:
+          plink_frame_tx(cand, PLINK_CONFIRM, 0);
+          break;
+        default:
+          break;
+      }
+      break;
+    case PLINK_HOLDING:
+      switch (event) {
+        case CLS_ACPT:
+          // if (del_timer(&cand->plink_timer))
+          //	cand->ignore_plink_timer = 1;
+          fsm_restart(cand);
+          break;
+        case OPN_ACPT:
+        case CNF_ACPT:
+        case OPN_RJCT:
+        case CNF_RJCT:
+          reason = cand->reason;
+          plink_frame_tx(cand, PLINK_CLOSE, reason);
+          break;
+        default:
+          break;
+      }
+      break;
+    default:
+      sae_debug(AMPE_DEBUG_FSM, "Unsupported event transition %d", event);
+      break;
+  }
+
+  if (changed)
+    cb->meshd_set_mesh_conf(cand->conf->mesh, changed);
 }
 
 #define PLINK_GET_LLID(p) (p + 2)
 #define PLINK_GET_PLID(p) (p + 4)
-
 
 /**
  * start_peer_link - attempt to establish a peer link
@@ -968,47 +1050,49 @@ static void fsm_step(struct candidate *cand, enum plink_event event)
  *
  * Returns 0 or a negative error.
  */
-int start_peer_link(unsigned char *peer_mac, unsigned char *me, void *cookie)
-{
-    struct candidate *cand;
+int start_peer_link(unsigned char *peer_mac, unsigned char *me, void *cookie) {
+  struct candidate *cand;
 
-    assert(peer_mac && me);
+  assert(peer_mac && me);
 
- 	if ((cand = find_peer(peer_mac, 0)) == NULL) {
-        sae_debug(AMPE_DEBUG_FSM, "Mesh plink: Attempt to peer with "
-                " non-authed peer\n");
-            return -EPERM;
-	}
+  if ((cand = find_peer(peer_mac, 0)) == NULL) {
+    sae_debug(
+        AMPE_DEBUG_FSM,
+        "Mesh plink: Attempt to peer with "
+        " non-authed peer\n");
+    return -EPERM;
+  }
 
-    peer_ampe_init(&ampe_conf, cand, cookie);
-	set_link_state(cand, PLINK_OPN_SNT);
-    cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
+  peer_ampe_init(&ampe_conf, cand, cookie);
+  set_link_state(cand, PLINK_OPN_SNT);
+  cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
 
-	sae_debug(AMPE_DEBUG_FSM, "Mesh plink: starting establishment "
-            "with " MACSTR "\n", MAC2STR(peer_mac));
+  sae_debug(
+      AMPE_DEBUG_FSM,
+      "Mesh plink: starting establishment "
+      "with " MACSTR "\n",
+      MAC2STR(peer_mac));
 
-
-	return plink_frame_tx(cand, PLINK_OPEN, 0);
+  return plink_frame_tx(cand, PLINK_OPEN, 0);
 }
 
-static uint32_t get_basic_rates(struct info_elems *elems)
-{
-    int i, bit = 0;
-    uint32_t basic_rates = 0;
+static uint32_t get_basic_rates(struct info_elems *elems) {
+  int i, bit = 0;
+  uint32_t basic_rates = 0;
 
-    if (elems->sup_rates) {
-        for (i = 0; i < elems->sup_rates_len; i++)
-            if (elems->sup_rates[i] & 0x80)
-                basic_rates |= 1 << bit++;
-    }
+  if (elems->sup_rates) {
+    for (i = 0; i < elems->sup_rates_len; i++)
+      if (elems->sup_rates[i] & 0x80)
+        basic_rates |= 1 << bit++;
+  }
 
-    if (elems->ext_rates) {
-        for (i = 0; i < elems->ext_rates_len; i++)
-            if (elems->ext_rates[i] & 0x80)
-                basic_rates |= 1 << bit++;
-    }
+  if (elems->ext_rates) {
+    for (i = 0; i < elems->ext_rates_len; i++)
+      if (elems->ext_rates[i] & 0x80)
+        basic_rates |= 1 << bit++;
+  }
 
-    return basic_rates;
+  return basic_rates;
 }
 
 /**
@@ -1023,265 +1107,288 @@ static uint32_t get_basic_rates(struct info_elems *elems)
  * the frame could not be processed or it was corrupted, the function still
  * returns 0.
  */
-int process_ampe_frame(struct ieee80211_mgmt_frame *mgmt, int len,
-                        unsigned char *me, void *cookie)
-{
-    struct info_elems elems;
-    struct info_elems our_elems;
-    unsigned char ftype;
-	struct candidate *cand = NULL;
-	enum plink_event event;
-	unsigned char ie_len = 0;
-	unsigned short plid = 0, llid = 0;
-    unsigned char *ies;
-    unsigned short ies_len;
-    size_t pmkid_len;
+int process_ampe_frame(
+    struct ieee80211_mgmt_frame *mgmt,
+    int len,
+    unsigned char *me,
+    void *cookie) {
+  struct info_elems elems;
+  struct info_elems our_elems;
+  unsigned char ftype;
+  struct candidate *cand = NULL;
+  enum plink_event event;
+  unsigned char ie_len = 0;
+  unsigned short plid = 0, llid = 0;
+  unsigned char *ies;
+  unsigned short ies_len;
+  size_t pmkid_len;
 
 #define FAKE_LOSS_PROBABILITY 0
 #if (FAKE_LOSS_PROBABILITY > 0)
-    do {
-        unsigned short dice;
-        dice = RAND_bytes((unsigned char *) &dice, sizeof(dice));
-        if ((dice % 100) < FAKE_LOSS_PROBABILITY) {
-            sae_debug(AMPE_DEBUG_FSM, "Frame dropped\n");
-            return 0;
-        }
-    } while (0);
+  do {
+    unsigned short dice;
+    dice = RAND_bytes((unsigned char *)&dice, sizeof(dice));
+    if ((dice % 100) < FAKE_LOSS_PROBABILITY) {
+      sae_debug(AMPE_DEBUG_FSM, "Frame dropped\n");
+      return 0;
+    }
+  } while (0);
 #endif
 
-	/* management header, category, action code, mesh id and peering mgmt*/
-	if (len < 24 + 1 + 1 + 2 + 2)
-		return 0;
-
-	//if (is_multicast_ether_addr(mgmt->da)) {
-	//	sae_debug(AMPE_DEBUG_FSM, "Mesh plink: ignore frame to multicast address");
-	//	return 0;
-	//}
-
-
-	ies = start_of_ies(mgmt, len, &ies_len);
-	parse_ies(ies, ies_len, &elems);
-	if (!elems.mesh_peering) {  // || !elems.rsn) {
-		sae_debug(AMPE_DEBUG_FSM, "Mesh plink: missing necessary peer link ie\n");
-		return 0;
-	}
-
-	ftype = mgmt->action.action_code;
-	ie_len = elems.mesh_peering_len;
-
-	pmkid_len = ampe_conf.mesh->conf->is_secure ? sizeof(cand->pmkid) : 0;
-
-	if ((ftype == PLINK_OPEN && ie_len != 4 + pmkid_len) ||
-	    (ftype == PLINK_CONFIRM && ie_len != 6 + pmkid_len) ||
-	    (ftype == PLINK_CLOSE && ie_len != 6 + pmkid_len && ie_len != 8 + pmkid_len)) {
-		sae_debug(AMPE_DEBUG_FSM, "Mesh plink: incorrect plink ie length %d %d\n",
-		    ftype, ie_len);
-		return 0;
-	}
-
-    if (ftype != PLINK_CLOSE && (!elems.mesh_id || !elems.mesh_config)) {
-        sae_debug(AMPE_DEBUG_FSM, "Mesh plink: missing necessary ie %p %p\n", elems.mesh_id, elems.mesh_config);
-        return 0;
-    }
-
-	/* Note the lines below are correct, the llid in the frame is the plid
-	 * from the point of view of this host.
-	 */
- 	memcpy(&plid, PLINK_GET_LLID(elems.mesh_peering), 2);
-    if (ftype == PLINK_CONFIRM || (ftype == PLINK_CLOSE && ie_len == 10))
-        memcpy(&llid, PLINK_GET_PLID(elems.mesh_peering), 2);
-
-    /* match BSSBasicRateSet*/
-    parse_ies(sta_fixed_ies, sta_fixed_ies_len, &our_elems);
-    if (ftype != PLINK_CLOSE && get_basic_rates(&our_elems) != get_basic_rates(&elems)) {
-        sae_debug(AMPE_DEBUG_FSM, "mesh plink: mismatched BSSBasicRateSet!\n");
-        return 0;
-    }
-
-    /* require authed peers if secure mesh */
-    if (ampe_conf.mesh->conf->is_secure) {
-        /* "1" here means only get peers in SAE_ACCEPTED */
-        if ((cand = find_peer(mgmt->sa, 1)) == NULL) {
-            sae_debug(AMPE_DEBUG_FSM, "Mesh plink: plink open from unauthed peer "MACSTR"\n",
-                      MAC2STR(mgmt->sa));
-            return 0;
-        }
-    } else {
-        /*
-         * In open mesh, there's no auth stage, so we create the station
-         * when the first mgmt frame or beacon is received.  Do that now
-         * if we haven't already.
-         */
-        cand = find_peer(mgmt->sa, 0);
-        if (!cand) {
-            cand = create_candidate(mgmt->sa, me, 0, cookie);
-            if (!cand) {
-                sae_debug(AMPE_DEBUG_FSM, "Mesh plink: could not create new peer "MACSTR"\n",
-                          MAC2STR(mgmt->sa));
-                return 0;
-            }
-        }
-    }
-
-    if (cand->my_lid == 0)
-        peer_ampe_init(&ampe_conf, cand, cookie);
-
-    if (elems.sup_rates) {
-        memcpy(cand->sup_rates, elems.sup_rates,
-                elems.sup_rates_len);
-        cand->sup_rates_len = elems.sup_rates_len;
-        if (elems.ext_rates) {
-            memcpy(cand->sup_rates + elems.sup_rates_len,
-                    elems.ext_rates, elems.ext_rates_len);
-            cand->sup_rates_len += elems.ext_rates_len;
-        }
-    }
-
-    if (elems.ht_cap && elems.ht_cap_len <= sizeof(cand->ht_cap)) {
-        memcpy(&cand->ht_cap, elems.ht_cap, elems.ht_cap_len);
-    }
-
-    if (elems.ht_info && elems.ht_info_len <= sizeof(cand->ht_info)) {
-        memcpy(&cand->ht_info, elems.ht_info, elems.ht_info_len);
-    }
-
-    check_frame_protection(cand, mgmt, len, &elems);
-
-    cand->cookie = cookie;
-
-	if (cand->link_state == PLINK_BLOCKED) {
-		return 0;
-	}
-
-	/* Now we will figure out the appropriate event... */
-	event = PLINK_UNDEFINED;
-//	if (ftype != PLINK_CLOSE && (!mesh_matches_local(&elems, sdata))) {
-	if (ftype != PLINK_CLOSE) {
-		switch (ftype) {
-		case PLINK_OPEN:
-			event = OPN_RJCT;
-			break;
-		case PLINK_CONFIRM:
-			event = CNF_RJCT;
-			break;
-		case PLINK_CLOSE:
-			break;
-		}
-	}
-
-    switch (ftype) {
-    case PLINK_OPEN:
-        if (!plink_free_count() ||
-            (cand->peer_lid && cand->peer_lid != plid))
-            event = OPN_IGNR;
-        else {
-            cand->peer_lid = plid;
-            event = OPN_ACPT;
-        }
-        break;
-    case PLINK_CONFIRM:
-        if (!plink_free_count() ||
-            (cand->my_lid != llid || cand->peer_lid != plid))
-            event = CNF_IGNR;
-        else
-            event = CNF_ACPT;
-        break;
-    case PLINK_CLOSE:
-        if (cand->link_state == PLINK_ESTAB)
-            /* Do not check for llid or plid. This does not
-             * follow the standard but since multiple plinks
-             * per cand are not supported, it is necessary in
-             * order to avoid a livelock when MP A sees an
-             * establish peer link to MP B but MP B does not
-             * see it. This can be caused by a timeout in
-             * B's peer link establishment or B beign
-             * restarted.
-             */
-            event = CLS_ACPT;
-        else if (cand->peer_lid != plid)
-            event = CLS_IGNR;
-        else if (ie_len == 7 && cand->my_lid != llid)
-            event = CLS_IGNR;
-        else
-            event = CLS_ACPT;
-        break;
-    default:
-        sae_debug(AMPE_DEBUG_FSM, "Mesh plink: unknown frame subtype\n");
-        return 0;
-    }
-
-	sae_debug(AMPE_DEBUG_FSM, "Mesh plink (peer, state, llid, plid, event): " MACSTR " %s %d %d %d\n",
-		MAC2STR(mgmt->sa), mplstates[cand->link_state],
-		le16toh(cand->my_lid), le16toh(cand->peer_lid),
-		event);
-
-    fsm_step(cand, event);
-
+  /* management header, category, action code, mesh id and peering mgmt*/
+  if (len < 24 + 1 + 1 + 2 + 2)
     return 0;
-}
 
-static bool check_callbacks(struct ampe_cb *callbacks)
-{
-    bool valid = callbacks != NULL;
-    valid = valid && callbacks->meshd_write_mgmt != NULL;
-    valid = valid && callbacks->meshd_set_mesh_conf != NULL;
-    valid = valid && callbacks->set_plink_state != NULL;
-    valid = valid && callbacks->estab_peer_link != NULL;
-    return valid;
-}
+  // if (is_multicast_ether_addr(mgmt->da)) {
+  //	sae_debug(AMPE_DEBUG_FSM, "Mesh plink: ignore frame to multicast
+  //address");
+  //	return 0;
+  //}
 
-int ampe_initialize(struct mesh_node *mesh, struct ampe_cb *callbacks)
-{
-        int sup_rates_len;
+  ies = start_of_ies(mgmt, len, &ies_len);
+  parse_ies(ies, ies_len, &elems);
+  if (!elems.mesh_peering) { // || !elems.rsn) {
+    sae_debug(AMPE_DEBUG_FSM, "Mesh plink: missing necessary peer link ie\n");
+    return 0;
+  }
 
-        if (!check_callbacks(callbacks))
-            return -1;
+  ftype = mgmt->action.action_code;
+  ie_len = elems.mesh_peering_len;
 
-        cb = callbacks;
+  pmkid_len = ampe_conf.mesh->conf->is_secure ? sizeof(cand->pmkid) : 0;
 
-        /* TODO: move these to a config file */
-        ampe_conf.retry_timeout_ms = 1000;
-        ampe_conf.holding_timeout_ms = 1000;
-        ampe_conf.confirm_timeout_ms = 1000;
-        ampe_conf.max_retries = 10;
-        ampe_conf.mesh = mesh;
+  if ((ftype == PLINK_OPEN && ie_len != 4 + pmkid_len) ||
+      (ftype == PLINK_CONFIRM && ie_len != 6 + pmkid_len) ||
+      (ftype == PLINK_CLOSE && ie_len != 6 + pmkid_len &&
+       ie_len != 8 + pmkid_len)) {
+    sae_debug(
+        AMPE_DEBUG_FSM,
+        "Mesh plink: incorrect plink ie length %d %d\n",
+        ftype,
+        ie_len);
+    return 0;
+  }
 
-        if (mesh->conf->is_secure) {
-            RAND_bytes(mgtk_tx, 16);
-            sae_hexdump(AMPE_DEBUG_KEYS, "mgtk: ", mgtk_tx, sizeof(mgtk_tx));
-        }
+  if (ftype != PLINK_CLOSE && (!elems.mesh_id || !elems.mesh_config)) {
+    sae_debug(
+        AMPE_DEBUG_FSM,
+        "Mesh plink: missing necessary ie %p %p\n",
+        elems.mesh_id,
+        elems.mesh_config);
+    return 0;
+  }
 
-        if (mesh->conf->pmf) {
-            RAND_bytes(mesh->igtk_tx, 16);
-            mesh->igtk_keyid = 4;
-            memset(mesh->igtk_ipn, 0, sizeof(mesh->igtk_ipn));
-            sae_hexdump(AMPE_DEBUG_KEYS, "igtk: ", mesh->igtk_tx, sizeof(mesh->igtk_tx));
-        }
+  /* Note the lines below are correct, the llid in the frame is the plid
+   * from the point of view of this host.
+   */
+  memcpy(&plid, PLINK_GET_LLID(elems.mesh_peering), 2);
+  if (ftype == PLINK_CONFIRM || (ftype == PLINK_CLOSE && ie_len == 10))
+    memcpy(&llid, PLINK_GET_PLID(elems.mesh_peering), 2);
 
-        /* We can do this because valid supported rates non null and the array is null terminated */
-        sup_rates_len = strnlen((char *) mesh->conf->rates, sizeof(mesh->conf->rates));
-        if (sup_rates_len <= 8) {
-            /*  rates fit into a the supported rates IE */
-            sta_fixed_ies_len = 2 + sup_rates_len;
-            sta_fixed_ies = malloc(sta_fixed_ies_len);
-            *sta_fixed_ies = IEEE80211_EID_SUPPORTED_RATES;
-            *(sta_fixed_ies+1) = sup_rates_len;
-            memcpy(sta_fixed_ies+2, mesh->conf->rates, sup_rates_len);
-        } else if (sup_rates_len < sizeof(mesh->conf->rates)) {
-            /*  rates overflow onto the extended supported rates IE */
-            sta_fixed_ies_len = 4 + sup_rates_len;
-            sta_fixed_ies = malloc(sta_fixed_ies_len);
-            *sta_fixed_ies = IEEE80211_EID_SUPPORTED_RATES;
-            *(sta_fixed_ies + 1) = 8;
-            memcpy(sta_fixed_ies + 2, mesh->conf->rates, 8);
-            *(sta_fixed_ies + 10) = IEEE80211_EID_EXTENDED_SUP_RATES;
-            *(sta_fixed_ies + 11) = sup_rates_len - 8;
-            memcpy(sta_fixed_ies + 12, mesh->conf->rates + 8, sup_rates_len - 8);
-        } else {
-            sae_debug(SAE_DEBUG_ERR, "mesh->conf->rates should be null-terminated");
-            return -1;
-        }
+  /* match BSSBasicRateSet*/
+  parse_ies(sta_fixed_ies, sta_fixed_ies_len, &our_elems);
+  if (ftype != PLINK_CLOSE &&
+      get_basic_rates(&our_elems) != get_basic_rates(&elems)) {
+    sae_debug(AMPE_DEBUG_FSM, "mesh plink: mismatched BSSBasicRateSet!\n");
+    return 0;
+  }
 
-        sae_hexdump(MESHD_DEBUG , "Fixed Information Elements in this STA", sta_fixed_ies, sta_fixed_ies_len);
+  /* require authed peers if secure mesh */
+  if (ampe_conf.mesh->conf->is_secure) {
+    /* "1" here means only get peers in SAE_ACCEPTED */
+    if ((cand = find_peer(mgmt->sa, 1)) == NULL) {
+      sae_debug(
+          AMPE_DEBUG_FSM,
+          "Mesh plink: plink open from unauthed peer " MACSTR "\n",
+          MAC2STR(mgmt->sa));
+      return 0;
+    }
+  } else {
+    /*
+     * In open mesh, there's no auth stage, so we create the station
+     * when the first mgmt frame or beacon is received.  Do that now
+     * if we haven't already.
+     */
+    cand = find_peer(mgmt->sa, 0);
+    if (!cand) {
+      cand = create_candidate(mgmt->sa, me, 0, cookie);
+      if (!cand) {
+        sae_debug(
+            AMPE_DEBUG_FSM,
+            "Mesh plink: could not create new peer " MACSTR "\n",
+            MAC2STR(mgmt->sa));
         return 0;
+      }
+    }
+  }
+
+  if (cand->my_lid == 0)
+    peer_ampe_init(&ampe_conf, cand, cookie);
+
+  if (elems.sup_rates) {
+    memcpy(cand->sup_rates, elems.sup_rates, elems.sup_rates_len);
+    cand->sup_rates_len = elems.sup_rates_len;
+    if (elems.ext_rates) {
+      memcpy(
+          cand->sup_rates + elems.sup_rates_len,
+          elems.ext_rates,
+          elems.ext_rates_len);
+      cand->sup_rates_len += elems.ext_rates_len;
+    }
+  }
+
+  if (elems.ht_cap && elems.ht_cap_len <= sizeof(cand->ht_cap)) {
+    memcpy(&cand->ht_cap, elems.ht_cap, elems.ht_cap_len);
+  }
+
+  if (elems.ht_info && elems.ht_info_len <= sizeof(cand->ht_info)) {
+    memcpy(&cand->ht_info, elems.ht_info, elems.ht_info_len);
+  }
+
+  check_frame_protection(cand, mgmt, len, &elems);
+
+  cand->cookie = cookie;
+
+  if (cand->link_state == PLINK_BLOCKED) {
+    return 0;
+  }
+
+  /* Now we will figure out the appropriate event... */
+  event = PLINK_UNDEFINED;
+  //	if (ftype != PLINK_CLOSE && (!mesh_matches_local(&elems, sdata))) {
+  if (ftype != PLINK_CLOSE) {
+    switch (ftype) {
+      case PLINK_OPEN:
+        event = OPN_RJCT;
+        break;
+      case PLINK_CONFIRM:
+        event = CNF_RJCT;
+        break;
+      case PLINK_CLOSE:
+        break;
+    }
+  }
+
+  switch (ftype) {
+    case PLINK_OPEN:
+      if (!plink_free_count() || (cand->peer_lid && cand->peer_lid != plid))
+        event = OPN_IGNR;
+      else {
+        cand->peer_lid = plid;
+        event = OPN_ACPT;
+      }
+      break;
+    case PLINK_CONFIRM:
+      if (!plink_free_count() ||
+          (cand->my_lid != llid || cand->peer_lid != plid))
+        event = CNF_IGNR;
+      else
+        event = CNF_ACPT;
+      break;
+    case PLINK_CLOSE:
+      if (cand->link_state == PLINK_ESTAB)
+        /* Do not check for llid or plid. This does not
+         * follow the standard but since multiple plinks
+         * per cand are not supported, it is necessary in
+         * order to avoid a livelock when MP A sees an
+         * establish peer link to MP B but MP B does not
+         * see it. This can be caused by a timeout in
+         * B's peer link establishment or B beign
+         * restarted.
+         */
+        event = CLS_ACPT;
+      else if (cand->peer_lid != plid)
+        event = CLS_IGNR;
+      else if (ie_len == 7 && cand->my_lid != llid)
+        event = CLS_IGNR;
+      else
+        event = CLS_ACPT;
+      break;
+    default:
+      sae_debug(AMPE_DEBUG_FSM, "Mesh plink: unknown frame subtype\n");
+      return 0;
+  }
+
+  sae_debug(
+      AMPE_DEBUG_FSM,
+      "Mesh plink (peer, state, llid, plid, event): " MACSTR " %s %d %d %d\n",
+      MAC2STR(mgmt->sa),
+      mplstates[cand->link_state],
+      le16toh(cand->my_lid),
+      le16toh(cand->peer_lid),
+      event);
+
+  fsm_step(cand, event);
+
+  return 0;
+}
+
+static bool check_callbacks(struct ampe_cb *callbacks) {
+  bool valid = callbacks != NULL;
+  valid = valid && callbacks->meshd_write_mgmt != NULL;
+  valid = valid && callbacks->meshd_set_mesh_conf != NULL;
+  valid = valid && callbacks->set_plink_state != NULL;
+  valid = valid && callbacks->estab_peer_link != NULL;
+  return valid;
+}
+
+int ampe_initialize(struct mesh_node *mesh, struct ampe_cb *callbacks) {
+  int sup_rates_len;
+
+  if (!check_callbacks(callbacks))
+    return -1;
+
+  cb = callbacks;
+
+  /* TODO: move these to a config file */
+  ampe_conf.retry_timeout_ms = 1000;
+  ampe_conf.holding_timeout_ms = 1000;
+  ampe_conf.confirm_timeout_ms = 1000;
+  ampe_conf.max_retries = 10;
+  ampe_conf.mesh = mesh;
+
+  if (mesh->conf->is_secure) {
+    RAND_bytes(mgtk_tx, 16);
+    sae_hexdump(AMPE_DEBUG_KEYS, "mgtk: ", mgtk_tx, sizeof(mgtk_tx));
+  }
+
+  if (mesh->conf->pmf) {
+    RAND_bytes(mesh->igtk_tx, 16);
+    mesh->igtk_keyid = 4;
+    memset(mesh->igtk_ipn, 0, sizeof(mesh->igtk_ipn));
+    sae_hexdump(
+        AMPE_DEBUG_KEYS, "igtk: ", mesh->igtk_tx, sizeof(mesh->igtk_tx));
+  }
+
+  /* We can do this because valid supported rates non null and the array is null
+   * terminated */
+  sup_rates_len = strnlen((char *)mesh->conf->rates, sizeof(mesh->conf->rates));
+  if (sup_rates_len <= 8) {
+    /*  rates fit into a the supported rates IE */
+    sta_fixed_ies_len = 2 + sup_rates_len;
+    sta_fixed_ies = malloc(sta_fixed_ies_len);
+    *sta_fixed_ies = IEEE80211_EID_SUPPORTED_RATES;
+    *(sta_fixed_ies + 1) = sup_rates_len;
+    memcpy(sta_fixed_ies + 2, mesh->conf->rates, sup_rates_len);
+  } else if (sup_rates_len < sizeof(mesh->conf->rates)) {
+    /*  rates overflow onto the extended supported rates IE */
+    sta_fixed_ies_len = 4 + sup_rates_len;
+    sta_fixed_ies = malloc(sta_fixed_ies_len);
+    *sta_fixed_ies = IEEE80211_EID_SUPPORTED_RATES;
+    *(sta_fixed_ies + 1) = 8;
+    memcpy(sta_fixed_ies + 2, mesh->conf->rates, 8);
+    *(sta_fixed_ies + 10) = IEEE80211_EID_EXTENDED_SUP_RATES;
+    *(sta_fixed_ies + 11) = sup_rates_len - 8;
+    memcpy(sta_fixed_ies + 12, mesh->conf->rates + 8, sup_rates_len - 8);
+  } else {
+    sae_debug(SAE_DEBUG_ERR, "mesh->conf->rates should be null-terminated");
+    return -1;
+  }
+
+  sae_hexdump(
+      MESHD_DEBUG,
+      "Fixed Information Elements in this STA",
+      sta_fixed_ies,
+      sta_fixed_ies_len);
+  return 0;
 }

--- a/ampe.h
+++ b/ampe.h
@@ -11,137 +11,142 @@
 #include "ieee802_11.h"
 
 enum plink_state {
-    PLINK_LISTEN,
-    PLINK_OPN_SNT,
-    PLINK_OPN_RCVD,
-    PLINK_CNF_RCVD,
-    PLINK_ESTAB,
-    PLINK_HOLDING,
-    PLINK_BLOCKED
+  PLINK_LISTEN,
+  PLINK_OPN_SNT,
+  PLINK_OPN_RCVD,
+  PLINK_CNF_RCVD,
+  PLINK_ESTAB,
+  PLINK_HOLDING,
+  PLINK_BLOCKED
 };
 
 /* For Linux these values need to match NL80211_CHAN_XXX equivs */
-enum ht_channel_type {
-	CHAN_NO_HT,
-	CHAN_HT20,
-	CHAN_HT40MINUS,
-	CHAN_HT40PLUS
-};
+enum ht_channel_type { CHAN_NO_HT, CHAN_HT20, CHAN_HT40MINUS, CHAN_HT40PLUS };
 
 enum ieee80211_band {
-	IEEE80211_BAND_2GHZ,
-	IEEE80211_BAND_5GHZ,
+  IEEE80211_BAND_2GHZ,
+  IEEE80211_BAND_5GHZ,
 
-	/* keep last */
-	IEEE80211_NUM_BANDS
+  /* keep last */
+  IEEE80211_NUM_BANDS
 };
 
 struct local_ht_caps {
-	uint16_t cap;
-	bool ht_supported;
-	uint8_t ampdu_factor;
-	uint8_t ampdu_density;
-	struct mcs_info mcs;
+  uint16_t cap;
+  bool ht_supported;
+  uint8_t ampdu_factor;
+  uint8_t ampdu_density;
+  struct mcs_info mcs;
 };
 
 struct ieee80211_supported_band {
-	uint16_t *rates;
-	int n_bitrates;
-	struct local_ht_caps ht_cap;
+  uint16_t *rates;
+  int n_bitrates;
+  struct local_ht_caps ht_cap;
 };
 
 typedef union {
-    struct in_addr v4; /* in network byte order */
-    struct in6_addr v6; /* in network byte order */
+  struct in_addr v4; /* in network byte order */
+  struct in6_addr v6; /* in network byte order */
 } ip_address;
 
 /* mesh configuration parameters. Our bss_conf */
 struct meshd_config {
-    char interface[IFNAMSIZ + 1];
-    char meshid[MESHD_MAX_SSID_LEN + 1];
-    int meshid_len;
-    int passive;
-    int mediaopt;
-    int channel;
-    int band;
-    int debug;
-    int is_secure;
-    enum ht_channel_type channel_type;     /* HT mode */
-    /* ready to be copied into rate IEs. Includes BSSBasicRateSet */
+  char interface[IFNAMSIZ + 1];
+  char meshid[MESHD_MAX_SSID_LEN + 1];
+  int meshid_len;
+  int passive;
+  int mediaopt;
+  int channel;
+  int band;
+  int debug;
+  int is_secure;
+  enum ht_channel_type channel_type; /* HT mode */
+/* ready to be copied into rate IEs. Includes BSSBasicRateSet */
 #define MAX_SUPP_RATES 32
-    unsigned char rates[MAX_SUPP_RATES];
-    uint16_t ht_prot_mode;
-    int pmf;
-    int mcast_rate;
-    int beacon_interval;
-    int path_refresh_time;
-    int min_discovery_timeout;
-    int gate_announcements;
-    int hwmp_active_path_timeout;
-    int hwmp_net_diameter_traversal_time;
-    int hwmp_rootmode;
-    int hwmp_rann_interval;
-    int hwmp_active_path_to_root_timeout;
-    int hwmp_root_interval;
+  unsigned char rates[MAX_SUPP_RATES];
+  uint16_t ht_prot_mode;
+  int pmf;
+  int mcast_rate;
+  int beacon_interval;
+  int path_refresh_time;
+  int min_discovery_timeout;
+  int gate_announcements;
+  int hwmp_active_path_timeout;
+  int hwmp_net_diameter_traversal_time;
+  int hwmp_rootmode;
+  int hwmp_rann_interval;
+  int hwmp_active_path_to_root_timeout;
+  int hwmp_root_interval;
 
-    int rekey_enable;
-    char bridge[IFNAMSIZ];
-    int rekey_multicast_group_family;
-    ip_address rekey_multicast_group_address; /* in network byte order */
-    int rekey_ping_port; /* in network byte order */
-    int rekey_pong_port; /* in network byte order */
-    int rekey_ping_count_max;
-    int rekey_ping_timeout; /* in msec */
-    int rekey_ping_jitter; /* in msec */
-    int rekey_reauth_count_max;
-    int rekey_ok_ping_count_max;
+  int rekey_enable;
+  char bridge[IFNAMSIZ];
+  int rekey_multicast_group_family;
+  ip_address rekey_multicast_group_address; /* in network byte order */
+  int rekey_ping_port; /* in network byte order */
+  int rekey_pong_port; /* in network byte order */
+  int rekey_ping_count_max;
+  int rekey_ping_timeout; /* in msec */
+  int rekey_ping_jitter; /* in msec */
+  int rekey_reauth_count_max;
+  int rekey_ok_ping_count_max;
 };
 
 /* the single global interface and mesh node info we're handling.
  * BSS configuration stuff would also go here. Shared with AMPE. */
 struct mesh_node {
-    int freq;
-    enum ht_channel_type channel_type;     /* HT mode */
-    uint8_t mymacaddr[ETH_ALEN];
-    struct ieee80211_supported_band bands[IEEE80211_NUM_BANDS];
-    /* current band */
-    enum ieee80211_band band;
-    struct meshd_config *conf;
+  int freq;
+  enum ht_channel_type channel_type; /* HT mode */
+  uint8_t mymacaddr[ETH_ALEN];
+  struct ieee80211_supported_band bands[IEEE80211_NUM_BANDS];
+  /* current band */
+  enum ieee80211_band band;
+  struct meshd_config *conf;
 
-    /* integrity protection key */
-    int igtk_keyid;
-    uint8_t igtk_ipn[6];
-    uint8_t igtk_tx[16];
+  /* integrity protection key */
+  int igtk_keyid;
+  uint8_t igtk_ipn[6];
+  uint8_t igtk_tx[16];
 };
 
 struct ampe_config {
-    unsigned int retry_timeout_ms;
-    unsigned int holding_timeout_ms;
-    unsigned int confirm_timeout_ms;
-    unsigned int max_retries;
-    struct mesh_node *mesh;
+  unsigned int retry_timeout_ms;
+  unsigned int holding_timeout_ms;
+  unsigned int confirm_timeout_ms;
+  unsigned int max_retries;
+  struct mesh_node *mesh;
 };
 
 /* meshd_set_mesh_conf */
 #define MESH_CONF_CHANGED_HT 1 << 0
 
 struct ampe_cb {
-    int (*meshd_write_mgmt)(char *frame, int framelen, void *cookie);
-    int (*meshd_set_mesh_conf)(struct mesh_node *mesh, uint32_t changed);
-    int (*set_plink_state)(unsigned char *peer, int state, void *cookie);
-    void (*estab_peer_link)(unsigned char *peer, unsigned char *mtk,
-            int mtk_len, unsigned char *peer_mgtk, int peer_mgtk_len,
-            unsigned int mgtk_expiration,
-            unsigned char *peer_igtk, int peer_igtk_len, int peer_igtk_keyid,
-            unsigned char *sup_rates,
-            unsigned short sup_rates_len,
-            void *cookie);
-    struct evl_ops* evl;
+  int (*meshd_write_mgmt)(char *frame, int framelen, void *cookie);
+  int (*meshd_set_mesh_conf)(struct mesh_node *mesh, uint32_t changed);
+  int (*set_plink_state)(unsigned char *peer, int state, void *cookie);
+  void (*estab_peer_link)(
+      unsigned char *peer,
+      unsigned char *mtk,
+      int mtk_len,
+      unsigned char *peer_mgtk,
+      int peer_mgtk_len,
+      unsigned int mgtk_expiration,
+      unsigned char *peer_igtk,
+      int peer_igtk_len,
+      int peer_igtk_keyid,
+      unsigned char *sup_rates,
+      unsigned short sup_rates_len,
+      void *cookie);
+  struct evl_ops *evl;
 };
 
 /*  app calls these:  */
 int ampe_initialize(struct mesh_node *mesh, struct ampe_cb *cb);
-int process_ampe_frame(struct ieee80211_mgmt_frame *frame, int len, unsigned char *me, void *cookie);
+int process_ampe_frame(
+    struct ieee80211_mgmt_frame *frame,
+    int len,
+    unsigned char *me,
+    void *cookie);
 int start_peer_link(unsigned char *peer_mac, unsigned char *me, void *cookie);
 
 #endif /* _SAE_AMPE_H_ */

--- a/common.h
+++ b/common.h
@@ -39,33 +39,36 @@
 #ifndef _SAE_COMMON_H_
 #define _SAE_COMMON_H_
 
-#define MESHD_STA       0
-#define MESHD_ADHOC     1
-#define MESHD_HOSTAP    2
-#define MESHD_MONITOR   3
-#define MESHD_IBSS      4
-#define MESHD_11a       1
-#define MESHD_11b       2
-#define MESHD_11g       3
+#define MESHD_STA 0
+#define MESHD_ADHOC 1
+#define MESHD_HOSTAP 2
+#define MESHD_MONITOR 3
+#define MESHD_IBSS 4
+#define MESHD_11a 1
+#define MESHD_11b 2
+#define MESHD_11g 3
 #define MESHD_MAX_SSID_LEN 32
 int parse_buffer(char *, char **);
 
-#define SAE_DEBUG_ERR           0x01
-#define SAE_DEBUG_PROTOCOL_MSG  0x02
+#define SAE_DEBUG_ERR 0x01
+#define SAE_DEBUG_PROTOCOL_MSG 0x02
 #define SAE_DEBUG_STATE_MACHINE 0x04
-#define SAE_DEBUG_CRYPTO        0x08
-#define SAE_DEBUG_CRYPTO_VERB   0x10
-#define AMPE_DEBUG_CANDIDATES   0x20
-#define MESHD_DEBUG             0x40
-#define AMPE_DEBUG_FSM          0x80
-#define AMPE_DEBUG_KEYS        0x100
-#define AMPE_DEBUG_ERR         0x200
-#define SAE_DEBUG_REKEY        0x400
+#define SAE_DEBUG_CRYPTO 0x08
+#define SAE_DEBUG_CRYPTO_VERB 0x10
+#define AMPE_DEBUG_CANDIDATES 0x20
+#define MESHD_DEBUG 0x40
+#define AMPE_DEBUG_FSM 0x80
+#define AMPE_DEBUG_KEYS 0x100
+#define AMPE_DEBUG_ERR 0x200
+#define SAE_DEBUG_REKEY 0x400
 extern unsigned int sae_debug_mask;
-void sae_debug (int level, const char *fmt, ...)
+void sae_debug(int level, const char *fmt, ...)
     __attribute__((format(printf, 2, 3)));
-void sae_hexdump(int level, const char *label, const unsigned char *start, int
-        len);
+void sae_hexdump(
+    int level,
+    const char *label,
+    const unsigned char *start,
+    int len);
 
 #ifndef le16
 #define le16 unsigned short
@@ -82,4 +85,4 @@ typedef int config_int_t;
 typedef long int config_int_t;
 #endif
 
-#endif  /* _SAE_COMMON_H_ */
+#endif /* _SAE_COMMON_H_ */

--- a/crypto/aes_locl.h
+++ b/crypto/aes_locl.h
@@ -7,7 +7,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -56,13 +56,23 @@
 #error AES is disabled.
 #endif
 
-#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64))
-# define SWAP(x) (_lrotl(x, 8) & 0x00ff00ff | _lrotr(x, 8) & 0xff00ff00)
-# define GETU32(p) SWAP(*((u32 *)(p)))
-# define PUTU32(ct, st) { *((u32 *)(ct)) = SWAP((st)); }
+#if defined(_MSC_VER) && \
+    (defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64))
+#define SWAP(x) (_lrotl(x, 8) & 0x00ff00ff | _lrotr(x, 8) & 0xff00ff00)
+#define GETU32(p) SWAP(*((u32 *)(p)))
+#define PUTU32(ct, st) \
+  { *((u32 *)(ct)) = SWAP((st)); }
 #else
-# define GETU32(pt) (((u32)(pt)[0] << 24) ^ ((u32)(pt)[1] << 16) ^ ((u32)(pt)[2] <<  8) ^ ((u32)(pt)[3]))
-# define PUTU32(ct, st) { (ct)[0] = (u8)((st) >> 24); (ct)[1] = (u8)((st) >> 16); (ct)[2] = (u8)((st) >>  8); (ct)[3] = (u8)(st); }
+#define GETU32(pt)                                                     \
+  (((u32)(pt)[0] << 24) ^ ((u32)(pt)[1] << 16) ^ ((u32)(pt)[2] << 8) ^ \
+   ((u32)(pt)[3]))
+#define PUTU32(ct, st)          \
+  {                             \
+    (ct)[0] = (u8)((st) >> 24); \
+    (ct)[1] = (u8)((st) >> 16); \
+    (ct)[2] = (u8)((st) >> 8);  \
+    (ct)[3] = (u8)(st);         \
+  }
 #endif
 
 #ifdef AES_LONG
@@ -73,9 +83,9 @@ typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-#define MAXKC   (256/32)
-#define MAXKB   (256/8)
-#define MAXNR   14
+#define MAXKC (256 / 32)
+#define MAXKB (256 / 8)
+#define MAXNR 14
 
 /* This controls loop-unrolling in aes_core.c */
 #undef FULL_UNROLL

--- a/crypto/aes_siv.c
+++ b/crypto/aes_siv.c
@@ -54,291 +54,295 @@
  * http://www.cs.ucdavis.edu/~rogaway/papers/keywrap.pdf
  */
 
-#define Rb		0x87
+#define Rb 0x87
 
-static unsigned char zero[AES_BLOCK_SIZE] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-};
+static unsigned char zero[AES_BLOCK_SIZE] = {0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00,
+                                             0x00};
 
 /*
  * xor()
  *	output ^= input
  */
-static void
-xor (unsigned char *output, const unsigned char *input)
-{
-    int i;
+static void xor
+    (unsigned char *output, const unsigned char *input) {
+      int i;
 
-    i = AES_BLOCK_SIZE - 1;
-    do {
-	output[i] ^= input[i];
-	i--;
-    } while (i >= 0);
-    return;
-}
-
-/*
- * times_two()
- *	compute the product of 2 and "input" as a polynomial multiplication
- *	modulo the prime polynomial x^128 + x^7 + x^2 + x + 1
- */
-static void
-times_two (unsigned char *output, unsigned char *input)
-{
-    int i;
-    unsigned char *out = output, *in = input;
-    unsigned char carry = 0;
-
-    out = output + AES_BLOCK_SIZE - 1;
-    in = input + AES_BLOCK_SIZE - 1;
-    for (i = 0; i < AES_BLOCK_SIZE; i++) {
-	*(out--) = (*in << 1) | carry;
-	carry = (*(in--) & 0x80) ? 1 : 0;
+      i = AES_BLOCK_SIZE - 1;
+      do {
+        output[i] ^= input[i];
+        i--;
+      } while (i >= 0);
+      return;
     }
 
-    if (carry) {
-	output[AES_BLOCK_SIZE-1] ^= Rb;
-    }
-    return;
+    /*
+     * times_two()
+     *	compute the product of 2 and "input" as a polynomial multiplication
+     *	modulo the prime polynomial x^128 + x^7 + x^2 + x + 1
+     */
+    static void times_two(unsigned char *output, unsigned char *input) {
+  int i;
+  unsigned char *out = output, *in = input;
+  unsigned char carry = 0;
+
+  out = output + AES_BLOCK_SIZE - 1;
+  in = input + AES_BLOCK_SIZE - 1;
+  for (i = 0; i < AES_BLOCK_SIZE; i++) {
+    *(out--) = (*in << 1) | carry;
+    carry = (*(in--) & 0x80) ? 1 : 0;
+  }
+
+  if (carry) {
+    output[AES_BLOCK_SIZE - 1] ^= Rb;
+  }
+  return;
 }
 
 /*
  * pad()
  *	add 10^* onto a buffer to pad it out to AES_BLOCK_SIZE len
  */
-static void
-pad (unsigned char *buf, int len)
-{
-    int i;
+static void pad(unsigned char *buf, int len) {
+  int i;
 
-    i = len;
-    buf[i++] = 0x80;
-    if (i < AES_BLOCK_SIZE) {
-	memset(buf + i, 0, AES_BLOCK_SIZE - i);
-    }
+  i = len;
+  buf[i++] = 0x80;
+  if (i < AES_BLOCK_SIZE) {
+    memset(buf + i, 0, AES_BLOCK_SIZE - i);
+  }
 }
 
 /*
  * aes_cmac()
  *	CMAC mode of AES per NIST SP 800-38B
  */
-void
-aes_cmac (siv_ctx *ctx, const unsigned char *msg, int mlen, unsigned char *C)
-{
-    int n, i, slop;
-    unsigned char Mn[AES_BLOCK_SIZE], *ptr;
+void aes_cmac(
+    siv_ctx *ctx,
+    const unsigned char *msg,
+    int mlen,
+    unsigned char *C) {
+  int n, i, slop;
+  unsigned char Mn[AES_BLOCK_SIZE], *ptr;
 
-    memcpy(C, zero, AES_BLOCK_SIZE);
+  memcpy(C, zero, AES_BLOCK_SIZE);
 
-    /*
-     * n is the number of block-length blocks
-     */
-    n = (mlen+(AES_BLOCK_SIZE-1))/AES_BLOCK_SIZE;
+  /*
+   * n is the number of block-length blocks
+   */
+  n = (mlen + (AES_BLOCK_SIZE - 1)) / AES_BLOCK_SIZE;
 
-    /*
-     * CBC mode for first n-1 blocks
-     */
-    ptr = (unsigned char *)msg;
-    for (i = 0; i < (n-1); i++) {
-	xor(C, ptr);
-	AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
-	ptr += AES_BLOCK_SIZE;
-    }
-
-    /*
-     * if last block is whole then (M ^ K1)
-     * else (M || 10* ^ K2)
-     */
-    memset(Mn, 0, AES_BLOCK_SIZE);
-    if ((slop = (mlen % AES_BLOCK_SIZE)) != 0) {
-	memcpy(Mn, ptr, slop);
-	pad(Mn, slop);
-	xor(Mn, ctx->K2);
-    } else {
-	if (msg != NULL && mlen != 0) {
-	    memcpy(Mn, ptr, AES_BLOCK_SIZE);
-	    xor(Mn, ctx->K1);
-	} else {
-	    pad(Mn, 0);
-	    xor(Mn, ctx->K2);
-	}
-    }
-    /*
-     * and do CBC with that xor'd and possibly padded block
-     */
-    xor(C, Mn);
+  /*
+   * CBC mode for first n-1 blocks
+   */
+  ptr = (unsigned char *)msg;
+  for (i = 0; i < (n - 1); i++) {
+    xor(C, ptr);
     AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
-    return;
+    ptr += AES_BLOCK_SIZE;
+  }
+
+  /*
+   * if last block is whole then (M ^ K1)
+   * else (M || 10* ^ K2)
+   */
+  memset(Mn, 0, AES_BLOCK_SIZE);
+  if ((slop = (mlen % AES_BLOCK_SIZE)) != 0) {
+    memcpy(Mn, ptr, slop);
+    pad(Mn, slop);
+    xor(Mn, ctx->K2);
+  } else {
+    if (msg != NULL && mlen != 0) {
+      memcpy(Mn, ptr, AES_BLOCK_SIZE);
+      xor(Mn, ctx->K1);
+    } else {
+      pad(Mn, 0);
+      xor(Mn, ctx->K2);
+    }
+  }
+  /*
+   * and do CBC with that xor'd and possibly padded block
+   */
+  xor(C, Mn);
+  AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
+  return;
 }
 
 /*
  * s2v_final()
  *	input the last chunk into the s2v, output the digest
  */
-int
-s2v_final (siv_ctx *ctx, const unsigned char *X, int xlen, unsigned char *digest)
-{
-    unsigned char T[AES_BLOCK_SIZE], C[AES_BLOCK_SIZE];
-    unsigned char padX[AES_BLOCK_SIZE], *ptr;
-    int blocks, i, slop;
+int s2v_final(
+    siv_ctx *ctx,
+    const unsigned char *X,
+    int xlen,
+    unsigned char *digest) {
+  unsigned char T[AES_BLOCK_SIZE], C[AES_BLOCK_SIZE];
+  unsigned char padX[AES_BLOCK_SIZE], *ptr;
+  int blocks, i, slop;
 
-    if (xlen < AES_BLOCK_SIZE) {
-	/*
-	 * if it's less than the block size of the sPRF then
-	 * do another x2 of our running total and pad the
-	 * input before the final xor and sPRF.
-	 */
-	memcpy(padX, X, xlen);
-	pad(padX, xlen);
+  if (xlen < AES_BLOCK_SIZE) {
+    /*
+     * if it's less than the block size of the sPRF then
+     * do another x2 of our running total and pad the
+     * input before the final xor and sPRF.
+     */
+    memcpy(padX, X, xlen);
+    pad(padX, xlen);
 
-	times_two(T, ctx->T);
-	xor(T, padX);
-	aes_cmac(ctx, T, AES_BLOCK_SIZE, digest);
+    times_two(T, ctx->T);
+    xor(T, padX);
+    aes_cmac(ctx, T, AES_BLOCK_SIZE, digest);
+  } else {
+    if (xlen == AES_BLOCK_SIZE) {
+      /*
+       * the final buffer is exactly the block size
+       */
+      memcpy(T, X, AES_BLOCK_SIZE);
+      xor(T, ctx->T);
+      aes_cmac(ctx, T, AES_BLOCK_SIZE, digest);
     } else {
-        if (xlen == AES_BLOCK_SIZE) {
-            /*
-             * the final buffer is exactly the block size
-             */
-            memcpy(T, X, AES_BLOCK_SIZE);
-            xor(T, ctx->T);
-            aes_cmac(ctx, T, AES_BLOCK_SIZE, digest);
-        } else {
-            /*
-             * -1 because the last 2 blocks get special treatment
-             * and there's another -1 in the for loop below where
-             * we AES-CMAC the buffer.
-             */
-            blocks = (xlen+(AES_BLOCK_SIZE-1))/AES_BLOCK_SIZE - 1;
-            ptr = (unsigned char *)X;
-            memcpy(C, zero, AES_BLOCK_SIZE);
-            if (blocks > 1) {
-                /*
-                 * do AES-CMAC on all the buffers up to the last 2 blocks
-                 */
-                for (i = 0; i < (blocks-1); i++) {
-                    xor(C, ptr);
-                    AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
-                    ptr += AES_BLOCK_SIZE;
-                }
-            }
-            memcpy(T, ptr, AES_BLOCK_SIZE);
-            slop = xlen % AES_BLOCK_SIZE;
-            if (slop) {
-                /*
-                 * if there's slop then do the xor-end onto this block
-                 */
-                for (i = 0; i < AES_BLOCK_SIZE - slop; i++) {
-                    T[i + slop] ^= ctx->T[i];
-                }
-                /*
-                 * continue with AES-CMAC on this partially xor'd buffer
-                 */
-                xor(C, T);
-                AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
-                ptr += AES_BLOCK_SIZE;
-                /*
-                 * now the final block is small so xor the end then pad and xor
-                 */
-                memset(T, 0, AES_BLOCK_SIZE);
-                memcpy(T, ptr, slop);
-                for (i = 0; i < slop; i++) {
-                    T[i] ^= ctx->T[(AES_BLOCK_SIZE-slop)+i];
-                }
-                pad(T, slop);
-                xor(T, ctx->K2);
-            } else {
-                /*
-                 * otherwise there's no slop so just AES-CMAC the next whole block
-                 */
-                xor(C, ptr);
-                AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
-                ptr += AES_BLOCK_SIZE;
-                /*
-                 * xor-end the entire last block...
-                 */
-                memcpy(T, ptr, AES_BLOCK_SIZE);
-                xor(T, ctx->T);
-                /*
-                 * and treat it as the last (whole) block in AES-CMAC
-                 */
-                xor(T, ctx->K1);
-            }
-            /*
-             * a final CBC finishes AES-CMAC
-             */
-            xor(C, T);
-            AES_ecb_encrypt(C, digest, &ctx->s2v_sched, AES_ENCRYPT);
+      /*
+       * -1 because the last 2 blocks get special treatment
+       * and there's another -1 in the for loop below where
+       * we AES-CMAC the buffer.
+       */
+      blocks = (xlen + (AES_BLOCK_SIZE - 1)) / AES_BLOCK_SIZE - 1;
+      ptr = (unsigned char *)X;
+      memcpy(C, zero, AES_BLOCK_SIZE);
+      if (blocks > 1) {
+        /*
+         * do AES-CMAC on all the buffers up to the last 2 blocks
+         */
+        for (i = 0; i < (blocks - 1); i++) {
+          xor(C, ptr);
+          AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
+          ptr += AES_BLOCK_SIZE;
         }
-
+      }
+      memcpy(T, ptr, AES_BLOCK_SIZE);
+      slop = xlen % AES_BLOCK_SIZE;
+      if (slop) {
+        /*
+         * if there's slop then do the xor-end onto this block
+         */
+        for (i = 0; i < AES_BLOCK_SIZE - slop; i++) {
+          T[i + slop] ^= ctx->T[i];
+        }
+        /*
+         * continue with AES-CMAC on this partially xor'd buffer
+         */
+        xor(C, T);
+        AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
+        ptr += AES_BLOCK_SIZE;
+        /*
+         * now the final block is small so xor the end then pad and xor
+         */
+        memset(T, 0, AES_BLOCK_SIZE);
+        memcpy(T, ptr, slop);
+        for (i = 0; i < slop; i++) {
+          T[i] ^= ctx->T[(AES_BLOCK_SIZE - slop) + i];
+        }
+        pad(T, slop);
+        xor(T, ctx->K2);
+      } else {
+        /*
+         * otherwise there's no slop so just AES-CMAC the next whole block
+         */
+        xor(C, ptr);
+        AES_ecb_encrypt(C, C, &ctx->s2v_sched, AES_ENCRYPT);
+        ptr += AES_BLOCK_SIZE;
+        /*
+         * xor-end the entire last block...
+         */
+        memcpy(T, ptr, AES_BLOCK_SIZE);
+        xor(T, ctx->T);
+        /*
+         * and treat it as the last (whole) block in AES-CMAC
+         */
+        xor(T, ctx->K1);
+      }
+      /*
+       * a final CBC finishes AES-CMAC
+       */
+      xor(C, T);
+      AES_ecb_encrypt(C, digest, &ctx->s2v_sched, AES_ENCRYPT);
     }
-    return 0;
+  }
+  return 0;
 }
 
 /*
  * s2v_add()
  *	add an sPRF'd string to s2v
  */
-void
-s2v_add (siv_ctx *ctx, const unsigned char *Y)
-{
-    unsigned char T[AES_BLOCK_SIZE];
+void s2v_add(siv_ctx *ctx, const unsigned char *Y) {
+  unsigned char T[AES_BLOCK_SIZE];
 
-    memcpy(T, ctx->T, AES_BLOCK_SIZE);
-    times_two(ctx->T, T);
-    xor(ctx->T, Y);
+  memcpy(T, ctx->T, AES_BLOCK_SIZE);
+  times_two(ctx->T, T);
+  xor(ctx->T, Y);
 }
 
 /*
  * s2v_update()
  *	add a raw string to the s2v
  */
-void
-s2v_update (siv_ctx *ctx, const unsigned char *X, int xlen)
-{
-    unsigned char Y[AES_BLOCK_SIZE];
+void s2v_update(siv_ctx *ctx, const unsigned char *X, int xlen) {
+  unsigned char Y[AES_BLOCK_SIZE];
 
-    aes_cmac(ctx, X, xlen, Y);
-    s2v_add(ctx, Y);
+  aes_cmac(ctx, X, xlen, Y);
+  s2v_add(ctx, Y);
 }
 
 /*
  * siv_init()
  *	initiate an siv context
  */
-int
-siv_init (siv_ctx *ctx, const unsigned char *key, int keylen)
-{
-    unsigned char L[AES_BLOCK_SIZE];
+int siv_init(siv_ctx *ctx, const unsigned char *key, int keylen) {
+  unsigned char L[AES_BLOCK_SIZE];
 
-    memset((char *)ctx, 0, sizeof(siv_ctx));
-    switch (keylen) {
-        case SIV_512:   /* a pair of 256 bit keys */
-            AES_set_encrypt_key(key, 256, &ctx->s2v_sched);
-            AES_set_encrypt_key(key+AES_256_BYTES, 256, &ctx->ctr_sched);
-            break;
-        case SIV_384:   /* a pair of 192 bit keys */
-            AES_set_encrypt_key(key, 192, &ctx->s2v_sched);
-            AES_set_encrypt_key(key+AES_192_BYTES, 192, &ctx->ctr_sched);
-            break;
-        case SIV_256:   /* a pair of 128 bit keys */
-            AES_set_encrypt_key(key, 128, &ctx->s2v_sched);
-            AES_set_encrypt_key(key+AES_128_BYTES, 128, &ctx->ctr_sched);
-            break;
-        default:
-            return -1;
-    }
+  memset((char *)ctx, 0, sizeof(siv_ctx));
+  switch (keylen) {
+    case SIV_512: /* a pair of 256 bit keys */
+      AES_set_encrypt_key(key, 256, &ctx->s2v_sched);
+      AES_set_encrypt_key(key + AES_256_BYTES, 256, &ctx->ctr_sched);
+      break;
+    case SIV_384: /* a pair of 192 bit keys */
+      AES_set_encrypt_key(key, 192, &ctx->s2v_sched);
+      AES_set_encrypt_key(key + AES_192_BYTES, 192, &ctx->ctr_sched);
+      break;
+    case SIV_256: /* a pair of 128 bit keys */
+      AES_set_encrypt_key(key, 128, &ctx->s2v_sched);
+      AES_set_encrypt_key(key + AES_128_BYTES, 128, &ctx->ctr_sched);
+      break;
+    default:
+      return -1;
+  }
 
-    /*
-     * compute CMAC subkeys
-     */
-    AES_ecb_encrypt(zero, L, &ctx->s2v_sched, AES_ENCRYPT);
-    times_two(ctx->K1, L);
-    times_two(ctx->K2, ctx->K1);
+  /*
+   * compute CMAC subkeys
+   */
+  AES_ecb_encrypt(zero, L, &ctx->s2v_sched, AES_ENCRYPT);
+  times_two(ctx->K1, L);
+  times_two(ctx->K2, ctx->K1);
 
-    memset(ctx->benchmark, 0, AES_BLOCK_SIZE);
-    aes_cmac(ctx, zero, AES_BLOCK_SIZE, ctx->T);
-    return 1;
+  memset(ctx->benchmark, 0, AES_BLOCK_SIZE);
+  aes_cmac(ctx, zero, AES_BLOCK_SIZE, ctx->T);
+  return 1;
 }
 
 /*
@@ -346,92 +350,88 @@ siv_init (siv_ctx *ctx, const unsigned char *key, int keylen)
  *	restart a siv context, same as siv_init but leaves the
  *	keying material alone
  */
-void
-siv_restart (siv_ctx *ctx)
-{
-    memset(ctx->benchmark, 0, AES_BLOCK_SIZE);
-    memset(ctx->T, 0, AES_BLOCK_SIZE);
-    aes_cmac(ctx, zero, AES_BLOCK_SIZE, ctx->T);
+void siv_restart(siv_ctx *ctx) {
+  memset(ctx->benchmark, 0, AES_BLOCK_SIZE);
+  memset(ctx->T, 0, AES_BLOCK_SIZE);
+  aes_cmac(ctx, zero, AES_BLOCK_SIZE, ctx->T);
 }
 
 /*
  * s2v_benchmark()
  *	save intermediate T state for optimization
  */
-void
-s2v_benchmark (siv_ctx *ctx)
-{
-    memcpy(ctx->benchmark, ctx->T, AES_BLOCK_SIZE);
+void s2v_benchmark(siv_ctx *ctx) {
+  memcpy(ctx->benchmark, ctx->T, AES_BLOCK_SIZE);
 }
 
 /*
  * s2v_reset()
  *	copy the benchmarked state back to T
  */
-void
-s2v_reset (siv_ctx *ctx)
-{
-    memcpy(ctx->T, ctx->benchmark, AES_BLOCK_SIZE);
+void s2v_reset(siv_ctx *ctx) {
+  memcpy(ctx->T, ctx->benchmark, AES_BLOCK_SIZE);
 }
 
 /*
  * vPRF()
  */
-void
-vprf (siv_ctx *ctx, unsigned char *outp, const int nad, ...)
-{
-    va_list ap;
-    unsigned char *ad;
-    int adlen, numad = nad;
+void vprf(siv_ctx *ctx, unsigned char *outp, const int nad, ...) {
+  va_list ap;
+  unsigned char *ad;
+  int adlen, numad = nad;
 
-    if (numad) {
-        siv_restart(ctx);
-        va_start(ap, nad);
-        while (numad > 1) {
-            ad = (unsigned char *) va_arg(ap, char *);
-            adlen = va_arg(ap, int);
-            s2v_update(ctx, ad, adlen);
-            numad--;
-        }
-        ad = (unsigned char *) va_arg(ap, char *);
-        adlen = va_arg(ap, int);
-        s2v_final(ctx, ad, adlen, outp);
+  if (numad) {
+    siv_restart(ctx);
+    va_start(ap, nad);
+    while (numad > 1) {
+      ad = (unsigned char *)va_arg(ap, char *);
+      adlen = va_arg(ap, int);
+      s2v_update(ctx, ad, adlen);
+      numad--;
     }
+    ad = (unsigned char *)va_arg(ap, char *);
+    adlen = va_arg(ap, int);
+    s2v_final(ctx, ad, adlen, outp);
+  }
 }
 
 /*
  * siv_aes_ctr()
  *      aes in CTR mode for SIV
  */
-void
-siv_aes_ctr (siv_ctx *ctx, const unsigned char *p, const int lenp,
-             unsigned char *c, const unsigned char *iv)
-{
-    int i, j;
-    unsigned char ctr[AES_BLOCK_SIZE], ecr[AES_BLOCK_SIZE];
-    unsigned long inc;
+void siv_aes_ctr(
+    siv_ctx *ctx,
+    const unsigned char *p,
+    const int lenp,
+    unsigned char *c,
+    const unsigned char *iv) {
+  int i, j;
+  unsigned char ctr[AES_BLOCK_SIZE], ecr[AES_BLOCK_SIZE];
+  unsigned long inc;
 
-    memcpy(ctr, iv, AES_BLOCK_SIZE);
-    /*
-     * zero out the high order bits of the last two 32-bit words.
-     * This allows ctr mode to be implemented mod sizeof(ulong)
-     * or sizeof(longlong).
-     *
-     * we're just doing addition modulo 2^32 though....
-     */
-    ctr[12] &= 0x7f; ctr[8] &= 0x7f;
-    inc = GETU32(ctr + 12);
-    for (i = 0; i < lenp; i+=AES_BLOCK_SIZE) {
-        AES_ecb_encrypt(ctr, ecr, &ctx->ctr_sched, AES_ENCRYPT);
-        for (j = 0; j < AES_BLOCK_SIZE; j++) {
-            if ((i + j) == lenp) {
-                return;
-            }
-            c[i+j] = p[i+j] ^ ecr[j];
-        }
-        inc++; inc &= 0xffffffff;
-        PUTU32(ctr + 12, inc);
+  memcpy(ctr, iv, AES_BLOCK_SIZE);
+  /*
+   * zero out the high order bits of the last two 32-bit words.
+   * This allows ctr mode to be implemented mod sizeof(ulong)
+   * or sizeof(longlong).
+   *
+   * we're just doing addition modulo 2^32 though....
+   */
+  ctr[12] &= 0x7f;
+  ctr[8] &= 0x7f;
+  inc = GETU32(ctr + 12);
+  for (i = 0; i < lenp; i += AES_BLOCK_SIZE) {
+    AES_ecb_encrypt(ctr, ecr, &ctx->ctr_sched, AES_ENCRYPT);
+    for (j = 0; j < AES_BLOCK_SIZE; j++) {
+      if ((i + j) == lenp) {
+        return;
+      }
+      c[i + j] = p[i + j] ^ ecr[j];
     }
+    inc++;
+    inc &= 0xffffffff;
+    PUTU32(ctr + 12, inc);
+  }
 }
 
 /*
@@ -442,35 +442,38 @@ siv_aes_ctr (siv_ctx *ctx, const unsigned char *p, const int lenp,
  *      char pointing to a buffer of data and an integer length
  *      representing the length in bytes of that data.
  */
-int
-siv_encrypt (siv_ctx *ctx, const unsigned char *p, unsigned char *c,
-             const int len, unsigned char *counter,
-             const int nad, ...)
-{
-    va_list ap;
-    unsigned char *ad;
-    int adlen, numad = nad;
-    unsigned char ctr[AES_BLOCK_SIZE];
+int siv_encrypt(
+    siv_ctx *ctx,
+    const unsigned char *p,
+    unsigned char *c,
+    const int len,
+    unsigned char *counter,
+    const int nad,
+    ...) {
+  va_list ap;
+  unsigned char *ad;
+  int adlen, numad = nad;
+  unsigned char ctr[AES_BLOCK_SIZE];
 
-    if (numad) {
-        va_start(ap, nad);
-        while (numad) {
-            ad = (unsigned char *) va_arg(ap, char *);
-            adlen = va_arg(ap, int);
-            s2v_update(ctx, ad, adlen);
-            numad--;
-        }
+  if (numad) {
+    va_start(ap, nad);
+    while (numad) {
+      ad = (unsigned char *)va_arg(ap, char *);
+      adlen = va_arg(ap, int);
+      s2v_update(ctx, ad, adlen);
+      numad--;
     }
-    s2v_final(ctx, p, len, ctr);
-    memcpy(counter, ctr, AES_BLOCK_SIZE);
-    siv_aes_ctr(ctx, p, len, c, ctr);
-    /*
-     * the only part of the context that is carried along with
-     * subsequent calls to siv_encrypt() are the keys, so reset
-     * everything else.
-     */
-    siv_restart(ctx);
-    return 1;
+  }
+  s2v_final(ctx, p, len, ctr);
+  memcpy(counter, ctr, AES_BLOCK_SIZE);
+  siv_aes_ctr(ctx, p, len, c, ctr);
+  /*
+   * the only part of the context that is carried along with
+   * subsequent calls to siv_encrypt() are the keys, so reset
+   * everything else.
+   */
+  siv_restart(ctx);
+  return 1;
 }
 
 /*
@@ -481,39 +484,42 @@ siv_encrypt (siv_ctx *ctx, const unsigned char *p, unsigned char *c,
  *      char pointing to a buffer of data and an integer length
  *      representing the length in bytes of that data.
  */
-int
-siv_decrypt (siv_ctx *ctx, const unsigned char *c, unsigned char *p,
-             const int len, unsigned char *counter,
-             const int nad, ...)
-{
-    va_list ap;
-    unsigned char *ad;
-    int adlen, numad = nad;
-    unsigned char ctr[AES_BLOCK_SIZE];
+int siv_decrypt(
+    siv_ctx *ctx,
+    const unsigned char *c,
+    unsigned char *p,
+    const int len,
+    unsigned char *counter,
+    const int nad,
+    ...) {
+  va_list ap;
+  unsigned char *ad;
+  int adlen, numad = nad;
+  unsigned char ctr[AES_BLOCK_SIZE];
 
-    memcpy(ctr, counter, AES_BLOCK_SIZE);
-    siv_aes_ctr(ctx, c, len, p, ctr);
-    if (numad) {
-        va_start(ap, nad);
-        while (numad) {
-            ad = (unsigned char *) va_arg(ap, char *);
-            adlen = va_arg(ap, int);
-            s2v_update(ctx, ad, adlen);
-            numad--;
-        }
+  memcpy(ctr, counter, AES_BLOCK_SIZE);
+  siv_aes_ctr(ctx, c, len, p, ctr);
+  if (numad) {
+    va_start(ap, nad);
+    while (numad) {
+      ad = (unsigned char *)va_arg(ap, char *);
+      adlen = va_arg(ap, int);
+      s2v_update(ctx, ad, adlen);
+      numad--;
     }
-    s2v_final(ctx, p, len, ctr);
+  }
+  s2v_final(ctx, p, len, ctr);
 
-    /*
-     * the only part of the context that is carried along with
-     * subsequent calls to siv_decrypt() are the keys, so reset
-     * everything else.
-     */
-    siv_restart(ctx);
-    if (memcmp(ctr, counter, AES_BLOCK_SIZE)) {
-        memset(p, 0, len);
-        return -1;      /* FAIL */
-    } else {
-        return 1;
-    }
+  /*
+   * the only part of the context that is carried along with
+   * subsequent calls to siv_decrypt() are the keys, so reset
+   * everything else.
+   */
+  siv_restart(ctx);
+  if (memcmp(ctr, counter, AES_BLOCK_SIZE)) {
+    memset(p, 0, len);
+    return -1; /* FAIL */
+  } else {
+    return 1;
+  }
 }

--- a/crypto/siv.h
+++ b/crypto/siv.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) The Industrial Lounge, 2007
  *
- *  Copyright holder grants permission for redistribution and use in source 
- *  and binary forms, with or without modification, provided that the 
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
  *  following conditions are met:
  *     1. Redistribution of source code must retain the above copyright
  *        notice, this list of conditions, and the following disclaimer
@@ -18,13 +18,13 @@
  *         Dan Harkins (dharkins at lounge dot org)"
  *
  *  "DISCLAIMER OF LIABILITY
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE INDUSTRIAL LOUNGE ``AS IS'' 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE INDUSTRIAL LOUNGE ``AS IS''
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
  *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
  *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
@@ -40,39 +40,55 @@
 
 #include <openssl/aes.h>
 
-#define AES_128_BYTES	16
-#define AES_192_BYTES	24
-#define AES_256_BYTES	32
-#define SIV_256         256
-#define SIV_384         384
-#define SIV_512         512
+#define AES_128_BYTES 16
+#define AES_192_BYTES 24
+#define AES_256_BYTES 32
+#define SIV_256 256
+#define SIV_384 384
+#define SIV_512 512
 
 typedef struct _siv_ctx {
-    unsigned char K1[AES_BLOCK_SIZE];
-    unsigned char K2[AES_BLOCK_SIZE];
-    unsigned char T[AES_BLOCK_SIZE];
-    unsigned char benchmark[AES_BLOCK_SIZE];
-    AES_KEY ctr_sched;
-    AES_KEY s2v_sched;
+  unsigned char K1[AES_BLOCK_SIZE];
+  unsigned char K2[AES_BLOCK_SIZE];
+  unsigned char T[AES_BLOCK_SIZE];
+  unsigned char benchmark[AES_BLOCK_SIZE];
+  AES_KEY ctr_sched;
+  AES_KEY s2v_sched;
 } siv_ctx;
 
 /*
  * exported APIs
  */
-void aes_cmac (siv_ctx *, const unsigned char *, int, unsigned char *);
+void aes_cmac(siv_ctx *, const unsigned char *, int, unsigned char *);
 int siv_init(siv_ctx *, const unsigned char *, int);
 void s2v_reset(siv_ctx *);
 void s2v_benchmark(siv_ctx *);
 void s2v_add(siv_ctx *, const unsigned char *);
 void s2v_update(siv_ctx *, const unsigned char *, int);
 int s2v_final(siv_ctx *, const unsigned char *, int, unsigned char *);
-void vprf(siv_ctx *, unsigned char *, const int, ... );
+void vprf(siv_ctx *, unsigned char *, const int, ...);
 void siv_restart(siv_ctx *);
-void siv_aes_ctr(siv_ctx *, const unsigned char *, const int, unsigned char *, 
-                 const unsigned char *);
-int siv_encrypt(siv_ctx *, const unsigned char *, unsigned char *, 
-                const int, unsigned char *, const int, ... );
-int siv_decrypt(siv_ctx *, const unsigned char *, unsigned char *,
-                const int, unsigned char *, const int, ... );
+void siv_aes_ctr(
+    siv_ctx *,
+    const unsigned char *,
+    const int,
+    unsigned char *,
+    const unsigned char *);
+int siv_encrypt(
+    siv_ctx *,
+    const unsigned char *,
+    unsigned char *,
+    const int,
+    unsigned char *,
+    const int,
+    ...);
+int siv_decrypt(
+    siv_ctx *,
+    const unsigned char *,
+    unsigned char *,
+    const int,
+    unsigned char *,
+    const int,
+    ...);
 
 #endif /* _SAE_SIV_H_ */

--- a/evl_ops.h
+++ b/evl_ops.h
@@ -1,9 +1,9 @@
 #ifndef _EVL_OPS_H_
 #define _EVL_OPS_H_
 
-#define SRV_SEC(x)	((x) * 1000000ULL)
-#define SRV_MSEC(x)	((x) * 1000ULL)
-#define SRV_USEC(x)	x
+#define SRV_SEC(x) ((x)*1000000ULL)
+#define SRV_MSEC(x) ((x)*1000ULL)
+#define SRV_USEC(x) x
 
 typedef unsigned long long timerid;
 
@@ -18,11 +18,14 @@ typedef void (*fdcb)(int fd, void *data);
 typedef void (*timercb)(void *data);
 
 struct evl_ops {
-    timerid (*add_timeout_with_jitter)(microseconds usec, timercb proc,
-                                       void *data, microseconds jitter_usecs);
-    timerid (*add_timeout)(microseconds usec, timercb proc, void *data);
-    int (*rem_timeout)(timerid);
-    int (*add_input)(int, void *, fdcb);
-    void (*rem_input)(int);
+  timerid (*add_timeout_with_jitter)(
+      microseconds usec,
+      timercb proc,
+      void *data,
+      microseconds jitter_usecs);
+  timerid (*add_timeout)(microseconds usec, timercb proc, void *data);
+  int (*rem_timeout)(timerid);
+  int (*add_input)(int, void *, fdcb);
+  void (*rem_input)(int);
 };
 #endif /* _EVL_OPS_H_ */

--- a/freebsd/meshd.c
+++ b/freebsd/meshd.c
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) Dan Harkins, 2008, 2009, 2010
  *
- *  Copyright holder grants permission for redistribution and use in source 
- *  and binary forms, with or without modification, provided that the 
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
  *  following conditions are met:
  *     1. Redistribution of source code must retain the above copyright
  *        notice, this list of conditions, and the following disclaimer
@@ -18,13 +18,13 @@
  *         Dan Harkins (dharkins at lounge dot org)"
  *
  *  "DISCLAIMER OF LIABILITY
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
  *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
  *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
@@ -36,36 +36,36 @@
  * license (including the GNU public license).
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <string.h>
 #include <errno.h>
-#include <signal.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <sys/sysctl.h>
-#include <sys/queue.h>
-#include <netinet/in.h>
+#include <fcntl.h>
+#include <net/bpf.h>
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/if_media.h>
-#include <net/bpf.h>
 #include <net/route.h>
 #include <net80211/ieee80211.h>
-#include <net80211/ieee80211_ioctl.h>
 #include <net80211/ieee80211_freebsd.h>
+#include <net80211/ieee80211_ioctl.h>
+#include <netinet/in.h>
 #include <openssl/rand.h>
-#include "service.h"
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <unistd.h>
 #include "common.h"
 #include "sae.h"
+#include "service.h"
 
 struct interface {
-    TAILQ_ENTRY(interface) entry;
-    unsigned char ifname[IFNAMSIZ];
-    unsigned char bssid[ETH_ALEN];
-    unsigned char is_loopback;
-    int fd;     /* BPF socket */
+  TAILQ_ENTRY(interface) entry;
+  unsigned char ifname[IFNAMSIZ];
+  unsigned char bssid[ETH_ALEN];
+  unsigned char is_loopback;
+  int fd; /* BPF socket */
 };
 TAILQ_HEAD(bar, interface) interfaces;
 
@@ -73,202 +73,209 @@ service_context srvctx;
 unsigned char mesh_ssid[33];
 static int debug = 0, passive = 0, beacon = 5;
 
-static void
-dump_ssid (struct ieee80211_mgmt_frame *frame, int len)
-{
-    char el_id, el_len, ssid[33];
-    unsigned char *ptr;
-    int left;
+static void dump_ssid(struct ieee80211_mgmt_frame *frame, int len) {
+  char el_id, el_len, ssid[33];
+  unsigned char *ptr;
+  int left;
 
-    ptr = frame->beacon.variable;
-    left = len - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
-    while (left > 2) {
-        el_id = *ptr++;
-        left--;
-        el_len = *ptr++;
-        left--;
-        if (el_len > left) {
-            return;
-        }
-        if (el_id == IEEE802_11_IE_SSID) {
-            if (el_len > 32) {
-                return;
-            }
-            memset(ssid, 0, sizeof(ssid));
-            memcpy(ssid, ptr, el_len);
-            break;
-        }
+  ptr = frame->beacon.variable;
+  left = len - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
+  while (left > 2) {
+    el_id = *ptr++;
+    left--;
+    el_len = *ptr++;
+    left--;
+    if (el_len > left) {
+      return;
     }
+    if (el_id == IEEE802_11_IE_SSID) {
+      if (el_len > 32) {
+        return;
+      }
+      memset(ssid, 0, sizeof(ssid));
+      memcpy(ssid, ptr, el_len);
+      break;
+    }
+  }
 }
 
-static void
-bpf_in (int fd, void *data)
-{
-    struct interface *inf = (struct interface *)data;
-    char el_id, el_len, ssid[33];
-    unsigned char buf[2048], *ptr, *els;
-    struct bpf_hdr *hdr;
-    struct ieee80211_mgmt_frame *frame;
-    unsigned short frame_control;
-    int type, stype, len, framesize, left;
+static void bpf_in(int fd, void *data) {
+  struct interface *inf = (struct interface *)data;
+  char el_id, el_len, ssid[33];
+  unsigned char buf[2048], *ptr, *els;
+  struct bpf_hdr *hdr;
+  struct ieee80211_mgmt_frame *frame;
+  unsigned short frame_control;
+  int type, stype, len, framesize, left;
 
-    if ((len = read(fd, buf, sizeof(buf))) < 0) {
-        fprintf(stderr, "can't read off bpf socket!\n");
-        perror("read");
-        return;
+  if ((len = read(fd, buf, sizeof(buf))) < 0) {
+    fprintf(stderr, "can't read off bpf socket!\n");
+    perror("read");
+    return;
+  }
+
+  ptr = buf;
+  while (len > 0) {
+    hdr = (struct bpf_hdr *)ptr;
+    /*
+     * if loopback skip over the BPF's pseudo header.
+     */
+    if (inf->is_loopback) {
+      frame =
+          (struct ieee80211_mgmt_frame
+               *)(ptr + hdr->bh_hdrlen + sizeof(unsigned long));
+      framesize = hdr->bh_datalen - sizeof(unsigned long);
+    } else {
+      frame = (struct ieee80211_mgmt_frame *)(ptr + hdr->bh_hdrlen);
+      framesize = hdr->bh_datalen;
+    }
+    if (framesize > len) {
+      fprintf(
+          stderr,
+          "something is seriously fucked up! read %d, frame is %d\n",
+          len,
+          framesize);
+      return;
     }
 
-    ptr = buf;
-    while (len > 0) {
-        hdr = (struct bpf_hdr *)ptr;
-        /*
-         * if loopback skip over the BPF's pseudo header.
-         */
-        if (inf->is_loopback) {
-            frame = (struct ieee80211_mgmt_frame *)(ptr + hdr->bh_hdrlen + sizeof(unsigned long));
-            framesize = hdr->bh_datalen - sizeof(unsigned long);
-        } else {
-            frame = (struct ieee80211_mgmt_frame *)(ptr + hdr->bh_hdrlen);
-            framesize = hdr->bh_datalen;
-        }
-        if (framesize > len) {
-            fprintf(stderr, "something is seriously fucked up! read %d, frame is %d\n",
-                    len, framesize);
-            return;
-        }
-
-        /*
-         * even though we explicitly state that we don't want to see our
-         * own frames the "multicast" "beacons" we send over loopback
-         * seem to get delivered to us anyway. Drop them.
-         */
-        if (memcmp(frame->sa, inf->bssid, ETH_ALEN) == 0) {
-            /*
-             * there might be another frame...
-             */
-            len -= BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
-            ptr += BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
-            continue;
-        }
-
-        frame_control = ieee_order(frame->frame_control);
-        type = IEEE802_11_FC_GET_TYPE(frame_control);
-        stype = IEEE802_11_FC_GET_STYPE(frame_control);
-        if (debug) {
-            if (stype == IEEE802_11_FC_STYPE_BEACON) {
-                dump_ssid(frame, hdr->bh_datalen);
-            }
-        }
-
-        if (type == IEEE802_11_FC_TYPE_MGMT) {
-            switch (stype) {
-                case IEEE802_11_FC_STYPE_BEACON:
-                    if (passive) {
-                        break;
-                    }
-                    els = frame->beacon.variable;
-                    left = framesize - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
-                    /*
-                     * els is the next IE in the beacon,
-                     * left is how much is left to read in the beacon
-                     */
-                    while (left > 2) {
-                        el_id = *els++; 
-                        left--;
-                        el_len = *els++; 
-                        left--;
-                        if (el_len > left) {
-                            /*
-                             * someone's trying to mess with us...
-                             */
-                            break;
-                        }
-                        if (el_id == IEEE802_11_IE_SSID) { 
-                            if (el_len > 32) {
-                                /*
-                                 * again with the messing...
-                                 */
-                                break;
-                            }
-                            memset(ssid, 0, sizeof(ssid));
-                            memcpy(ssid, els, el_len);
-                            /*
-                             * if it's not an interesting ssid then ignore the beacon
-                             * otherwise send it off to SAE.
-                             */
-                            if ((el_len == 0) || memcmp(ssid, mesh_ssid, strlen(ssid))) {
-                                break;
-                            }
-                            if (process_mgmt_frame(frame, framesize, inf->bssid, true) < 0) {
-                                fprintf(stderr, "error processing beacon for %s from " MACSTR "\n",
-                                        ssid, MAC2STR(frame->sa));
-                            }
-                            break;
-                        }
-                        els += el_len;
-                        left -= el_len;
-                    }
-                    break;
-                case IEEE802_11_FC_STYPE_AUTH:
-                    if (memcmp(frame->da, inf->bssid, ETH_ALEN) == 0) {
-                        if (process_mgmt_frame(frame, framesize, inf->bssid, true) < 0) {
-                            fprintf(stderr, "error processing AUTH frame from " MACSTR "\n",
-                                    MAC2STR(frame->sa));
-                        }
-                    }
-                    break;
-                case IEEE802_11_FC_STYPE_ACTION:
-                    /* APE exchange */
-                    break;
-            }
-        }
-        /*
-         * there might be another frame...
-         */
-        len -= BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
-        ptr += BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+    /*
+     * even though we explicitly state that we don't want to see our
+     * own frames the "multicast" "beacons" we send over loopback
+     * seem to get delivered to us anyway. Drop them.
+     */
+    if (memcmp(frame->sa, inf->bssid, ETH_ALEN) == 0) {
+      /*
+       * there might be another frame...
+       */
+      len -= BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+      ptr += BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+      continue;
     }
+
+    frame_control = ieee_order(frame->frame_control);
+    type = IEEE802_11_FC_GET_TYPE(frame_control);
+    stype = IEEE802_11_FC_GET_STYPE(frame_control);
+    if (debug) {
+      if (stype == IEEE802_11_FC_STYPE_BEACON) {
+        dump_ssid(frame, hdr->bh_datalen);
+      }
+    }
+
+    if (type == IEEE802_11_FC_TYPE_MGMT) {
+      switch (stype) {
+        case IEEE802_11_FC_STYPE_BEACON:
+          if (passive) {
+            break;
+          }
+          els = frame->beacon.variable;
+          left = framesize - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
+          /*
+           * els is the next IE in the beacon,
+           * left is how much is left to read in the beacon
+           */
+          while (left > 2) {
+            el_id = *els++;
+            left--;
+            el_len = *els++;
+            left--;
+            if (el_len > left) {
+              /*
+               * someone's trying to mess with us...
+               */
+              break;
+            }
+            if (el_id == IEEE802_11_IE_SSID) {
+              if (el_len > 32) {
+                /*
+                 * again with the messing...
+                 */
+                break;
+              }
+              memset(ssid, 0, sizeof(ssid));
+              memcpy(ssid, els, el_len);
+              /*
+               * if it's not an interesting ssid then ignore the beacon
+               * otherwise send it off to SAE.
+               */
+              if ((el_len == 0) || memcmp(ssid, mesh_ssid, strlen(ssid))) {
+                break;
+              }
+              if (process_mgmt_frame(frame, framesize, inf->bssid, true) < 0) {
+                fprintf(
+                    stderr,
+                    "error processing beacon for %s from " MACSTR "\n",
+                    ssid,
+                    MAC2STR(frame->sa));
+              }
+              break;
+            }
+            els += el_len;
+            left -= el_len;
+          }
+          break;
+        case IEEE802_11_FC_STYPE_AUTH:
+          if (memcmp(frame->da, inf->bssid, ETH_ALEN) == 0) {
+            if (process_mgmt_frame(frame, framesize, inf->bssid, true) < 0) {
+              fprintf(
+                  stderr,
+                  "error processing AUTH frame from " MACSTR "\n",
+                  MAC2STR(frame->sa));
+            }
+          }
+          break;
+        case IEEE802_11_FC_STYPE_ACTION:
+          /* APE exchange */
+          break;
+      }
+    }
+    /*
+     * there might be another frame...
+     */
+    len -= BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+    ptr += BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+  }
 }
 
 /*
  * service provided to sae: sending of management frames over-the-air
  */
-int meshd_write_mgmt (char *data, int len)
-{
-    char buf[2048];
-    struct interface *inf = NULL;
-    struct ieee80211_mgmt_frame *frame = (struct ieee80211_mgmt_frame *)data;
-    unsigned long af;
+int meshd_write_mgmt(char *data, int len) {
+  char buf[2048];
+  struct interface *inf = NULL;
+  struct ieee80211_mgmt_frame *frame = (struct ieee80211_mgmt_frame *)data;
+  unsigned long af;
 
-    TAILQ_FOREACH(inf, &interfaces, entry) {
-        if (memcmp(frame->sa, inf->bssid, ETH_ALEN) == 0) {
-            break;
-        }
+  TAILQ_FOREACH(inf, &interfaces, entry) {
+    if (memcmp(frame->sa, inf->bssid, ETH_ALEN) == 0) {
+      break;
     }
-    if (inf == NULL) {
-        fprintf(stderr, "can't find " MACSTR " to send mgmt frame!\n",
-                MAC2STR(frame->sa));
-        return -1;
+  }
+  if (inf == NULL) {
+    fprintf(
+        stderr,
+        "can't find " MACSTR " to send mgmt frame!\n",
+        MAC2STR(frame->sa));
+    return -1;
+  }
+  if (inf->is_loopback) {
+    /*
+     * add the loopback pseudo-header to indicate the AF
+     */
+    memset(buf, 0, sizeof(buf));
+    af = AF_INET;
+    memcpy(buf, &af, sizeof(unsigned long));
+    memcpy(buf + sizeof(unsigned long), data, len);
+    if (write(inf->fd, buf, len + sizeof(unsigned long)) < 0) {
+      fprintf(stderr, "unable to write management frame!\n");
+      return -1;
     }
-    if (inf->is_loopback) {
-        /*
-         * add the loopback pseudo-header to indicate the AF
-         */
-        memset(buf, 0, sizeof(buf));
-        af = AF_INET;
-        memcpy(buf, &af, sizeof(unsigned long));
-        memcpy(buf + sizeof(unsigned long), data, len);
-        if (write(inf->fd, buf, len + sizeof(unsigned long)) < 0) {
-            fprintf(stderr, "unable to write management frame!\n");
-            return -1;
-        }
-    } else {
-        if (write(inf->fd, data, len) < 0) {
-            fprintf(stderr, "unable to write management frame!\n");
-            return -1;
-        }
+  } else {
+    if (write(inf->fd, data, len) < 0) {
+      fprintf(stderr, "unable to write management frame!\n");
+      return -1;
     }
-    return len;
+  }
+  return len;
 }
 
 /*
@@ -276,157 +283,160 @@ int meshd_write_mgmt (char *data, int len)
  *      sae has finished for the specified MAC address. If the reason
  *      is because it was successful, there will be a key (PMK) to plumb
  */
-void
-fin (unsigned short reason, unsigned char *mac, unsigned char *key, int keylen)
-{
-    printf("status of " MACSTR " is %d, ", MAC2STR(mac), reason);
-    if ((reason == 0) && (key != NULL) && (keylen > 0)) {
-        printf("plumb the %d byte key into the kernel now!\n", keylen);
-    } else {
-        printf("(an error)\n");
-    }
+void fin(
+    unsigned short reason,
+    unsigned char *mac,
+    unsigned char *key,
+    int keylen) {
+  printf("status of " MACSTR " is %d, ", MAC2STR(mac), reason);
+  if ((reason == 0) && (key != NULL) && (keylen > 0)) {
+    printf("plumb the %d byte key into the kernel now!\n", keylen);
+  } else {
+    printf("(an error)\n");
+  }
 }
 
-static void
-add_interface (unsigned char *ptr)
-{
-    struct interface *inf;
-    char bpfdev[sizeof "/dev/bpfXXXXXXXX"];
-    int s, var, bpfnum = 0;
-    struct ifreq ifr;
-    struct bpf_program bpf_filter;
-    struct bpf_insn allofit[] = {
-        /*
-         * a bpf filter to get beacons, authentication and action frames 
-         */
-        BPF_STMT(BPF_LD+BPF_B+BPF_ABS, 0),
-        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0x80, 0, 1),    /* beacon */
-        BPF_STMT(BPF_RET+BPF_K, (unsigned int) -1),
-        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0xb0, 0, 1),    /* auth */
-        BPF_STMT(BPF_RET+BPF_K, (unsigned int) -1),
-        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0xd0, 0, 1),    /* action for APE */
-        BPF_STMT(BPF_RET+BPF_K, (unsigned int) -1),     /* coming soon :-) */
-        BPF_STMT(BPF_RET+BPF_K, 0),
-    };
-    struct bpf_insn sim80211[] = {
-        /*
-         * for loopback interfaces, just grab everything
-         */
-        { 0x6, 0, 0, 0x00000800 },
-    };
+static void add_interface(unsigned char *ptr) {
+  struct interface *inf;
+  char bpfdev[sizeof "/dev/bpfXXXXXXXX"];
+  int s, var, bpfnum = 0;
+  struct ifreq ifr;
+  struct bpf_program bpf_filter;
+  struct bpf_insn allofit[] = {
+      /*
+       * a bpf filter to get beacons, authentication and action frames
+       */
+      BPF_STMT(BPF_LD + BPF_B + BPF_ABS, 0),
+      BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0x80, 0, 1), /* beacon */
+      BPF_STMT(BPF_RET + BPF_K, (unsigned int)-1),
+      BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0xb0, 0, 1), /* auth */
+      BPF_STMT(BPF_RET + BPF_K, (unsigned int)-1),
+      BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0xd0, 0, 1), /* action for APE */
+      BPF_STMT(BPF_RET + BPF_K, (unsigned int)-1), /* coming soon :-) */
+      BPF_STMT(BPF_RET + BPF_K, 0),
+  };
+  struct bpf_insn sim80211[] = {
+      /*
+       * for loopback interfaces, just grab everything
+       */
+      {0x6, 0, 0, 0x00000800},
+  };
 
-    TAILQ_FOREACH(inf, &interfaces, entry) {
-        if (memcmp(&inf->ifname, ptr, strlen(ptr)) == 0) {
-            printf("%s is already on the list!\n", ptr);
-            return;
-        }
+  TAILQ_FOREACH(inf, &interfaces, entry) {
+    if (memcmp(&inf->ifname, ptr, strlen(ptr)) == 0) {
+      printf("%s is already on the list!\n", ptr);
+      return;
     }
-    if ((inf = (struct interface *)malloc(sizeof(struct interface))) == NULL) {
-        fprintf(stderr, "failed to malloc space for new interface %s!\n", ptr);
-        return;
-    }
-    strncpy(inf->ifname, ptr, strlen(ptr));
+  }
+  if ((inf = (struct interface *)malloc(sizeof(struct interface))) == NULL) {
+    fprintf(stderr, "failed to malloc space for new interface %s!\n", ptr);
+    return;
+  }
+  strncpy(inf->ifname, ptr, strlen(ptr));
 
+  /*
+   * see if this is a loopback interface
+   */
+  if ((s = socket(PF_INET, SOCK_RAW, 0)) < 0) {
+    fprintf(stderr, "unable to get raw socket to determine interface flags!\n");
+    free(inf);
+    return;
+  }
+  memset(&ifr, 0, sizeof(ifr));
+  strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
+  if (ioctl(s, SIOCGIFFLAGS, &ifr) < 0) {
+    fprintf(stderr, "unable to get ifflags for %s!\n", ptr);
     /*
-     * see if this is a loopback interface
+     * should this be fatal? Dunno, let's just assume it's _not_ loopback
      */
-    if ((s = socket(PF_INET, SOCK_RAW, 0)) < 0) {
-        fprintf(stderr, "unable to get raw socket to determine interface flags!\n");
-        free(inf);
-        return;
-    }
-    memset(&ifr, 0, sizeof(ifr));
-    strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
-    if (ioctl(s, SIOCGIFFLAGS, &ifr) < 0) {
-        fprintf(stderr, "unable to get ifflags for %s!\n", ptr);
-        /*
-         * should this be fatal? Dunno, let's just assume it's _not_ loopback
-         */
-        ifr.ifr_flags = 0;
-    }
-    close(s);
-    if (ifr.ifr_flags & IFF_LOOPBACK) {
-        inf->is_loopback = 1;
-    }
-    /*
-     * find a non-busy bpf device
-     */
-    do {
-        (void)snprintf(bpfdev, sizeof(bpfdev), "/dev/bpf%d", bpfnum++);
-        inf->fd = open(bpfdev, O_RDWR);
-    } while (inf->fd < 0 && errno == EBUSY);
-    if (inf->fd < 0) {
-        fprintf(stderr, "error opening bpf device %s!\n", bpfdev);
-        perror("open");
-        exit(1);
-    }
+    ifr.ifr_flags = 0;
+  }
+  close(s);
+  if (ifr.ifr_flags & IFF_LOOPBACK) {
+    inf->is_loopback = 1;
+  }
+  /*
+   * find a non-busy bpf device
+   */
+  do {
+    (void)snprintf(bpfdev, sizeof(bpfdev), "/dev/bpf%d", bpfnum++);
+    inf->fd = open(bpfdev, O_RDWR);
+  } while (inf->fd < 0 && errno == EBUSY);
+  if (inf->fd < 0) {
+    fprintf(stderr, "error opening bpf device %s!\n", bpfdev);
+    perror("open");
+    exit(1);
+  }
 
-    var = 2048;
-    if (ioctl(inf->fd, BIOCSBLEN, &var)) {
-        fprintf(stderr, "can't set bpf buffer length!\n");
-        exit(1);
+  var = 2048;
+  if (ioctl(inf->fd, BIOCSBLEN, &var)) {
+    fprintf(stderr, "can't set bpf buffer length!\n");
+    exit(1);
+  }
+  memset(&ifr, 0, sizeof(ifr));
+  strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
+  printf(
+      "setting bpf%d to interface %s, %s\n",
+      bpfnum - 1,
+      ifr.ifr_name,
+      inf->is_loopback ? "loopback" : "not loopback");
+  if (ioctl(inf->fd, BIOCSETIF, &ifr)) {
+    fprintf(stderr, "unable to set bpf!\n");
+    exit(1);
+  }
+  if (ioctl(inf->fd, BIOCPROMISC, &ifr)) {
+    fprintf(stderr, "can't set bpf to be promiscuous!\n");
+    exit(1);
+  }
+  var = 1;
+  if (ioctl(inf->fd, BIOCIMMEDIATE, &var)) {
+    fprintf(stderr, "can't set bpf to be immediate!\n");
+    exit(1);
+  }
+  var = 0;
+  if (ioctl(inf->fd, BIOCSSEESENT, &var)) {
+    fprintf(stderr, "can't tell bpf to ignore our own packets!\n");
+    /* not really fatal, just bothersome */
+  }
+  if (inf->is_loopback) {
+    /*
+     * make up a bssid for the loopback interface
+     */
+    RAND_pseudo_bytes(&inf->bssid[0], ETH_ALEN);
+    var = DLT_NULL;
+    if (ioctl(inf->fd, BIOCSDLT, &var)) {
+      fprintf(stderr, "can't set bpf link layer type!\n");
+      exit(1);
     }
-    memset(&ifr, 0, sizeof(ifr));
-    strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
-    printf("setting bpf%d to interface %s, %s\n", bpfnum-1, ifr.ifr_name,
-           inf->is_loopback ? "loopback" : "not loopback");
-    if (ioctl(inf->fd, BIOCSETIF, &ifr)) {
-        fprintf(stderr, "unable to set bpf!\n");
-        exit(1);
+    bpf_filter.bf_len = sizeof(sim80211) / sizeof(struct bpf_insn);
+    bpf_filter.bf_insns = sim80211;
+    if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
+      fprintf(stderr, "can't set bpf filter!\n");
+      perror("ioctl setting bpf filter");
+      exit(1);
     }
-    if (ioctl(inf->fd, BIOCPROMISC, &ifr)) {
-        fprintf(stderr, "can't set bpf to be promiscuous!\n");
-        exit(1);
+  } else {
+    var = DLT_IEEE802_11;
+    if (ioctl(inf->fd, BIOCSDLT, &var)) {
+      fprintf(stderr, "can't set bpf link layer type!\n");
+      exit(1);
     }
     var = 1;
-    if (ioctl(inf->fd, BIOCIMMEDIATE, &var)) {
-        fprintf(stderr, "can't set bpf to be immediate!\n");
-        exit(1);
+    if (ioctl(inf->fd, BIOCSHDRCMPLT, &var)) {
+      fprintf(stderr, "can't tell bpf we are doing our own headers!\n");
+      exit(1);
     }
-    var = 0;
-    if (ioctl(inf->fd, BIOCSSEESENT, &var)) {
-        fprintf(stderr, "can't tell bpf to ignore our own packets!\n");
-        /* not really fatal, just bothersome */
+    bpf_filter.bf_len = sizeof(allofit) / sizeof(struct bpf_insn);
+    bpf_filter.bf_insns = allofit;
+    if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
+      fprintf(stderr, "can't set bpf filter!\n");
+      perror("ioctl setting bpf filter");
+      exit(1);
     }
-    if (inf->is_loopback) {
-        /*
-         * make up a bssid for the loopback interface
-         */
-        RAND_pseudo_bytes(&inf->bssid[0], ETH_ALEN);
-        var = DLT_NULL;
-        if (ioctl(inf->fd, BIOCSDLT, &var)) {
-            fprintf(stderr, "can't set bpf link layer type!\n");
-            exit(1);
-        }
-        bpf_filter.bf_len = sizeof(sim80211) / sizeof(struct bpf_insn);
-        bpf_filter.bf_insns = sim80211;
-        if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
-            fprintf(stderr, "can't set bpf filter!\n");
-            perror("ioctl setting bpf filter");
-            exit(1);
-        }
-    } else {
-        var = DLT_IEEE802_11;
-        if (ioctl(inf->fd, BIOCSDLT, &var)) {
-            fprintf(stderr, "can't set bpf link layer type!\n");
-            exit(1);
-        }
-        var = 1;
-        if (ioctl(inf->fd, BIOCSHDRCMPLT, &var)) {
-            fprintf(stderr, "can't tell bpf we are doing our own headers!\n");
-            exit(1);
-        }
-        bpf_filter.bf_len = sizeof(allofit) / sizeof(struct bpf_insn);
-        bpf_filter.bf_insns = allofit;
-        if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
-            fprintf(stderr, "can't set bpf filter!\n");
-            perror("ioctl setting bpf filter");
-            exit(1);
-        }
-    }
-    srv_add_input(srvctx, inf->fd, inf, bpf_in);
-    TAILQ_INSERT_TAIL(&interfaces, inf, entry);
-    return;
+  }
+  srv_add_input(srvctx, inf->fd, inf, bpf_in);
+  TAILQ_INSERT_TAIL(&interfaces, inf, entry);
+  return;
 }
 
 /*
@@ -434,414 +444,439 @@ add_interface (unsigned char *ptr)
  *      beacons are normally sent out automagically by the radio but if we're
  *      simulating this protocol over the loopback we need to send them here.
  */
-static void
-send_beacon (void *data)
-{
-    struct interface *inf = (struct interface *)data;
-    struct ieee80211_mgmt_frame *frame;
-    unsigned char buf[2048], *el;
-    unsigned char broadcast[ETH_ALEN] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
-    int len, blen;
-    unsigned long af;
+static void send_beacon(void *data) {
+  struct interface *inf = (struct interface *)data;
+  struct ieee80211_mgmt_frame *frame;
+  unsigned char buf[2048], *el;
+  unsigned char broadcast[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+  int len, blen;
+  unsigned long af;
 
-    if (inf == NULL) {
-        return;
-    }
-    memset(buf, 0, sizeof(buf));
-    /*
-     * add the loopback pseudo-header to indicate or pseudo-AF
-     */
-    af = AF_INET;
-    memcpy(buf, &af, sizeof(unsigned long));
-    frame = (struct ieee80211_mgmt_frame *)(buf + sizeof(unsigned long));
-    frame->frame_control = ieee_order((IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_BEACON << 4));
-    memcpy(frame->da, broadcast, ETH_ALEN);
-    memcpy(frame->sa, inf->bssid, ETH_ALEN);
-    memcpy(frame->bssid, inf->bssid, ETH_ALEN);
-
-    /*
-     * not a truely valid beacon but so what, this is a simulator and
-     * all we really care about is the ssid
-     */
-    el = frame->beacon.variable;
-    *el = IEEE802_11_IE_SSID;
-    el++;
-    *el = strlen(mesh_ssid);
-    el++;
-    memcpy(el, mesh_ssid, strlen(mesh_ssid));
-    el += strlen(mesh_ssid);
-
-    len = el - buf;
-    blen = write(inf->fd, buf, len);
-    if (blen < 0) {
-        perror("write");
-    }
-    srv_add_timeout(srvctx, SRV_SEC(beacon), send_beacon, inf);
+  if (inf == NULL) {
     return;
+  }
+  memset(buf, 0, sizeof(buf));
+  /*
+   * add the loopback pseudo-header to indicate or pseudo-AF
+   */
+  af = AF_INET;
+  memcpy(buf, &af, sizeof(unsigned long));
+  frame = (struct ieee80211_mgmt_frame *)(buf + sizeof(unsigned long));
+  frame->frame_control = ieee_order(
+      (IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_BEACON << 4));
+  memcpy(frame->da, broadcast, ETH_ALEN);
+  memcpy(frame->sa, inf->bssid, ETH_ALEN);
+  memcpy(frame->bssid, inf->bssid, ETH_ALEN);
+
+  /*
+   * not a truely valid beacon but so what, this is a simulator and
+   * all we really care about is the ssid
+   */
+  el = frame->beacon.variable;
+  *el = IEEE802_11_IE_SSID;
+  el++;
+  *el = strlen(mesh_ssid);
+  el++;
+  memcpy(el, mesh_ssid, strlen(mesh_ssid));
+  el += strlen(mesh_ssid);
+
+  len = el - buf;
+  blen = write(inf->fd, buf, len);
+  if (blen < 0) {
+    perror("write");
+  }
+  srv_add_timeout(srvctx, SRV_SEC(beacon), send_beacon, inf);
+  return;
 }
 
 /*
  * chan2freq()
  *      convert an 802.11 channel into a frequencey, stolen from ifconfig...
  */
-static unsigned int
-chan2freq(unsigned int chan)
-{
-    /*
-     * "Kenneth, what is the frequency!!!????"
-     *          - William Tager
-     */
-    if (chan == 14)
-        return 2484;
-    if (chan < 14)			/* 0-13 */
-        return 2407 + chan*5;
-    if (chan < 27)			/* 15-26 */
-        return 2512 + ((chan-15)*20);
-    return 5000 + (chan*5);
+static unsigned int chan2freq(unsigned int chan) {
+  /*
+   * "Kenneth, what is the frequency!!!????"
+   *          - William Tager
+   */
+  if (chan == 14)
+    return 2484;
+  if (chan < 14) /* 0-13 */
+    return 2407 + chan * 5;
+  if (chan < 27) /* 15-26 */
+    return 2512 + ((chan - 15) * 20);
+  return 5000 + (chan * 5);
 }
 
-int
-main (int argc, char **argv)
-{
-    int i, s, c, ret, mediaopt, band;
-    unsigned int channel, freq;
-    struct interface *inf;
-    struct ifreq ifr;
-    struct ieee80211req ireq;
-    struct ifmediareq ifmreq;
-    struct ieee80211req_chaninfo chans;
-    struct sigaction act;
-    char confdir[80], conffile[80], mesh_interface[10];
-    char str[80], *ptr, *cruft;
-    size_t needed;
-    FILE *fp;
-    int mib[6];
-    struct if_msghdr *ifm;
-    struct sockaddr_dl *sdl;
+int main(int argc, char **argv) {
+  int i, s, c, ret, mediaopt, band;
+  unsigned int channel, freq;
+  struct interface *inf;
+  struct ifreq ifr;
+  struct ieee80211req ireq;
+  struct ifmediareq ifmreq;
+  struct ieee80211req_chaninfo chans;
+  struct sigaction act;
+  char confdir[80], conffile[80], mesh_interface[10];
+  char str[80], *ptr, *cruft;
+  size_t needed;
+  FILE *fp;
+  int mib[6];
+  struct if_msghdr *ifm;
+  struct sockaddr_dl *sdl;
 
-    strcpy(confdir, "/usr/local/config");
-    for (;;) {
-        c = getopt(argc, argv, "hI:b");
-        if (c < 0) {
-            break;
-        }
-        switch (c) {
-            case 'I':
-                snprintf(confdir, sizeof(confdir), optarg);
-                break;
-            case 'b':
-                /*
-                 * detach from controlling terminal and redirect output to /dev/null.
-                 * meshd will not cd to "/" to allow -I to specify relative directories.
-                 */
-                if (daemon(1, 0)) {
-                    perror("daemon");
-                    fprintf(stderr, "%s: unable to daemonize!\n", argv[0]);
-                    exit(1);
-                }
-                break;
-            default:
-            case 'h':
-                fprintf(stderr, 
-                        "USAGE: %s [-hIb]\n\t-h  show usage, and exit\n"
-                        "\t-I  directory of config files\n"
-                        "\t-b  run in the background\n",
-                        argv[0]);
-                exit(1);
-                
-        }
+  strcpy(confdir, "/usr/local/config");
+  for (;;) {
+    c = getopt(argc, argv, "hI:b");
+    if (c < 0) {
+      break;
     }
-
-    TAILQ_INIT(&interfaces);
-    if ((srvctx = srv_create_context()) == NULL) {
-        fprintf(stderr, "%s: cannot create service context!\n", argv[0]);
+    switch (c) {
+      case 'I':
+        snprintf(confdir, sizeof(confdir), optarg);
+        break;
+      case 'b':
+        /*
+         * detach from controlling terminal and redirect output to /dev/null.
+         * meshd will not cd to "/" to allow -I to specify relative directories.
+         */
+        if (daemon(1, 0)) {
+          perror("daemon");
+          fprintf(stderr, "%s: unable to daemonize!\n", argv[0]);
+          exit(1);
+        }
+        break;
+      default:
+      case 'h':
+        fprintf(
+            stderr,
+            "USAGE: %s [-hIb]\n\t-h  show usage, and exit\n"
+            "\t-I  directory of config files\n"
+            "\t-b  run in the background\n",
+            argv[0]);
         exit(1);
     }
+  }
 
-    snprintf(conffile, sizeof(conffile), "%s/meshd.conf", confdir);
-    strcpy(mesh_ssid, "meshd");
-    strcpy(mesh_interface, "lo0");
-    debug = 0;
-    passive = 0;
-    channel = 6;
-    mediaopt = MESHD_ADHOC;
-    band = MESHD_11b;
-    if ((fp = fopen(conffile, "r")) != NULL) {
-        while (!feof(fp)) {
-            if (fgets(str, sizeof(str), fp) == 0) {
-                continue;
-            }
-            if ((ret = parse_buffer(str, &ptr)) < 0) {
-                break;
-            }
-            if (ret == 0) {
-                continue;
-            }
-            if (strncmp(str, "interface", strlen("interface")) == 0) {
-                add_interface(ptr);
-            }
-            if (strncmp(str, "ssid", strlen("ssid")) == 0) {
-                strcpy(mesh_ssid, ptr);
-            }
-            if (strncmp(str, "passive", strlen("passive")) == 0) {
-                passive = atoi(ptr);
-            }
-            if (strncmp(str, "beacon", strlen("beacon")) == 0) {
-                beacon = atoi(ptr);
-            }
-            if (strncmp(str, "debug", strlen("debug")) == 0) {
-                debug = atoi(ptr);
-            }
-            if (strncmp(str, "mediaopt", strlen("mediaopt")) == 0) {
-                mediaopt = atoi(ptr);
-            }
-            if (strncmp(str, "channel", strlen("channel")) == 0) {
-                channel = atoi(ptr);
-            }
-            if (strncmp(str, "band", strlen("band")) == 0) {
-                if (strncmp(ptr, "11a", strlen("11a")) == 0) {
-                    band = MESHD_11a;
-                } else if (strncmp(ptr, "11b", strlen("11b")) == 0) {
-                    band = MESHD_11b;
-                } else if (strncmp(ptr, "11g", strlen("11g")) == 0) {
-                    band = MESHD_11g;
-                } else {
-                    band = -1;
-                }
-            }
-        }
-    }
-
-    if (TAILQ_EMPTY(&interfaces)) {
-        fprintf(stderr, "%s: no interfaces defined!\n", argv[0]);
-        add_interface("lo0");
-    }
-    printf("interfaces and MAC addresses:\n");
-    TAILQ_FOREACH(inf, &interfaces, entry) {
-        if (inf->is_loopback) {
-            /*
-             * no radio to configure but just set a timer for these
-             * phony beacons
-             */
-            printf("\t%s: " MACSTR "\n", inf->ifname, MAC2STR(inf->bssid));
-            (void)srv_add_timeout(srvctx, SRV_SEC(beacon), send_beacon, inf);
-        } else {
-            /*
-             * not loopback, it's some radio so configure it!
-             */
-            if ((s = socket(PF_INET, SOCK_RAW, 0)) < 0) {
-                fprintf(stderr, "unable to get raw socket to determine interface flags!\n");
-                exit(1);
-            }
-            /*
-             * get the link-layer address of the interface and make that
-             * the radio's bssid
-             */
-            memset(&ifr, 0, sizeof(ifr));
-            strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
-            if (ioctl(s, SIOCGIFINDEX, &ifr) < 0) {
-                fprintf(stderr, "%s: cannot determine ifindex!\n", argv[0]);
-                exit(1);
-            }
-            mib[0] = CTL_NET;
-            mib[1] = PF_ROUTE;
-            mib[2] = 0;
-            mib[3] = 0;
-            mib[4] = NET_RT_IFLIST;
-            mib[5] = ifr.ifr_index;
-            if (sysctl(mib, 6, NULL, &needed, NULL, 0) < 0) {
-                fprintf(stderr, "%s: cannot determine size of info from sysctl!\n", argv[0]);
-                exit(1);
-            }
-            if ((cruft = malloc(needed)) == NULL) {
-                fprintf(stderr, "%s: cannot malloc space to retrieve sysctl info!\n", argv[0]);
-                exit(1);
-            }
-            if (sysctl(mib, 6, cruft, &needed, NULL, 0) < 0) {
-                free(cruft);
-                fprintf(stderr, "%s: cannot obtain info from sysctl!\n", argv[0]);
-                exit(1);
-            }
-            ifm = (struct if_msghdr *)cruft;
-            if (ifm->ifm_type != RTM_IFINFO) {
-                fprintf(stderr, "%s: unexpected result from sysctl, expected %d got %d\n",
-                        argv[0], RTM_IFINFO, ifm->ifm_type);
-                exit(1);
-            }
-            if (ifm->ifm_data.ifi_datalen == 0) {
-                ifm->ifm_data.ifi_datalen = sizeof(struct if_data);
-            }
-            sdl = (struct sockaddr_dl *)((char *)ifm + sizeof(struct if_msghdr) - sizeof(struct if_data) + ifm->ifm_data.ifi_datalen);
-            memcpy(inf->bssid, LLADDR(sdl), ETH_ALEN);
-            free(cruft);
-
-            memset(&ireq, 0, sizeof(struct ieee80211req));
-            strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
-            ireq.i_type = IEEE80211_IOC_BSSID;
-            ireq.i_len = ETH_ALEN;
-            ireq.i_data = inf->bssid;
-            if (ioctl(s, SIOCS80211, &ireq) < 0) {
-                fprintf(stderr, "%s: unable to set bssid!\n", argv[0]);
-                perror("ioctl setting bssid");
-                exit(1);
-            }
-            printf("\t%s: " MACSTR "\n", inf->ifname, MAC2STR(inf->bssid));
-            /*
-             * enable RSN
-             */
-            memset(&ireq, 0, sizeof(struct ieee80211req));
-            strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
-            ireq.i_type = IEEE80211_IOC_WPA;
-            ireq.i_val = 2;
-            if (ioctl(s, SIOCS80211, &ireq) < 0) {
-                fprintf(stderr, "%s: unable to set RSN!\n", argv[0]);
-                perror("ioctl setting RSN");
-                exit(1);
-            }
-            /*
-             * set the ssid
-             */
-            memset(&ireq, 0, sizeof(struct ieee80211req));
-            strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
-            ireq.i_type = IEEE80211_IOC_SSID;
-            ireq.i_data = mesh_ssid;
-            ireq.i_len = strlen(mesh_ssid);
-
-            if (ioctl(s, SIOCS80211, &ireq) < 0) {
-                fprintf(stderr, "%s: unable to set SSID!\n", argv[0]);
-                perror("ioctl");
-                exit(1);
-            }
-            /*
-             * set the media option
-             */
-            memset(&ifmreq, 0, sizeof(ifmreq));
-            strlcpy(ifmreq.ifm_name, inf->ifname, IFNAMSIZ);
-            if (ioctl(s, SIOCGIFMEDIA, &ifmreq) < 0) {
-                fprintf(stderr, "%s: unable to get mediaopt!\n", argv[0]);
-                exit(1);
-            }
-            switch (mediaopt) {
-                case MESHD_STA:
-                    ifmreq.ifm_current &= ~(IFM_IEEE80211_HOSTAP | IFM_IEEE80211_MONITOR | IFM_IEEE80211_ADHOC | IFM_IEEE80211_IBSS);
-                    break;
-                case MESHD_ADHOC:
-                    ifmreq.ifm_current &= ~(IFM_IEEE80211_HOSTAP | IFM_IEEE80211_MONITOR | IFM_IEEE80211_IBSS);
-                    ifmreq.ifm_current |= IFM_IEEE80211_ADHOC;
-                    break;
-                case MESHD_HOSTAP:
-                    ifmreq.ifm_current &= ~(IFM_IEEE80211_MONITOR | IFM_IEEE80211_ADHOC | IFM_IEEE80211_IBSS);
-                    ifmreq.ifm_current |= IFM_IEEE80211_HOSTAP;
-                    break;
-                case MESHD_MONITOR:
-                    ifmreq.ifm_current &= ~(IFM_IEEE80211_HOSTAP | IFM_IEEE80211_ADHOC | IFM_IEEE80211_IBSS);
-                    ifmreq.ifm_current |= IFM_IEEE80211_MONITOR;
-                    break;
-                case MESHD_IBSS:
-                    ifmreq.ifm_current &= ~(IFM_IEEE80211_HOSTAP | IFM_IEEE80211_ADHOC | IFM_IEEE80211_MONITOR);
-                    ifmreq.ifm_current |= IFM_IEEE80211_IBSS;
-                    break;
-            }
-            ifmreq.ifm_current &= ~(IFM_IEEE80211_11A | IFM_IEEE80211_11B | IFM_IEEE80211_11G | IFM_IEEE80211_FH);
-            switch (band) {
-                case MESHD_11a:
-                    ifmreq.ifm_current |= IFM_IEEE80211_11A;
-                    break;
-                case MESHD_11b:
-                    ifmreq.ifm_current |= IFM_IEEE80211_11B;
-                    break;
-                case MESHD_11g:
-                    ifmreq.ifm_current |= IFM_IEEE80211_11G;
-                    break;
-                default:
-                    fprintf(stderr, "%s: unknown mode %d\n", argv[0], band);
-                    exit(1);
-            }
-
-            if (ioctl(s, SIOCSIFMEDIA, &ifmreq) < 0) {
-                fprintf(stderr, "%s: unable to set mediaopt!\n", argv[0]);
-                perror("ioctl");
-                exit(1);
-            }
-
-            /*
-             * figure out what channels are allowable on this radio
-             */
-            memset(&ireq, 0, sizeof(ireq));
-            strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
-            ireq.i_type = IEEE80211_IOC_CHANINFO;
-            ireq.i_data = &chans;
-            ireq.i_len = sizeof(chans);
-            if (ioctl(s, SIOCG80211, &ireq) < 0) {
-                fprintf(stderr, "%s: unable to get available channels!\n", argv[0]);
-                exit(1);
-            }
-
-            freq = chan2freq(channel);
-            for (i = 0; i < chans.ic_nchans; i++) {
-                /*
-                 * go through them all, ignore if not in the configured band 
-                 */
-                if (IEEE80211_IS_CHAN_A(&chans.ic_chans[i]) && (band != MESHD_11a)) {
-                    continue;
-                }
-                if (!IEEE80211_IS_CHAN_A(&chans.ic_chans[i]) && (band == MESHD_11a)) {
-                    continue;
-                }
-                if (freq == chans.ic_chans[i].ic_freq) {
-                    break;
-                }
-            }
-            if (i == chans.ic_nchans) {
-                fprintf(stderr, "%s: invalid channel, %d, for band %s\n", argv[0], channel,
-                        band == MESHD_11a ? "11a" : band == MESHD_11b ? "11b" : "11g");
-                exit(1);
-            }
-            memset(&ireq, 0, sizeof(ireq));
-            strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
-            ireq.i_type = IEEE80211_IOC_CHANNEL;
-            ireq.i_val = channel;
-            if (ioctl(s, SIOCS80211, &ireq) < 0) {
-                fprintf(stderr, "%s: unable to set channel %d for band %s\n", argv[0], channel,
-                        band == MESHD_11a ? "11a" : band == MESHD_11b ? "11b" : "11g");
-                /* unfortunate, but is it fatal? Nah */
-            }
-            printf("setting to channel %d, frequency %d\n", channel, freq);
-    
-            /*
-             * finally let's make sure the interface is up
-             */
-            if (ioctl(s, SIOCGIFFLAGS, &ifr) < 0) {
-                fprintf(stderr, "%s: cannot get ifflags for %s\n", argv[0], inf->ifname);
-                exit(1);
-            }
-            if ((ifr.ifr_flags & IFF_UP) == 0) {
-                ifr.ifr_flags |= IFF_UP;
-                if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) {
-                    fprintf(stderr, "%s: can't set %s to UP!\n", argv[0], inf->ifname);
-                }
-            }
-            close(s);
-        }
-    }
-
-    /*
-     * initialize SAE...
-     */
-    if (sae_initialize(mesh_ssid, confdir) < 0) {
-        fprintf(stderr, "%s: cannot configure SAE, check config file!\n", argv[0]);
-        exit(1);
-    }
-
-    /*
-     * re-read the SAE config upon receipt of HUP
-     */
-    act.sa_handler = sae_read_config;
-    sigaction(SIGHUP, &act, NULL);
-    act.sa_handler = sae_dump_db;
-    sigaction(SIGUSR1, &act, NULL);
-
-    srv_main_loop(srvctx);
-
+  TAILQ_INIT(&interfaces);
+  if ((srvctx = srv_create_context()) == NULL) {
+    fprintf(stderr, "%s: cannot create service context!\n", argv[0]);
     exit(1);
+  }
+
+  snprintf(conffile, sizeof(conffile), "%s/meshd.conf", confdir);
+  strcpy(mesh_ssid, "meshd");
+  strcpy(mesh_interface, "lo0");
+  debug = 0;
+  passive = 0;
+  channel = 6;
+  mediaopt = MESHD_ADHOC;
+  band = MESHD_11b;
+  if ((fp = fopen(conffile, "r")) != NULL) {
+    while (!feof(fp)) {
+      if (fgets(str, sizeof(str), fp) == 0) {
+        continue;
+      }
+      if ((ret = parse_buffer(str, &ptr)) < 0) {
+        break;
+      }
+      if (ret == 0) {
+        continue;
+      }
+      if (strncmp(str, "interface", strlen("interface")) == 0) {
+        add_interface(ptr);
+      }
+      if (strncmp(str, "ssid", strlen("ssid")) == 0) {
+        strcpy(mesh_ssid, ptr);
+      }
+      if (strncmp(str, "passive", strlen("passive")) == 0) {
+        passive = atoi(ptr);
+      }
+      if (strncmp(str, "beacon", strlen("beacon")) == 0) {
+        beacon = atoi(ptr);
+      }
+      if (strncmp(str, "debug", strlen("debug")) == 0) {
+        debug = atoi(ptr);
+      }
+      if (strncmp(str, "mediaopt", strlen("mediaopt")) == 0) {
+        mediaopt = atoi(ptr);
+      }
+      if (strncmp(str, "channel", strlen("channel")) == 0) {
+        channel = atoi(ptr);
+      }
+      if (strncmp(str, "band", strlen("band")) == 0) {
+        if (strncmp(ptr, "11a", strlen("11a")) == 0) {
+          band = MESHD_11a;
+        } else if (strncmp(ptr, "11b", strlen("11b")) == 0) {
+          band = MESHD_11b;
+        } else if (strncmp(ptr, "11g", strlen("11g")) == 0) {
+          band = MESHD_11g;
+        } else {
+          band = -1;
+        }
+      }
+    }
+  }
+
+  if (TAILQ_EMPTY(&interfaces)) {
+    fprintf(stderr, "%s: no interfaces defined!\n", argv[0]);
+    add_interface("lo0");
+  }
+  printf("interfaces and MAC addresses:\n");
+  TAILQ_FOREACH(inf, &interfaces, entry) {
+    if (inf->is_loopback) {
+      /*
+       * no radio to configure but just set a timer for these
+       * phony beacons
+       */
+      printf("\t%s: " MACSTR "\n", inf->ifname, MAC2STR(inf->bssid));
+      (void)srv_add_timeout(srvctx, SRV_SEC(beacon), send_beacon, inf);
+    } else {
+      /*
+       * not loopback, it's some radio so configure it!
+       */
+      if ((s = socket(PF_INET, SOCK_RAW, 0)) < 0) {
+        fprintf(
+            stderr, "unable to get raw socket to determine interface flags!\n");
+        exit(1);
+      }
+      /*
+       * get the link-layer address of the interface and make that
+       * the radio's bssid
+       */
+      memset(&ifr, 0, sizeof(ifr));
+      strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
+      if (ioctl(s, SIOCGIFINDEX, &ifr) < 0) {
+        fprintf(stderr, "%s: cannot determine ifindex!\n", argv[0]);
+        exit(1);
+      }
+      mib[0] = CTL_NET;
+      mib[1] = PF_ROUTE;
+      mib[2] = 0;
+      mib[3] = 0;
+      mib[4] = NET_RT_IFLIST;
+      mib[5] = ifr.ifr_index;
+      if (sysctl(mib, 6, NULL, &needed, NULL, 0) < 0) {
+        fprintf(
+            stderr,
+            "%s: cannot determine size of info from sysctl!\n",
+            argv[0]);
+        exit(1);
+      }
+      if ((cruft = malloc(needed)) == NULL) {
+        fprintf(
+            stderr,
+            "%s: cannot malloc space to retrieve sysctl info!\n",
+            argv[0]);
+        exit(1);
+      }
+      if (sysctl(mib, 6, cruft, &needed, NULL, 0) < 0) {
+        free(cruft);
+        fprintf(stderr, "%s: cannot obtain info from sysctl!\n", argv[0]);
+        exit(1);
+      }
+      ifm = (struct if_msghdr *)cruft;
+      if (ifm->ifm_type != RTM_IFINFO) {
+        fprintf(
+            stderr,
+            "%s: unexpected result from sysctl, expected %d got %d\n",
+            argv[0],
+            RTM_IFINFO,
+            ifm->ifm_type);
+        exit(1);
+      }
+      if (ifm->ifm_data.ifi_datalen == 0) {
+        ifm->ifm_data.ifi_datalen = sizeof(struct if_data);
+      }
+      sdl = (struct sockaddr_dl *)((char *)ifm + sizeof(struct if_msghdr) - sizeof(struct if_data) + ifm->ifm_data.ifi_datalen);
+      memcpy(inf->bssid, LLADDR(sdl), ETH_ALEN);
+      free(cruft);
+
+      memset(&ireq, 0, sizeof(struct ieee80211req));
+      strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
+      ireq.i_type = IEEE80211_IOC_BSSID;
+      ireq.i_len = ETH_ALEN;
+      ireq.i_data = inf->bssid;
+      if (ioctl(s, SIOCS80211, &ireq) < 0) {
+        fprintf(stderr, "%s: unable to set bssid!\n", argv[0]);
+        perror("ioctl setting bssid");
+        exit(1);
+      }
+      printf("\t%s: " MACSTR "\n", inf->ifname, MAC2STR(inf->bssid));
+      /*
+       * enable RSN
+       */
+      memset(&ireq, 0, sizeof(struct ieee80211req));
+      strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
+      ireq.i_type = IEEE80211_IOC_WPA;
+      ireq.i_val = 2;
+      if (ioctl(s, SIOCS80211, &ireq) < 0) {
+        fprintf(stderr, "%s: unable to set RSN!\n", argv[0]);
+        perror("ioctl setting RSN");
+        exit(1);
+      }
+      /*
+       * set the ssid
+       */
+      memset(&ireq, 0, sizeof(struct ieee80211req));
+      strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
+      ireq.i_type = IEEE80211_IOC_SSID;
+      ireq.i_data = mesh_ssid;
+      ireq.i_len = strlen(mesh_ssid);
+
+      if (ioctl(s, SIOCS80211, &ireq) < 0) {
+        fprintf(stderr, "%s: unable to set SSID!\n", argv[0]);
+        perror("ioctl");
+        exit(1);
+      }
+      /*
+       * set the media option
+       */
+      memset(&ifmreq, 0, sizeof(ifmreq));
+      strlcpy(ifmreq.ifm_name, inf->ifname, IFNAMSIZ);
+      if (ioctl(s, SIOCGIFMEDIA, &ifmreq) < 0) {
+        fprintf(stderr, "%s: unable to get mediaopt!\n", argv[0]);
+        exit(1);
+      }
+      switch (mediaopt) {
+        case MESHD_STA:
+          ifmreq.ifm_current &=
+              ~(IFM_IEEE80211_HOSTAP | IFM_IEEE80211_MONITOR |
+                IFM_IEEE80211_ADHOC | IFM_IEEE80211_IBSS);
+          break;
+        case MESHD_ADHOC:
+          ifmreq.ifm_current &=
+              ~(IFM_IEEE80211_HOSTAP | IFM_IEEE80211_MONITOR |
+                IFM_IEEE80211_IBSS);
+          ifmreq.ifm_current |= IFM_IEEE80211_ADHOC;
+          break;
+        case MESHD_HOSTAP:
+          ifmreq.ifm_current &= ~(
+              IFM_IEEE80211_MONITOR | IFM_IEEE80211_ADHOC | IFM_IEEE80211_IBSS);
+          ifmreq.ifm_current |= IFM_IEEE80211_HOSTAP;
+          break;
+        case MESHD_MONITOR:
+          ifmreq.ifm_current &= ~(
+              IFM_IEEE80211_HOSTAP | IFM_IEEE80211_ADHOC | IFM_IEEE80211_IBSS);
+          ifmreq.ifm_current |= IFM_IEEE80211_MONITOR;
+          break;
+        case MESHD_IBSS:
+          ifmreq.ifm_current &=
+              ~(IFM_IEEE80211_HOSTAP | IFM_IEEE80211_ADHOC |
+                IFM_IEEE80211_MONITOR);
+          ifmreq.ifm_current |= IFM_IEEE80211_IBSS;
+          break;
+      }
+      ifmreq.ifm_current &=
+          ~(IFM_IEEE80211_11A | IFM_IEEE80211_11B | IFM_IEEE80211_11G |
+            IFM_IEEE80211_FH);
+      switch (band) {
+        case MESHD_11a:
+          ifmreq.ifm_current |= IFM_IEEE80211_11A;
+          break;
+        case MESHD_11b:
+          ifmreq.ifm_current |= IFM_IEEE80211_11B;
+          break;
+        case MESHD_11g:
+          ifmreq.ifm_current |= IFM_IEEE80211_11G;
+          break;
+        default:
+          fprintf(stderr, "%s: unknown mode %d\n", argv[0], band);
+          exit(1);
+      }
+
+      if (ioctl(s, SIOCSIFMEDIA, &ifmreq) < 0) {
+        fprintf(stderr, "%s: unable to set mediaopt!\n", argv[0]);
+        perror("ioctl");
+        exit(1);
+      }
+
+      /*
+       * figure out what channels are allowable on this radio
+       */
+      memset(&ireq, 0, sizeof(ireq));
+      strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
+      ireq.i_type = IEEE80211_IOC_CHANINFO;
+      ireq.i_data = &chans;
+      ireq.i_len = sizeof(chans);
+      if (ioctl(s, SIOCG80211, &ireq) < 0) {
+        fprintf(stderr, "%s: unable to get available channels!\n", argv[0]);
+        exit(1);
+      }
+
+      freq = chan2freq(channel);
+      for (i = 0; i < chans.ic_nchans; i++) {
+        /*
+         * go through them all, ignore if not in the configured band
+         */
+        if (IEEE80211_IS_CHAN_A(&chans.ic_chans[i]) && (band != MESHD_11a)) {
+          continue;
+        }
+        if (!IEEE80211_IS_CHAN_A(&chans.ic_chans[i]) && (band == MESHD_11a)) {
+          continue;
+        }
+        if (freq == chans.ic_chans[i].ic_freq) {
+          break;
+        }
+      }
+      if (i == chans.ic_nchans) {
+        fprintf(
+            stderr,
+            "%s: invalid channel, %d, for band %s\n",
+            argv[0],
+            channel,
+            band == MESHD_11a ? "11a" : band == MESHD_11b ? "11b" : "11g");
+        exit(1);
+      }
+      memset(&ireq, 0, sizeof(ireq));
+      strlcpy(ireq.i_name, inf->ifname, IFNAMSIZ);
+      ireq.i_type = IEEE80211_IOC_CHANNEL;
+      ireq.i_val = channel;
+      if (ioctl(s, SIOCS80211, &ireq) < 0) {
+        fprintf(
+            stderr,
+            "%s: unable to set channel %d for band %s\n",
+            argv[0],
+            channel,
+            band == MESHD_11a ? "11a" : band == MESHD_11b ? "11b" : "11g");
+        /* unfortunate, but is it fatal? Nah */
+      }
+      printf("setting to channel %d, frequency %d\n", channel, freq);
+
+      /*
+       * finally let's make sure the interface is up
+       */
+      if (ioctl(s, SIOCGIFFLAGS, &ifr) < 0) {
+        fprintf(
+            stderr, "%s: cannot get ifflags for %s\n", argv[0], inf->ifname);
+        exit(1);
+      }
+      if ((ifr.ifr_flags & IFF_UP) == 0) {
+        ifr.ifr_flags |= IFF_UP;
+        if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) {
+          fprintf(stderr, "%s: can't set %s to UP!\n", argv[0], inf->ifname);
+        }
+      }
+      close(s);
+    }
+  }
+
+  /*
+   * initialize SAE...
+   */
+  if (sae_initialize(mesh_ssid, confdir) < 0) {
+    fprintf(stderr, "%s: cannot configure SAE, check config file!\n", argv[0]);
+    exit(1);
+  }
+
+  /*
+   * re-read the SAE config upon receipt of HUP
+   */
+  act.sa_handler = sae_read_config;
+  sigaction(SIGHUP, &act, NULL);
+  act.sa_handler = sae_dump_db;
+  sigaction(SIGUSR1, &act, NULL);
+
+  srv_main_loop(srvctx);
+
+  exit(1);
 }

--- a/freebsd/mon.c
+++ b/freebsd/mon.c
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) Dan Harkins, 2008, 2009, 2010
  *
- *  Copyright holder grants permission for redistribution and use in source 
- *  and binary forms, with or without modification, provided that the 
+ *  Copyright holder grants permission for redistribution and use in source
+ *  and binary forms, with or without modification, provided that the
  *  following conditions are met:
  *     1. Redistribution of source code must retain the above copyright
  *        notice, this list of conditions, and the following disclaimer
@@ -18,13 +18,13 @@
  *         Dan Harkins (dharkins at lounge dot org)"
  *
  *  "DISCLAIMER OF LIABILITY
- *  
+ *
  *  THIS SOFTWARE IS PROVIDED BY DAN HARKINS ``AS IS'' AND
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
- *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
  *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE INDUSTRIAL LOUNGE BE LIABLE
  *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
  *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
@@ -36,381 +36,401 @@
  * license (including the GNU public license).
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <string.h>
 #include <errno.h>
-#include <signal.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <sys/sysctl.h>
-#include <sys/queue.h>
-#include <netinet/in.h>
+#include <fcntl.h>
+#include <net/bpf.h>
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/if_media.h>
-#include <net/bpf.h>
 #include <net/route.h>
+#include <netinet/in.h>
 #include <openssl/rand.h>
-#include "service.h"
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <unistd.h>
 #include "common.h"
 #include "sae.h"
+#include "service.h"
 
 struct interface {
-    TAILQ_ENTRY(interface) entry;
-    unsigned char ifname[IFNAMSIZ];
-    unsigned char is_loopback;
-    int fd;     /* BPF socket */
+  TAILQ_ENTRY(interface) entry;
+  unsigned char ifname[IFNAMSIZ];
+  unsigned char is_loopback;
+  int fd; /* BPF socket */
 };
 TAILQ_HEAD(bar, interface) interfaces;
 
 service_context srvctx;
 unsigned char mesh_ssid[33];
 
-static void
-bpf_in (int fd, void *data)
-{
-    struct interface *inf = (struct interface *)data;
-    char el_id, el_len, ssid[33];
-    unsigned char buf[2048], *ptr, *els;
-    struct bpf_hdr *hdr;
-    struct ieee80211_mgmt_frame *frame;
-    unsigned short frame_control, grp, status, rc;
-    int type, stype, len, framesize, left;
+static void bpf_in(int fd, void *data) {
+  struct interface *inf = (struct interface *)data;
+  char el_id, el_len, ssid[33];
+  unsigned char buf[2048], *ptr, *els;
+  struct bpf_hdr *hdr;
+  struct ieee80211_mgmt_frame *frame;
+  unsigned short frame_control, grp, status, rc;
+  int type, stype, len, framesize, left;
 
-    if ((len = read(fd, buf, sizeof(buf))) < 0) {
-        fprintf(stderr, "can't read off bpf socket!\n");
-        perror("read");
-        return;
+  if ((len = read(fd, buf, sizeof(buf))) < 0) {
+    fprintf(stderr, "can't read off bpf socket!\n");
+    perror("read");
+    return;
+  }
+
+  ptr = buf;
+  while (len > 0) {
+    hdr = (struct bpf_hdr *)ptr;
+    /*
+     * if loopback skip over the BPF's pseudo header.
+     */
+    if (inf->is_loopback) {
+      frame =
+          (struct ieee80211_mgmt_frame
+               *)(ptr + hdr->bh_hdrlen + sizeof(unsigned long));
+      framesize = hdr->bh_datalen - sizeof(unsigned long);
+    } else {
+      frame = (struct ieee80211_mgmt_frame *)(ptr + hdr->bh_hdrlen);
+      framesize = hdr->bh_datalen;
+    }
+    if (framesize > len) {
+      fprintf(
+          stderr,
+          "something is seriously fucked up! read %d, frame is %d\n",
+          len,
+          framesize);
+      return;
     }
 
-    ptr = buf;
-    while (len > 0) {
-        hdr = (struct bpf_hdr *)ptr;
-        /*
-         * if loopback skip over the BPF's pseudo header.
-         */
-        if (inf->is_loopback) {
-            frame = (struct ieee80211_mgmt_frame *)(ptr + hdr->bh_hdrlen + sizeof(unsigned long));
-            framesize = hdr->bh_datalen - sizeof(unsigned long);
-        } else {
-            frame = (struct ieee80211_mgmt_frame *)(ptr + hdr->bh_hdrlen);
-            framesize = hdr->bh_datalen;
-        }
-        if (framesize > len) {
-            fprintf(stderr, "something is seriously fucked up! read %d, frame is %d\n",
-                    len, framesize);
-            return;
-        }
+    frame_control = ieee_order(frame->frame_control);
+    type = IEEE802_11_FC_GET_TYPE(frame_control);
+    stype = IEEE802_11_FC_GET_STYPE(frame_control);
 
-        frame_control = ieee_order(frame->frame_control);
-        type = IEEE802_11_FC_GET_TYPE(frame_control);
-        stype = IEEE802_11_FC_GET_STYPE(frame_control);
-
-        if (type == IEEE802_11_FC_TYPE_MGMT) {
-            switch (stype) {
-                case IEEE802_11_FC_STYPE_BEACON:
-                    els = frame->beacon.variable;
-                    left = framesize - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
-                    /*
-                     * els is the next IE in the beacon,
-                     * left is how much is left to read in the beacon
-                     */
-                    while (left > 2) {
-                        el_id = *els++; 
-                        left--;
-                        el_len = *els++; 
-                        left--;
-                        if (el_len > left) {
-                            /*
-                             * someone's trying to mess with us...
-                             */
-                            break;
-                        }
-                        if (el_id == IEEE802_11_IE_SSID) { 
-                            if (el_len > 32) {
-                                /*
-                                 * again with the messing...
-                                 */
-                                break;
-                            }
-                            memset(ssid, 0, sizeof(ssid));
-                            memcpy(ssid, els, el_len);
-                            if ((el_len != 0) && (memcmp(ssid, mesh_ssid, strlen(ssid)) == 0)) {
-                                printf("%s: beacon of %s from " MACSTR "\n", inf->ifname, ssid, MAC2STR(frame->sa));
-                            }
-                            break;
-                        }
-                        els += el_len;
-                        left -= el_len;
-                    }
-                    break;
-                case IEEE802_11_FC_STYPE_AUTH:
-                    if (frame->authenticate.alg != SAE_AUTH_ALG) {
-                        break;
-                    }
-                    switch (frame->authenticate.auth_seq) {
-                        case SAE_AUTH_COMMIT:
-                            printf("%s: %d COMMIT frame, " MACSTR " to " MACSTR " ", inf->ifname,
-                                   framesize, MAC2STR(frame->sa), MAC2STR(frame->da));
-                            status = ieee_order(frame->authenticate.status);
-                            grp = ieee_order(*((unsigned short *)(frame->authenticate.variable)));
-                            switch (status) {
-                                case WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED:
-                                    printf("rejecting due to no token\n");
-                                    break;
-                                case WLAN_STATUS_NOT_SUPPORTED_GROUP:
-                                    printf("rejecting due to unsupported group %d\n", grp);
-                                    break;
-                                case 0:
-                                    printf("offering group %d\n", grp);
-                                    break;
-                                default:
-                                    printf("unknown status %d!!!\n", status);
-                            }
-                            break;
-                        case SAE_AUTH_CONFIRM:
-                            rc = ieee_order(*((unsigned short *)(frame->authenticate.variable)));
-                            printf("%s: CONFIRM frame, " MACSTR " to " MACSTR ", rc = %d\n", 
-                                   inf->ifname, MAC2STR(frame->sa), MAC2STR(frame->da), rc);
-                            break;
-                        default:
-                            printf("%s: unknown frame (seq = %d), " MACSTR " to " MACSTR "\n", 
-                                   inf->ifname, frame->authenticate.auth_seq, 
-                                   MAC2STR(frame->sa), MAC2STR(frame->da));
-                            break;
-                    }
-                    break;
-                case IEEE802_11_FC_STYPE_ACTION:
-                    /* APE exchange */
-                    break;
+    if (type == IEEE802_11_FC_TYPE_MGMT) {
+      switch (stype) {
+        case IEEE802_11_FC_STYPE_BEACON:
+          els = frame->beacon.variable;
+          left = framesize - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
+          /*
+           * els is the next IE in the beacon,
+           * left is how much is left to read in the beacon
+           */
+          while (left > 2) {
+            el_id = *els++;
+            left--;
+            el_len = *els++;
+            left--;
+            if (el_len > left) {
+              /*
+               * someone's trying to mess with us...
+               */
+              break;
             }
-        }
-        /*
-         * there might be another frame...
-         */
-        len -= BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
-        ptr += BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+            if (el_id == IEEE802_11_IE_SSID) {
+              if (el_len > 32) {
+                /*
+                 * again with the messing...
+                 */
+                break;
+              }
+              memset(ssid, 0, sizeof(ssid));
+              memcpy(ssid, els, el_len);
+              if ((el_len != 0) &&
+                  (memcmp(ssid, mesh_ssid, strlen(ssid)) == 0)) {
+                printf(
+                    "%s: beacon of %s from " MACSTR "\n",
+                    inf->ifname,
+                    ssid,
+                    MAC2STR(frame->sa));
+              }
+              break;
+            }
+            els += el_len;
+            left -= el_len;
+          }
+          break;
+        case IEEE802_11_FC_STYPE_AUTH:
+          if (frame->authenticate.alg != SAE_AUTH_ALG) {
+            break;
+          }
+          switch (frame->authenticate.auth_seq) {
+            case SAE_AUTH_COMMIT:
+              printf(
+                  "%s: %d COMMIT frame, " MACSTR " to " MACSTR " ",
+                  inf->ifname,
+                  framesize,
+                  MAC2STR(frame->sa),
+                  MAC2STR(frame->da));
+              status = ieee_order(frame->authenticate.status);
+              grp = ieee_order(
+                  *((unsigned short *)(frame->authenticate.variable)));
+              switch (status) {
+                case WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED:
+                  printf("rejecting due to no token\n");
+                  break;
+                case WLAN_STATUS_NOT_SUPPORTED_GROUP:
+                  printf("rejecting due to unsupported group %d\n", grp);
+                  break;
+                case 0:
+                  printf("offering group %d\n", grp);
+                  break;
+                default:
+                  printf("unknown status %d!!!\n", status);
+              }
+              break;
+            case SAE_AUTH_CONFIRM:
+              rc = ieee_order(
+                  *((unsigned short *)(frame->authenticate.variable)));
+              printf(
+                  "%s: CONFIRM frame, " MACSTR " to " MACSTR ", rc = %d\n",
+                  inf->ifname,
+                  MAC2STR(frame->sa),
+                  MAC2STR(frame->da),
+                  rc);
+              break;
+            default:
+              printf(
+                  "%s: unknown frame (seq = %d), " MACSTR " to " MACSTR "\n",
+                  inf->ifname,
+                  frame->authenticate.auth_seq,
+                  MAC2STR(frame->sa),
+                  MAC2STR(frame->da));
+              break;
+          }
+          break;
+        case IEEE802_11_FC_STYPE_ACTION:
+          /* APE exchange */
+          break;
+      }
     }
+    /*
+     * there might be another frame...
+     */
+    len -= BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+    ptr += BPF_WORDALIGN(hdr->bh_hdrlen + hdr->bh_caplen);
+  }
 }
 
-static void
-add_interface (unsigned char *ptr)
-{
-    struct interface *inf;
-    char bpfdev[sizeof "/dev/bpfXXXXXXXX"];
-    int s, var, bpfnum = 0;
-    struct ifreq ifr;
-    struct bpf_program bpf_filter;
-    struct bpf_insn allofit[] = {
-        /*
-         * a bpf filter to get beacons, authentication and action frames 
-         */
-        BPF_STMT(BPF_LD+BPF_B+BPF_ABS, 0),
-        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0x80, 0, 1),    /* beacon */
-        BPF_STMT(BPF_RET+BPF_K, (unsigned int) -1),
-        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0xb0, 0, 1),    /* auth */
-        BPF_STMT(BPF_RET+BPF_K, (unsigned int) -1),
-        BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0xd0, 0, 1),    /* action for APE */
-        BPF_STMT(BPF_RET+BPF_K, (unsigned int) -1),     /* coming soon :-) */
-        BPF_STMT(BPF_RET+BPF_K, 0),
-    };
-    struct bpf_insn sim80211[] = {
-        /*
-         * for loopback interfaces, just grab everything
-         */
-        { 0x6, 0, 0, 0x00000800 },
-    };
+static void add_interface(unsigned char *ptr) {
+  struct interface *inf;
+  char bpfdev[sizeof "/dev/bpfXXXXXXXX"];
+  int s, var, bpfnum = 0;
+  struct ifreq ifr;
+  struct bpf_program bpf_filter;
+  struct bpf_insn allofit[] = {
+      /*
+       * a bpf filter to get beacons, authentication and action frames
+       */
+      BPF_STMT(BPF_LD + BPF_B + BPF_ABS, 0),
+      BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0x80, 0, 1), /* beacon */
+      BPF_STMT(BPF_RET + BPF_K, (unsigned int)-1),
+      BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0xb0, 0, 1), /* auth */
+      BPF_STMT(BPF_RET + BPF_K, (unsigned int)-1),
+      BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0xd0, 0, 1), /* action for APE */
+      BPF_STMT(BPF_RET + BPF_K, (unsigned int)-1), /* coming soon :-) */
+      BPF_STMT(BPF_RET + BPF_K, 0),
+  };
+  struct bpf_insn sim80211[] = {
+      /*
+       * for loopback interfaces, just grab everything
+       */
+      {0x6, 0, 0, 0x00000800},
+  };
 
-    TAILQ_FOREACH(inf, &interfaces, entry) {
-        if (memcmp(&inf->ifname, ptr, strlen(ptr)) == 0) {
-            printf("%s is already on the list!\n", ptr);
-            return;
-        }
+  TAILQ_FOREACH(inf, &interfaces, entry) {
+    if (memcmp(&inf->ifname, ptr, strlen(ptr)) == 0) {
+      printf("%s is already on the list!\n", ptr);
+      return;
     }
-    if ((inf = (struct interface *)malloc(sizeof(struct interface))) == NULL) {
-        fprintf(stderr, "failed to malloc space for new interface %s!\n", ptr);
-        return;
-    }
-    strncpy(inf->ifname, ptr, strlen(ptr));
+  }
+  if ((inf = (struct interface *)malloc(sizeof(struct interface))) == NULL) {
+    fprintf(stderr, "failed to malloc space for new interface %s!\n", ptr);
+    return;
+  }
+  strncpy(inf->ifname, ptr, strlen(ptr));
 
+  /*
+   * see if this is a loopback interface
+   */
+  if ((s = socket(PF_INET, SOCK_RAW, 0)) < 0) {
+    fprintf(stderr, "unable to get raw socket to determine interface flags!\n");
+    free(inf);
+    return;
+  }
+  memset(&ifr, 0, sizeof(ifr));
+  strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
+  if (ioctl(s, SIOCGIFFLAGS, &ifr) < 0) {
+    fprintf(stderr, "unable to get ifflags for %s!\n", ptr);
     /*
-     * see if this is a loopback interface
+     * should this be fatal? Dunno, let's just assume it's _not_ loopback
      */
-    if ((s = socket(PF_INET, SOCK_RAW, 0)) < 0) {
-        fprintf(stderr, "unable to get raw socket to determine interface flags!\n");
-        free(inf);
-        return;
-    }
-    memset(&ifr, 0, sizeof(ifr));
-    strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
-    if (ioctl(s, SIOCGIFFLAGS, &ifr) < 0) {
-        fprintf(stderr, "unable to get ifflags for %s!\n", ptr);
-        /*
-         * should this be fatal? Dunno, let's just assume it's _not_ loopback
-         */
-        ifr.ifr_flags = 0;
-    }
-    close(s);
-    if (ifr.ifr_flags & IFF_LOOPBACK) {
-        inf->is_loopback = 1;
-    }
-    /*
-     * find a non-busy bpf device
-     */
-    do {
-        (void)snprintf(bpfdev, sizeof(bpfdev), "/dev/bpf%d", bpfnum++);
-        inf->fd = open(bpfdev, O_RDWR);
-    } while (inf->fd < 0 && errno == EBUSY);
-    if (inf->fd < 0) {
-        fprintf(stderr, "error opening bpf device %s!\n", bpfdev);
-        perror("open");
-        exit(1);
-    }
+    ifr.ifr_flags = 0;
+  }
+  close(s);
+  if (ifr.ifr_flags & IFF_LOOPBACK) {
+    inf->is_loopback = 1;
+  }
+  /*
+   * find a non-busy bpf device
+   */
+  do {
+    (void)snprintf(bpfdev, sizeof(bpfdev), "/dev/bpf%d", bpfnum++);
+    inf->fd = open(bpfdev, O_RDWR);
+  } while (inf->fd < 0 && errno == EBUSY);
+  if (inf->fd < 0) {
+    fprintf(stderr, "error opening bpf device %s!\n", bpfdev);
+    perror("open");
+    exit(1);
+  }
 
-    var = 2048;
-    if (ioctl(inf->fd, BIOCSBLEN, &var)) {
-        fprintf(stderr, "can't set bpf buffer length!\n");
-        exit(1);
+  var = 2048;
+  if (ioctl(inf->fd, BIOCSBLEN, &var)) {
+    fprintf(stderr, "can't set bpf buffer length!\n");
+    exit(1);
+  }
+  memset(&ifr, 0, sizeof(ifr));
+  strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
+  printf(
+      "setting bpf%d to interface %s, %s\n",
+      bpfnum - 1,
+      ifr.ifr_name,
+      inf->is_loopback ? "loopback" : "not loopback");
+  if (ioctl(inf->fd, BIOCSETIF, &ifr)) {
+    fprintf(stderr, "unable to set bpf!\n");
+    exit(1);
+  }
+  if (ioctl(inf->fd, BIOCPROMISC, &ifr)) {
+    fprintf(stderr, "can't set bpf to be promiscuous!\n");
+    exit(1);
+  }
+  var = 1;
+  if (ioctl(inf->fd, BIOCIMMEDIATE, &var)) {
+    fprintf(stderr, "can't set bpf to be immediate!\n");
+    exit(1);
+  }
+  if (inf->is_loopback) {
+    var = DLT_NULL;
+    if (ioctl(inf->fd, BIOCSDLT, &var)) {
+      fprintf(stderr, "can't set bpf link layer type!\n");
+      exit(1);
     }
-    memset(&ifr, 0, sizeof(ifr));
-    strlcpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
-    printf("setting bpf%d to interface %s, %s\n", bpfnum-1, ifr.ifr_name,
-           inf->is_loopback ? "loopback" : "not loopback");
-    if (ioctl(inf->fd, BIOCSETIF, &ifr)) {
-        fprintf(stderr, "unable to set bpf!\n");
-        exit(1);
+    bpf_filter.bf_len = sizeof(sim80211) / sizeof(struct bpf_insn);
+    bpf_filter.bf_insns = sim80211;
+    if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
+      fprintf(stderr, "can't set bpf filter!\n");
+      perror("ioctl setting bpf filter");
+      exit(1);
     }
-    if (ioctl(inf->fd, BIOCPROMISC, &ifr)) {
-        fprintf(stderr, "can't set bpf to be promiscuous!\n");
-        exit(1);
+  } else {
+    var = DLT_IEEE802_11;
+    if (ioctl(inf->fd, BIOCSDLT, &var)) {
+      fprintf(stderr, "can't set bpf link layer type!\n");
+      exit(1);
     }
     var = 1;
-    if (ioctl(inf->fd, BIOCIMMEDIATE, &var)) {
-        fprintf(stderr, "can't set bpf to be immediate!\n");
-        exit(1);
+    if (ioctl(inf->fd, BIOCSHDRCMPLT, &var)) {
+      fprintf(stderr, "can't tell bpf we are doing our own headers!\n");
+      exit(1);
     }
-    if (inf->is_loopback) {
-        var = DLT_NULL;
-        if (ioctl(inf->fd, BIOCSDLT, &var)) {
-            fprintf(stderr, "can't set bpf link layer type!\n");
-            exit(1);
-        }
-        bpf_filter.bf_len = sizeof(sim80211) / sizeof(struct bpf_insn);
-        bpf_filter.bf_insns = sim80211;
-        if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
-            fprintf(stderr, "can't set bpf filter!\n");
-            perror("ioctl setting bpf filter");
-            exit(1);
-        }
-    } else {
-        var = DLT_IEEE802_11;
-        if (ioctl(inf->fd, BIOCSDLT, &var)) {
-            fprintf(stderr, "can't set bpf link layer type!\n");
-            exit(1);
-        }
-        var = 1;
-        if (ioctl(inf->fd, BIOCSHDRCMPLT, &var)) {
-            fprintf(stderr, "can't tell bpf we are doing our own headers!\n");
-            exit(1);
-        }
-        bpf_filter.bf_len = sizeof(allofit) / sizeof(struct bpf_insn);
-        bpf_filter.bf_insns = allofit;
-        if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
-            fprintf(stderr, "can't set bpf filter!\n");
-            perror("ioctl setting bpf filter");
-            exit(1);
-        }
+    bpf_filter.bf_len = sizeof(allofit) / sizeof(struct bpf_insn);
+    bpf_filter.bf_insns = allofit;
+    if (ioctl(inf->fd, BIOCSETF, &bpf_filter)) {
+      fprintf(stderr, "can't set bpf filter!\n");
+      perror("ioctl setting bpf filter");
+      exit(1);
     }
-    srv_add_input(srvctx, inf->fd, inf, bpf_in);
-    TAILQ_INSERT_TAIL(&interfaces, inf, entry);
-    return;
+  }
+  srv_add_input(srvctx, inf->fd, inf, bpf_in);
+  TAILQ_INSERT_TAIL(&interfaces, inf, entry);
+  return;
 }
 
-int
-main (int argc, char **argv)
-{
-    int c, ret;
-    struct interface *inf;
-    char confdir[80], conffile[80];
-    char str[80], *ptr;
-    FILE *fp;
+int main(int argc, char **argv) {
+  int c, ret;
+  struct interface *inf;
+  char confdir[80], conffile[80];
+  char str[80], *ptr;
+  FILE *fp;
 
-    strcpy(confdir, "/usr/local/config");
-    for (;;) {
-        c = getopt(argc, argv, "hI:b");
-        if (c < 0) {
-            break;
-        }
-        switch (c) {
-            case 'I':
-                snprintf(confdir, sizeof(confdir), optarg);
-                break;
-            case 'b':
-                /*
-                 * detach from controlling terminal and redirect output to /dev/null.
-                 * meshd will not cd to "/" to allow -I to specify relative directories.
-                 */
-                if (daemon(1, 0)) {
-                    perror("daemon");
-                    fprintf(stderr, "%s: unable to daemonize!\n", argv[0]);
-                    exit(1);
-                }
-                break;
-            default:
-            case 'h':
-                fprintf(stderr, 
-                        "USAGE: %s [-hIb]\n\t-h  show usage, and exit\n"
-                        "\t-I  directory of config files\n"
-                        "\t-b  run in the background\n",
-                        argv[0]);
-                exit(1);
-                
-        }
+  strcpy(confdir, "/usr/local/config");
+  for (;;) {
+    c = getopt(argc, argv, "hI:b");
+    if (c < 0) {
+      break;
     }
-
-    TAILQ_INIT(&interfaces);
-    if ((srvctx = srv_create_context()) == NULL) {
-        fprintf(stderr, "%s: cannot create service context!\n", argv[0]);
+    switch (c) {
+      case 'I':
+        snprintf(confdir, sizeof(confdir), optarg);
+        break;
+      case 'b':
+        /*
+         * detach from controlling terminal and redirect output to /dev/null.
+         * meshd will not cd to "/" to allow -I to specify relative directories.
+         */
+        if (daemon(1, 0)) {
+          perror("daemon");
+          fprintf(stderr, "%s: unable to daemonize!\n", argv[0]);
+          exit(1);
+        }
+        break;
+      default:
+      case 'h':
+        fprintf(
+            stderr,
+            "USAGE: %s [-hIb]\n\t-h  show usage, and exit\n"
+            "\t-I  directory of config files\n"
+            "\t-b  run in the background\n",
+            argv[0]);
         exit(1);
     }
+  }
 
-    /*
-     * put random cruft into the ssid field so if this field is not configured
-     * then we won't print out the SSID.
-     */
-    RAND_pseudo_bytes(mesh_ssid, sizeof(mesh_ssid));
-    snprintf(conffile, sizeof(conffile), "%s/mon.conf", confdir);
-    if ((fp = fopen(conffile, "r")) != NULL) {
-        while (!feof(fp)) {
-            if (fgets(str, sizeof(str), fp) == 0) {
-                continue;
-            }
-            if ((ret = parse_buffer(str, &ptr)) < 0) {
-                break;
-            }
-            if (ret == 0) {
-                continue;
-            }
-            if (strncmp(str, "interface", strlen("interface")) == 0) {
-                add_interface(ptr);
-            }
-            if (strncmp(str, "ssid", strlen("ssid")) == 0) {
-                strcpy(mesh_ssid, ptr);
-            }
-        }
-    }
-
-    if (TAILQ_EMPTY(&interfaces)) {
-        fprintf(stderr, "%s: no interfaces defined!\n", argv[0]);
-    } else {
-        printf("listening on: ");
-        TAILQ_FOREACH(inf, &interfaces, entry) {
-            printf("%s ", inf->ifname);
-        }
-        printf("\n");
-        srv_main_loop(srvctx);
-    }
+  TAILQ_INIT(&interfaces);
+  if ((srvctx = srv_create_context()) == NULL) {
+    fprintf(stderr, "%s: cannot create service context!\n", argv[0]);
     exit(1);
+  }
+
+  /*
+   * put random cruft into the ssid field so if this field is not configured
+   * then we won't print out the SSID.
+   */
+  RAND_pseudo_bytes(mesh_ssid, sizeof(mesh_ssid));
+  snprintf(conffile, sizeof(conffile), "%s/mon.conf", confdir);
+  if ((fp = fopen(conffile, "r")) != NULL) {
+    while (!feof(fp)) {
+      if (fgets(str, sizeof(str), fp) == 0) {
+        continue;
+      }
+      if ((ret = parse_buffer(str, &ptr)) < 0) {
+        break;
+      }
+      if (ret == 0) {
+        continue;
+      }
+      if (strncmp(str, "interface", strlen("interface")) == 0) {
+        add_interface(ptr);
+      }
+      if (strncmp(str, "ssid", strlen("ssid")) == 0) {
+        strcpy(mesh_ssid, ptr);
+      }
+    }
+  }
+
+  if (TAILQ_EMPTY(&interfaces)) {
+    fprintf(stderr, "%s: no interfaces defined!\n", argv[0]);
+  } else {
+    printf("listening on: ");
+    TAILQ_FOREACH(inf, &interfaces, entry) {
+      printf("%s ", inf->ifname);
+    }
+    printf("\n");
+    srv_main_loop(srvctx);
+  }
+  exit(1);
 }

--- a/ieee802_11.h
+++ b/ieee802_11.h
@@ -51,77 +51,78 @@
 /*
  * IEEE does things backwards, networking in non-network order.
  */
-#define ieee_order(x)   (x)                     /* if LE, do nothing */
+#define ieee_order(x) (x) /* if LE, do nothing */
 #else
 
-static inline unsigned short
-ieee_order (unsigned short x)                   /* if BE, byte-swap */
+static inline unsigned short ieee_order(unsigned short x) /* if BE, byte-swap */
 {
-    return ((x & 0xff) << 8) | (x >> 8);
+  return ((x & 0xff) << 8) | (x >> 8);
 }
 
-#endif  /* __LITTLE_ENDIAN */
+#endif /* __LITTLE_ENDIAN */
 
 /*
  * some useful defines...
  */
 
 #ifndef MAC2STR
-#define MAC2STR(a) (a)[0]&0xff, (a)[1]&0xff, (a)[2]&0xff, (a)[3]&0xff, (a)[4]&0xff, (a)[5]&0xff
+#define MAC2STR(a)                                                           \
+  (a)[0] & 0xff, (a)[1] & 0xff, (a)[2] & 0xff, (a)[3] & 0xff, (a)[4] & 0xff, \
+      (a)[5] & 0xff
 #define MACSTR "%02x:%02x:%02x:%02x:%02x:%02x"
 #endif
 
-#define IEEE802_11_FC_GET_TYPE(fc)  (((fc) & 0x000c) >> 2)
-#define IEEE802_11_FC_GET_STYPE(fc) (((fc) & 0x00f0) >> 4)
+#define IEEE802_11_FC_GET_TYPE(fc) (((fc)&0x000c) >> 2)
+#define IEEE802_11_FC_GET_STYPE(fc) (((fc)&0x00f0) >> 4)
 
-#define WLAN_STATUS_SUCCESSFUL                  0
-#define WLAN_STATUS_UNSPECIFIED_FAILURE         1
-#define WLAN_STATUS_AUTHENTICATION_TIMEOUT      16
-#define WLAN_STATUS_REQUEST_DECLINED            37
-#define WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED  76
-#define WLAN_STATUS_NOT_SUPPORTED_GROUP         77
+#define WLAN_STATUS_SUCCESSFUL 0
+#define WLAN_STATUS_UNSPECIFIED_FAILURE 1
+#define WLAN_STATUS_AUTHENTICATION_TIMEOUT 16
+#define WLAN_STATUS_REQUEST_DECLINED 37
+#define WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED 76
+#define WLAN_STATUS_NOT_SUPPORTED_GROUP 77
 
-#define IEEE802_11_IE_SSID                      0
-#define IEEE802_11_HDR_LEN                      24
+#define IEEE802_11_IE_SSID 0
+#define IEEE802_11_HDR_LEN 24
 
-#define ETH_ALEN                                6
+#define ETH_ALEN 6
 
 /* for ht_param */
-#define IEEE80211_HT_PARAM_CHA_SEC_OFFSET               0x03
-#define         IEEE80211_HT_PARAM_CHA_SEC_NONE         0x00
-#define         IEEE80211_HT_PARAM_CHA_SEC_ABOVE        0x01
-#define         IEEE80211_HT_PARAM_CHA_SEC_BELOW        0x03
-#define IEEE80211_HT_PARAM_CHAN_WIDTH_ANY               0x04
+#define IEEE80211_HT_PARAM_CHA_SEC_OFFSET 0x03
+#define IEEE80211_HT_PARAM_CHA_SEC_NONE 0x00
+#define IEEE80211_HT_PARAM_CHA_SEC_ABOVE 0x01
+#define IEEE80211_HT_PARAM_CHA_SEC_BELOW 0x03
+#define IEEE80211_HT_PARAM_CHAN_WIDTH_ANY 0x04
 
 /* for operation_mode */
-#define IEEE80211_HT_OP_MODE_PROTECTION                 0x0003
-#define         IEEE80211_HT_OP_MODE_PROTECTION_NONE            0
-#define         IEEE80211_HT_OP_MODE_PROTECTION_NONMEMBER       1
-#define         IEEE80211_HT_OP_MODE_PROTECTION_20MHZ           2
-#define         IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED     3
-#define IEEE80211_HT_OP_MODE_NON_GF_STA_PRSNT           0x0004
-#define IEEE80211_HT_OP_MODE_NON_HT_STA_PRSNT           0x0010
+#define IEEE80211_HT_OP_MODE_PROTECTION 0x0003
+#define IEEE80211_HT_OP_MODE_PROTECTION_NONE 0
+#define IEEE80211_HT_OP_MODE_PROTECTION_NONMEMBER 1
+#define IEEE80211_HT_OP_MODE_PROTECTION_20MHZ 2
+#define IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED 3
+#define IEEE80211_HT_OP_MODE_NON_GF_STA_PRSNT 0x0004
+#define IEEE80211_HT_OP_MODE_NON_HT_STA_PRSNT 0x0010
 
 /* 802.11n HT capabilities masks (for cap_info) */
-#define IEEE80211_HT_CAP_LDPC_CODING            0x0001
-#define IEEE80211_HT_CAP_SUP_WIDTH_20_40        0x0002
-#define IEEE80211_HT_CAP_SM_PS                  0x000C
-#define         IEEE80211_HT_CAP_SM_PS_SHIFT    2
-#define IEEE80211_HT_CAP_GRN_FLD                0x0010
-#define IEEE80211_HT_CAP_SGI_20                 0x0020
-#define IEEE80211_HT_CAP_SGI_40                 0x0040
-#define IEEE80211_HT_CAP_TX_STBC                0x0080
-#define IEEE80211_HT_CAP_RX_STBC                0x0300
-#define         IEEE80211_HT_CAP_RX_STBC_SHIFT  8
-#define IEEE80211_HT_CAP_DELAY_BA               0x0400
-#define IEEE80211_HT_CAP_MAX_AMSDU              0x0800
-#define IEEE80211_HT_CAP_DSSSCCK40              0x1000
-#define IEEE80211_HT_CAP_RESERVED               0x2000
-#define IEEE80211_HT_CAP_40MHZ_INTOLERANT       0x4000
-#define IEEE80211_HT_CAP_LSIG_TXOP_PROT         0x8000
+#define IEEE80211_HT_CAP_LDPC_CODING 0x0001
+#define IEEE80211_HT_CAP_SUP_WIDTH_20_40 0x0002
+#define IEEE80211_HT_CAP_SM_PS 0x000C
+#define IEEE80211_HT_CAP_SM_PS_SHIFT 2
+#define IEEE80211_HT_CAP_GRN_FLD 0x0010
+#define IEEE80211_HT_CAP_SGI_20 0x0020
+#define IEEE80211_HT_CAP_SGI_40 0x0040
+#define IEEE80211_HT_CAP_TX_STBC 0x0080
+#define IEEE80211_HT_CAP_RX_STBC 0x0300
+#define IEEE80211_HT_CAP_RX_STBC_SHIFT 8
+#define IEEE80211_HT_CAP_DELAY_BA 0x0400
+#define IEEE80211_HT_CAP_MAX_AMSDU 0x0800
+#define IEEE80211_HT_CAP_DSSSCCK40 0x1000
+#define IEEE80211_HT_CAP_RESERVED 0x2000
+#define IEEE80211_HT_CAP_40MHZ_INTOLERANT 0x4000
+#define IEEE80211_HT_CAP_LSIG_TXOP_PROT 0x8000
 
-#define KEY_LEN_AES_CCMP    16
-#define KEY_LEN_AES_CMAC    16
+#define KEY_LEN_AES_CCMP 16
+#define KEY_LEN_AES_CMAC 16
 
 /*
  * all we're interested in is mgmt frames of subtype beacon and auth,
@@ -129,151 +130,147 @@ ieee_order (unsigned short x)                   /* if BE, byte-swap */
  * declare our own minimal one.
  */
 struct ieee80211_mgmt_frame {
-    unsigned short frame_control;
+  unsigned short frame_control;
 #define IEEE802_11_FC_TYPE_MGMT 0
 #define IEEE802_11_FC_STYPE_BEACON 8
 #define IEEE802_11_FC_STYPE_AUTH 11
 #define IEEE802_11_FC_STYPE_ACTION 13
-    unsigned short duration;
-    unsigned char da[ETH_ALEN];
-    unsigned char sa[ETH_ALEN];
-    unsigned char bssid[ETH_ALEN];
-    unsigned short seq;
-    union {
-        struct {
-#define SAE_AUTH_ALG                    3
-            unsigned short alg;
-#define SAE_AUTH_COMMIT                 1
-#define SAE_AUTH_CONFIRM                2
-            unsigned short auth_seq;
-            unsigned short status;
-            union {
-                unsigned char var8[0];
-                unsigned short var16[0];
-            }u;
-        } __attribute__ ((packed)) authenticate;
-        struct {
-            unsigned char timestamp[8];
-            unsigned short interval;
-            unsigned short capabilities;
-            union {
-                unsigned char var8[0];
-                unsigned short var16[0];
-            }u;
-        } __attribute__ ((packed)) beacon;
-        struct {
-            unsigned char category;
-            unsigned char action_code;
-            /* PLINK_OPEN has these fields before IES:*/
-            /*  Capability (2 bytes) */
-            /* PLINK_CONFIRM has these fields before IES:*/
-            /*  Capability (2 bytes) */
-            /*  AID (2 bytes) */
-            /* PLINK_CLOSE has no additional fixed length fields */
-            union {
-                unsigned char var8[0];
-                unsigned short var16[0];
-            }u;
-        } __attribute__ ((packed)) action;
-    };
-} __attribute__ ((packed));
+  unsigned short duration;
+  unsigned char da[ETH_ALEN];
+  unsigned char sa[ETH_ALEN];
+  unsigned char bssid[ETH_ALEN];
+  unsigned short seq;
+  union {
+    struct {
+#define SAE_AUTH_ALG 3
+      unsigned short alg;
+#define SAE_AUTH_COMMIT 1
+#define SAE_AUTH_CONFIRM 2
+      unsigned short auth_seq;
+      unsigned short status;
+      union {
+        unsigned char var8[0];
+        unsigned short var16[0];
+      } u;
+    } __attribute__((packed)) authenticate;
+    struct {
+      unsigned char timestamp[8];
+      unsigned short interval;
+      unsigned short capabilities;
+      union {
+        unsigned char var8[0];
+        unsigned short var16[0];
+      } u;
+    } __attribute__((packed)) beacon;
+    struct {
+      unsigned char category;
+      unsigned char action_code;
+      /* PLINK_OPEN has these fields before IES:*/
+      /*  Capability (2 bytes) */
+      /* PLINK_CONFIRM has these fields before IES:*/
+      /*  Capability (2 bytes) */
+      /*  AID (2 bytes) */
+      /* PLINK_CLOSE has no additional fixed length fields */
+      union {
+        unsigned char var8[0];
+        unsigned short var16[0];
+      } u;
+    } __attribute__((packed)) action;
+  };
+} __attribute__((packed));
 
-enum plink_action_code {
-        PLINK_OPEN = 1,
-        PLINK_CONFIRM,
-        PLINK_CLOSE
-};
+enum plink_action_code { PLINK_OPEN = 1, PLINK_CONFIRM, PLINK_CLOSE };
 
 enum ieee_ie_ids {
-    IEEE80211_EID_SUPPORTED_RATES = 1,
-    IEEE80211_EID_HT_CAPABILITY = 45,
-    IEEE80211_EID_RSN = 48,
-    IEEE80211_EID_EXTENDED_SUP_RATES = 50,
-    IEEE80211_EID_HT_OPERATION = 61,
-    IEEE80211_EID_MESH_CONFIG = 113,
-    IEEE80211_EID_MESH_ID = 114,
-    IEEE80211_EID_MESH_PEERING = 117,
-    IEEE80211_EID_AMPE = 139,
-    IEEE80211_EID_MIC = 140,
+  IEEE80211_EID_SUPPORTED_RATES = 1,
+  IEEE80211_EID_HT_CAPABILITY = 45,
+  IEEE80211_EID_RSN = 48,
+  IEEE80211_EID_EXTENDED_SUP_RATES = 50,
+  IEEE80211_EID_HT_OPERATION = 61,
+  IEEE80211_EID_MESH_CONFIG = 113,
+  IEEE80211_EID_MESH_ID = 114,
+  IEEE80211_EID_MESH_PEERING = 117,
+  IEEE80211_EID_AMPE = 139,
+  IEEE80211_EID_MIC = 140,
 };
 
 enum ieee_categories {
-    IEEE80211_CATEGORY_MESH_ACTION = 13,
-    IEEE80211_CATEGORY_SELF_PROTECTED = 15,
+  IEEE80211_CATEGORY_MESH_ACTION = 13,
+  IEEE80211_CATEGORY_SELF_PROTECTED = 15,
 };
 
 struct ampe_ie {
-    unsigned char selected_pairwise_suite[4];
-    unsigned char local_nonce[32];
-    unsigned char peer_nonce[32];
+  unsigned char selected_pairwise_suite[4];
+  unsigned char local_nonce[32];
+  unsigned char peer_nonce[32];
 
-    /*
-     * Key Replay Counter (optional)
-     * MGTK || Key RSC || Key Expiration (optional)
-     * IGTK KeyID || IPN || IGTK (optional)
-     */
-    unsigned char variable[0];
-} __attribute__ ((packed));
+  /*
+   * Key Replay Counter (optional)
+   * MGTK || Key RSC || Key Expiration (optional)
+   * IGTK KeyID || IPN || IGTK (optional)
+   */
+  unsigned char variable[0];
+} __attribute__((packed));
 
 struct mcs_info {
-    uint8_t rx_mask[10];
-    uint16_t rx_highest;
-    uint8_t tx_params;
-    uint8_t reserved[3];
+  uint8_t rx_mask[10];
+  uint16_t rx_highest;
+  uint8_t tx_params;
+  uint8_t reserved[3];
 } __attribute__((packed));
 
 struct ht_cap_ie {
-    uint16_t cap_info; /* le */
-    uint8_t ampdu_params_info;
+  uint16_t cap_info; /* le */
+  uint8_t ampdu_params_info;
 
-    /* 16 bytes MCS information */
-    struct mcs_info mcs;
+  /* 16 bytes MCS information */
+  struct mcs_info mcs;
 
-    uint16_t extended_ht_cap_info;	/* le */
-    uint32_t tx_BF_cap_info;	/* le */
-    uint8_t antenna_selection_info;
-} __attribute__ ((packed));
+  uint16_t extended_ht_cap_info; /* le */
+  uint32_t tx_BF_cap_info; /* le */
+  uint8_t antenna_selection_info;
+} __attribute__((packed));
 
 struct ht_op_ie {
-    uint8_t primary_chan;
-    uint8_t ht_param;
-    uint16_t operation_mode; /* le */
-    uint16_t stbc_param;	/* le */
-    uint8_t basic_set[16];
-} __attribute__ ((packed));
+  uint8_t primary_chan;
+  uint8_t ht_param;
+  uint16_t operation_mode; /* le */
+  uint16_t stbc_param; /* le */
+  uint8_t basic_set[16];
+} __attribute__((packed));
 
 struct info_elems {
-    unsigned char *sup_rates;
-    unsigned char sup_rates_len;
+  unsigned char *sup_rates;
+  unsigned char sup_rates_len;
 
-    unsigned char *ext_rates;
-    unsigned char ext_rates_len;
+  unsigned char *ext_rates;
+  unsigned char ext_rates_len;
 
-    unsigned char *rsn;
-    unsigned char rsn_len;
+  unsigned char *rsn;
+  unsigned char rsn_len;
 
-    unsigned char *mesh_peering;
-    unsigned char mesh_peering_len;
+  unsigned char *mesh_peering;
+  unsigned char mesh_peering_len;
 
-    unsigned char *mesh_id;
-    unsigned char mesh_id_len;
+  unsigned char *mesh_id;
+  unsigned char mesh_id_len;
 
-    unsigned char *mesh_config;
-    unsigned char mesh_config_len;
+  unsigned char *mesh_config;
+  unsigned char mesh_config_len;
 
-    unsigned char *ht_cap;
-    unsigned char ht_cap_len;
+  unsigned char *ht_cap;
+  unsigned char ht_cap_len;
 
-    unsigned char *ht_info;
-    unsigned char ht_info_len;
+  unsigned char *ht_info;
+  unsigned char ht_info_len;
 
-    struct ampe_ie *ampe;
-    unsigned char ampe_len;
+  struct ampe_ie *ampe;
+  unsigned char ampe_len;
 
-    unsigned char *mic;
-    unsigned char mic_len;
+  unsigned char *mic;
+  unsigned char mic_len;
 };
 
 void parse_ies(unsigned char *start, int len, struct info_elems *elems);
 
-#endif  /* _SAE_FRAME_H_ */
+#endif /* _SAE_FRAME_H_ */

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -45,9 +45,9 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #if defined(__linux__) && !defined(__ANDROID__)
-  #ifdef __GLIBC__
-    #include <execinfo.h>
-  #endif
+#ifdef __GLIBC__
+#include <execinfo.h>
+#endif
 #endif /* defined(__linux__) && !defined(__ANDROID__) */
 
 #include "ampe.h"
@@ -98,843 +98,948 @@ extern unsigned char mgtk_tx[16];
 static struct meshd_config meshd_conf;
 static struct mesh_node mesh;
 
-const char rsn_ie[0x16] = {0x30, /* RSN element ID */
-                       0x14, /* length */
-                       0x1, 0x0, /* Version */
-                       0x0, 0x0F, 0xAC, 0x4, /* CCMP for group cipher suite */
-                       0x1, 0x0,             /* pairwise suite count */
-                       0x0, 0x0F, 0xAC, 0x4, /* CCMP for pairwise cipher suite */
-                       0x1, 0x0,             /* authentication suite count */
-                       0x0, 0x0F, 0xAC, 0x8, /* SAE for authentication */
-                       0x0, 0x0,             /* Capabilities */
-                       };
+const char rsn_ie[0x16] = {
+    0x30, /* RSN element ID */
+    0x14, /* length */
+    0x1,  0x0, /* Version */
+    0x0,  0x0F, 0xAC, 0x4, /* CCMP for group cipher suite */
+    0x1,  0x0, /* pairwise suite count */
+    0x0,  0x0F, 0xAC, 0x4, /* CCMP for pairwise cipher suite */
+    0x1,  0x0, /* authentication suite count */
+    0x0,  0x0F, 0xAC, 0x8, /* SAE for authentication */
+    0x0,  0x0, /* Capabilities */
+};
 
 /* Undo libnl's error code translation.  See nl_syserr2nlerr */
-static void nl2syserr(int error)
-{
-    error = abs(error);
+static void nl2syserr(int error) {
+  error = abs(error);
 
-    switch (error) {
-        case NLE_BAD_SOCK:		fprintf(stderr, "EBADF or ENOTSOCK\n"); break;
-        case NLE_EXIST:			fprintf(stderr, "EADDRINUSE or EEXIST\n"); break;
-        case NLE_NOADDR:		fprintf(stderr, "EADDRNOTAVAIL\n"); break;
-        case NLE_OBJ_NOTFOUND:	fprintf(stderr, "ENOENT\n"); break;
-        case NLE_INTR:			fprintf(stderr, "EINTR\n"); break;
-        case NLE_AGAIN:			fprintf(stderr, "EAGAIN\n"); break;
-        case NLE_INVAL:			fprintf(stderr, "EINVAL, ENOPROTOOPT or EFAULT\n"); break;
-        case NLE_NOACCESS:		fprintf(stderr, "EACCES\n"); break;
-        case NLE_NOMEM:			fprintf(stderr, "ENOMEM or ENOBUFS\n"); break;
-        case NLE_AF_NOSUPPORT:	fprintf(stderr, "EAFNOSUPPORT\n"); break;
-        case NLE_PROTO_MISMATCH:fprintf(stderr, "EPROTONOSUPPORT\n"); break;
-        case NLE_OPNOTSUPP:		fprintf(stderr, "EOPNOTSUPP\n"); break;
-        case NLE_PERM:			fprintf(stderr, "EPERM\n"); break;
-        case NLE_BUSY:			fprintf(stderr, "EBUSY\n"); break;
-        case NLE_RANGE:			fprintf(stderr, "ERANGE\n"); break;
-        default:                fprintf(stderr, "UNKNOWN NL ERROR\n"); break;
-    }
-    return;
+  switch (error) {
+    case NLE_BAD_SOCK:
+      fprintf(stderr, "EBADF or ENOTSOCK\n");
+      break;
+    case NLE_EXIST:
+      fprintf(stderr, "EADDRINUSE or EEXIST\n");
+      break;
+    case NLE_NOADDR:
+      fprintf(stderr, "EADDRNOTAVAIL\n");
+      break;
+    case NLE_OBJ_NOTFOUND:
+      fprintf(stderr, "ENOENT\n");
+      break;
+    case NLE_INTR:
+      fprintf(stderr, "EINTR\n");
+      break;
+    case NLE_AGAIN:
+      fprintf(stderr, "EAGAIN\n");
+      break;
+    case NLE_INVAL:
+      fprintf(stderr, "EINVAL, ENOPROTOOPT or EFAULT\n");
+      break;
+    case NLE_NOACCESS:
+      fprintf(stderr, "EACCES\n");
+      break;
+    case NLE_NOMEM:
+      fprintf(stderr, "ENOMEM or ENOBUFS\n");
+      break;
+    case NLE_AF_NOSUPPORT:
+      fprintf(stderr, "EAFNOSUPPORT\n");
+      break;
+    case NLE_PROTO_MISMATCH:
+      fprintf(stderr, "EPROTONOSUPPORT\n");
+      break;
+    case NLE_OPNOTSUPP:
+      fprintf(stderr, "EOPNOTSUPP\n");
+      break;
+    case NLE_PERM:
+      fprintf(stderr, "EPERM\n");
+      break;
+    case NLE_BUSY:
+      fprintf(stderr, "EBUSY\n");
+      break;
+    case NLE_RANGE:
+      fprintf(stderr, "ERANGE\n");
+      break;
+    default:
+      fprintf(stderr, "UNKNOWN NL ERROR\n");
+      break;
+  }
+  return;
 }
 
-/* copy the phy supported rate set into the mesh conf, and hardcode BSSBasicRateSet
+/* copy the phy supported rate set into the mesh conf, and hardcode
+ * BSSBasicRateSet
  * as the mandatory phy rates for now */
 /* TODO: allow user to configure BSSBasicRateSet */
-static void set_sup_basic_rates(struct meshd_config *mconf,
-                            u16 *rates, int rates_len)
-{
+static void
+set_sup_basic_rates(struct meshd_config *mconf, u16 *rates, int rates_len) {
+  int i, want;
+  char basic = 0x80;
 
-    int i, want;
-    char basic = 0x80;
+  memset(mconf->rates, 0, sizeof(mconf->rates));
+  assert(sizeof(mconf->rates) >= rates_len);
 
-    memset(mconf->rates, 0, sizeof(mconf->rates));
-    assert(sizeof(mconf->rates) >= rates_len);
+  for (i = 0; i < rates_len; i++)
+    /* nl80211 reports in 100kb/s, IEEE 802.11 is 500kb/s */
+    mconf->rates[i] = (uint8_t)(rates[i] / 5);
 
-    for (i = 0; i < rates_len; i++)
-        /* nl80211 reports in 100kb/s, IEEE 802.11 is 500kb/s */
-        mconf->rates[i] = (uint8_t) (rates[i] / 5);
-
-    switch(mconf->band) {
+  switch (mconf->band) {
     case MESHD_11a:
-        want = 3;
-        for (i = 0; i < rates_len; i++) {
-            if (rates[i] == 60 ||
-                rates[i] == 120 ||
-                rates[i] == 240) {
-                    mconf->rates[i] |= basic;
-                    want --;
-            }
+      want = 3;
+      for (i = 0; i < rates_len; i++) {
+        if (rates[i] == 60 || rates[i] == 120 || rates[i] == 240) {
+          mconf->rates[i] |= basic;
+          want--;
         }
-        assert(!want);
-        break;
+      }
+      assert(!want);
+      break;
     case MESHD_11b:
     case MESHD_11g:
-        want = 7;
-        for (i = 0; i < rates_len; i++) {
-            if (rates[i] == 10) {
-                mconf->rates[i] |= basic;
-                want--;
-            }
-
-            if (rates[i] == 20 ||
-                rates[i] == 55 ||
-                rates[i] == 110 ||
-                rates[i] == 60 ||
-                rates[i] == 120 ||
-                rates[i] == 240) {
-                mconf->rates[i] |= basic;
-                want--;
-            }
+      want = 7;
+      for (i = 0; i < rates_len; i++) {
+        if (rates[i] == 10) {
+          mconf->rates[i] |= basic;
+          want--;
         }
-        assert(want == 0 || want == 3 || want == 6);
-        break;
-    }
+
+        if (rates[i] == 20 || rates[i] == 55 || rates[i] == 110 ||
+            rates[i] == 60 || rates[i] == 120 || rates[i] == 240) {
+          mconf->rates[i] |= basic;
+          want--;
+        }
+      }
+      assert(want == 0 || want == 3 || want == 6);
+      break;
+  }
 }
 
-static enum ht_channel_type
-ht_op_to_channel_type(struct ht_op_ie *ht_op)
-{
-    enum nl80211_channel_type channel_type;
+static enum ht_channel_type ht_op_to_channel_type(struct ht_op_ie *ht_op) {
+  enum nl80211_channel_type channel_type;
 
-    if (!ht_op)
-        return CHAN_NO_HT;
+  if (!ht_op)
+    return CHAN_NO_HT;
 
-    switch (ht_op->ht_param & IEEE80211_HT_PARAM_CHA_SEC_OFFSET) {
-        case IEEE80211_HT_PARAM_CHA_SEC_NONE:
-            channel_type = CHAN_HT20;
-            break;
-        case IEEE80211_HT_PARAM_CHA_SEC_ABOVE:
-            channel_type = CHAN_HT40PLUS;
-            break;
-        case IEEE80211_HT_PARAM_CHA_SEC_BELOW:
-            channel_type = CHAN_HT40MINUS;
-            break;
-        default:
-            channel_type = CHAN_NO_HT;
-            break;
-    }
+  switch (ht_op->ht_param & IEEE80211_HT_PARAM_CHA_SEC_OFFSET) {
+    case IEEE80211_HT_PARAM_CHA_SEC_NONE:
+      channel_type = CHAN_HT20;
+      break;
+    case IEEE80211_HT_PARAM_CHA_SEC_ABOVE:
+      channel_type = CHAN_HT40PLUS;
+      break;
+    case IEEE80211_HT_PARAM_CHA_SEC_BELOW:
+      channel_type = CHAN_HT40MINUS;
+      break;
+    default:
+      channel_type = CHAN_NO_HT;
+      break;
+  }
 
-    return channel_type;
+  return channel_type;
 }
 
-static int get_mac_addr(const char * ifname, uint8_t *macaddr)
-{
-    int fd;
-    struct ifreq ifr;
-    fd = socket(AF_INET, SOCK_DGRAM, 0);
+static int get_mac_addr(const char *ifname, uint8_t *macaddr) {
+  int fd;
+  struct ifreq ifr;
+  fd = socket(AF_INET, SOCK_DGRAM, 0);
 
-    ifr.ifr_addr.sa_family = AF_INET;
-    strncpy(ifr.ifr_name, ifname, IFNAMSIZ-1);
+  ifr.ifr_addr.sa_family = AF_INET;
+  strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
 
-    if (ioctl(fd, SIOCGIFHWADDR, &ifr)) {
-        sae_debug(SAE_DEBUG_ERR, "meshd: failed to read MAC address for interface \"%s\": %s\n", ifname, strerror(errno));
-        return -1;
-    }
+  if (ioctl(fd, SIOCGIFHWADDR, &ifr)) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "meshd: failed to read MAC address for interface \"%s\": %s\n",
+        ifname,
+        strerror(errno));
+    return -1;
+  }
 
-    memcpy(macaddr, ifr.ifr_hwaddr.sa_data, ETH_ALEN);
-    close(fd);
+  memcpy(macaddr, ifr.ifr_hwaddr.sa_data, ETH_ALEN);
+  close(fd);
 
-    return 0;
+  return 0;
 }
 
-static void srv_handler_wrapper(int fd, void *data)
-{
-    int err;
-    if ((err = nl_recvmsgs_default((struct nl_sock *) data)) != 0) {
-        nl2syserr(err);
-    }
-    fflush(stdout);
+static void srv_handler_wrapper(int fd, void *data) {
+  int err;
+  if ((err = nl_recvmsgs_default((struct nl_sock *)data)) != 0) {
+    nl2syserr(err);
+  }
+  fflush(stdout);
 }
 
-static int tx_frame(struct netlink_config_s *nlcfg, struct mesh_node *mesh,
-                    unsigned char *frame, int len)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_FRAME;
-    int ret = 0;
-    char *pret;
+static int tx_frame(
+    struct netlink_config_s *nlcfg,
+    struct mesh_node *mesh,
+    unsigned char *frame,
+    int len) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_FRAME;
+  int ret = 0;
+  char *pret;
 
-    sae_debug(MESHD_DEBUG, "%s(%p, %p, %d)\n", __FUNCTION__, nlcfg, frame, len);
-    msg = nlmsg_alloc();
-    if (!msg)
-        return -ENOMEM;
+  sae_debug(MESHD_DEBUG, "%s(%p, %p, %d)\n", __FUNCTION__, nlcfg, frame, len);
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
 
-    if (!frame || !len)
-        return -EINVAL;
+  if (!frame || !len)
+    return -EINVAL;
 
-    pret = genlmsg_put(msg, 0, NL_AUTO_SEQ,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+  pret = genlmsg_put(
+      msg, 0, NL_AUTO_SEQ, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
 
-    if (pret == NULL)
-        goto nla_put_failure;
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-    NLA_PUT_U32(msg, NL80211_ATTR_WIPHY_FREQ, mesh->freq);
-    NLA_PUT(msg, NL80211_ATTR_FRAME, len, frame);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  NLA_PUT_U32(msg, NL80211_ATTR_WIPHY_FREQ, mesh->freq);
+  NLA_PUT(msg, NL80211_ATTR_FRAME, len, frame);
 
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    sae_debug(MESHD_DEBUG, "tx frame (seq num=%d)\n",
-            nlmsg_hdr(msg)->nlmsg_seq);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        sae_debug(MESHD_DEBUG, "tx frame failed: %d (%s)\n", ret,
-                strerror(-ret));
-    else
-        sae_hexdump(MESHD_DEBUG, "tx frame", frame, len);
-    return ret;
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  sae_debug(MESHD_DEBUG, "tx frame (seq num=%d)\n", nlmsg_hdr(msg)->nlmsg_seq);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    sae_debug(MESHD_DEBUG, "tx frame failed: %d (%s)\n", ret, strerror(-ret));
+  else
+    sae_hexdump(MESHD_DEBUG, "tx frame", frame, len);
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-int meshd_write_mgmt(char *buf, int framelen, void *cookie)
-{
-    tx_frame(&nlcfg, &mesh, (unsigned char *) buf, framelen);
-    return framelen;
+int meshd_write_mgmt(char *buf, int framelen, void *cookie) {
+  tx_frame(&nlcfg, &mesh, (unsigned char *)buf, framelen);
+  return framelen;
 }
 
-static int set_mesh_conf(struct netlink_config_s *nlcfg,
-                         struct mesh_node *mesh, uint32_t changed)
-{
+static int set_mesh_conf(
+    struct netlink_config_s *nlcfg,
+    struct mesh_node *mesh,
+    uint32_t changed) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_SET_MESH_CONFIG;
+  int ret = 0;
+  char *pret;
 
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_SET_MESH_CONFIG;
-    int ret = 0;
-    char *pret;
+  sae_debug(MESHD_DEBUG, "%s(%p, %d)\n", __FUNCTION__, nlcfg, changed);
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
 
-    sae_debug(MESHD_DEBUG, "%s(%p, %d)\n", __FUNCTION__, nlcfg, changed);
-    msg = nlmsg_alloc();
-    if (!msg)
-        return -ENOMEM;
+  pret = genlmsg_put(
+      msg, 0, NL_AUTO_SEQ, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
 
-    pret = genlmsg_put(msg, 0, NL_AUTO_SEQ,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    if (pret == NULL)
-        goto nla_put_failure;
+  struct nlattr *container = nla_nest_start(msg, NL80211_ATTR_MESH_CONFIG);
 
-    struct nlattr *container = nla_nest_start(msg,
-            NL80211_ATTR_MESH_CONFIG);
+  if (!container)
+    goto nla_put_failure;
 
-    if (!container)
-        goto nla_put_failure;
+  if (changed & MESH_CONF_CHANGED_HT)
+    NLA_PUT_U16(msg, NL80211_MESHCONF_HT_OPMODE, mesh->conf->ht_prot_mode);
+  nla_nest_end(msg, container);
 
-    if (changed & MESH_CONF_CHANGED_HT)
-        NLA_PUT_U16(msg, NL80211_MESHCONF_HT_OPMODE, mesh->conf->ht_prot_mode);
-    nla_nest_end(msg, container);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
 
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    sae_debug(MESHD_DEBUG, "set meshconf (seq num=%d)\n",
-            nlmsg_hdr(msg)->nlmsg_seq);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        sae_debug(MESHD_DEBUG, "set meshconf failed: %d (%s)\n", ret,
-                strerror(-ret));
-    return ret;
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  sae_debug(
+      MESHD_DEBUG, "set meshconf (seq num=%d)\n", nlmsg_hdr(msg)->nlmsg_seq);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    sae_debug(
+        MESHD_DEBUG, "set meshconf failed: %d (%s)\n", ret, strerror(-ret));
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-int meshd_set_mesh_conf(struct mesh_node *mesh, uint32_t changed)
-{
-    return set_mesh_conf(&nlcfg, mesh, changed);
+int meshd_set_mesh_conf(struct mesh_node *mesh, uint32_t changed) {
+  return set_mesh_conf(&nlcfg, mesh, changed);
 }
 
-static int handle_del_peer(struct netlink_config_s *nlcfg,
-        struct nl_msg *msg, void *arg)
-{
-    struct nlattr *tb[NL80211_ATTR_MAX + 1];
-    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-    struct candidate *peer;
+static int
+handle_del_peer(struct netlink_config_s *nlcfg, struct nl_msg *msg, void *arg) {
+  struct nlattr *tb[NL80211_ATTR_MAX + 1];
+  struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+  struct candidate *peer;
 
-    nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-            genlmsg_attrlen(gnlh, 0), NULL);
+  nla_parse(
+      tb,
+      NL80211_ATTR_MAX,
+      genlmsg_attrdata(gnlh, 0),
+      genlmsg_attrlen(gnlh, 0),
+      NULL);
 
-    if (nla_get_u32(tb[NL80211_ATTR_IFINDEX]) != nlcfg->ifindex)
-        return -1;
+  if (nla_get_u32(tb[NL80211_ATTR_IFINDEX]) != nlcfg->ifindex)
+    return -1;
 
-    if (!tb[NL80211_ATTR_MAC] || nla_len(tb[NL80211_ATTR_MAC]) != ETH_ALEN)
-        return -1;
+  if (!tb[NL80211_ATTR_MAC] || nla_len(tb[NL80211_ATTR_MAC]) != ETH_ALEN)
+    return -1;
 
-    if ((peer = find_peer(nla_data(tb[NL80211_ATTR_MAC]), 0)))
-         delete_peer(&peer);
+  if ((peer = find_peer(nla_data(tb[NL80211_ATTR_MAC]), 0)))
+    delete_peer(&peer);
 
-	return 0;
+  return 0;
 }
 
-static int handle_wiphy(struct mesh_node *mesh, struct nl_msg *msg, void *arg)
-{
-    struct nlattr *tb[NL80211_ATTR_MAX + 1];
-    struct nlattr *tb_band[NL80211_BAND_ATTR_MAX + 1];
-    struct nlattr *nl_band, *nl_rate;
-    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-    struct ieee80211_supported_band *lband;
-    int rem_band, rem_rate, n_rates = 0;
-    enum ieee80211_band band;
-    uint16_t sup_rates[MAX_SUPP_RATES] = { 0 };
-    struct nlattr *tb_rate[NL80211_BITRATE_ATTR_MAX + 1];
-    static struct nla_policy rate_policy[NL80211_BITRATE_ATTR_MAX + 1] = {
-        [NL80211_BITRATE_ATTR_RATE] = { .type = NLA_U32 },
-        [NL80211_BITRATE_ATTR_2GHZ_SHORTPREAMBLE] = { .type = NLA_FLAG },
-    };
+static int handle_wiphy(struct mesh_node *mesh, struct nl_msg *msg, void *arg) {
+  struct nlattr *tb[NL80211_ATTR_MAX + 1];
+  struct nlattr *tb_band[NL80211_BAND_ATTR_MAX + 1];
+  struct nlattr *nl_band, *nl_rate;
+  struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+  struct ieee80211_supported_band *lband;
+  int rem_band, rem_rate, n_rates = 0;
+  enum ieee80211_band band;
+  uint16_t sup_rates[MAX_SUPP_RATES] = {0};
+  struct nlattr *tb_rate[NL80211_BITRATE_ATTR_MAX + 1];
+  static struct nla_policy rate_policy[NL80211_BITRATE_ATTR_MAX + 1] = {
+          [NL80211_BITRATE_ATTR_RATE] = {.type = NLA_U32},
+          [NL80211_BITRATE_ATTR_2GHZ_SHORTPREAMBLE] = {.type = NLA_FLAG},
+  };
 
-    nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-            genlmsg_attrlen(gnlh, 0), NULL);
+  nla_parse(
+      tb,
+      NL80211_ATTR_MAX,
+      genlmsg_attrdata(gnlh, 0),
+      genlmsg_attrlen(gnlh, 0),
+      NULL);
 
-    if (!tb[NL80211_ATTR_WIPHY_BANDS])
-        return -1;
+  if (!tb[NL80211_ATTR_WIPHY_BANDS])
+    return -1;
 
-    nla_for_each_nested(nl_band, tb[NL80211_ATTR_WIPHY_BANDS], rem_band) {
+  nla_for_each_nested(nl_band, tb[NL80211_ATTR_WIPHY_BANDS], rem_band) {
+    band = nl_band->nla_type;
+    lband = &mesh->bands[band];
 
-        band = nl_band->nla_type;
-        lband = &mesh->bands[band];
+    nla_parse(
+        tb_band,
+        NL80211_BAND_ATTR_MAX,
+        nla_data(nl_band),
+        nla_len(nl_band),
+        NULL);
 
-        nla_parse(tb_band, NL80211_BAND_ATTR_MAX,
-                  nla_data(nl_band), nla_len(nl_band), NULL);
-
-        if (tb_band[NL80211_BAND_ATTR_HT_MCS_SET]) {
-            assert(sizeof(lband->ht_cap.mcs) == nla_len(tb_band[NL80211_BAND_ATTR_HT_MCS_SET]));
-            lband->ht_cap.ht_supported = true;
-            memcpy(&lband->ht_cap.mcs,
-                   nla_data(tb_band[NL80211_BAND_ATTR_HT_MCS_SET]),
-                   nla_len(tb_band[NL80211_BAND_ATTR_HT_MCS_SET]));
-            lband->ht_cap.cap = nla_get_u16(tb_band[NL80211_BAND_ATTR_HT_CAPA]);
-            lband->ht_cap.ampdu_factor = nla_get_u8(tb_band[NL80211_BAND_ATTR_HT_AMPDU_FACTOR]);
-            lband->ht_cap.ampdu_density = nla_get_u8(tb_band[NL80211_BAND_ATTR_HT_AMPDU_DENSITY]);
-        }
-
-        n_rates = 0;
-        nla_for_each_nested(nl_rate, tb_band[NL80211_BAND_ATTR_RATES], rem_rate) {
-            nla_parse(tb_rate, NL80211_BITRATE_ATTR_MAX, nla_data(nl_rate),
-                    nla_len(nl_rate), rate_policy);
-            if (!tb_rate[NL80211_BITRATE_ATTR_RATE])
-                continue;
-            sup_rates[n_rates] = nla_get_u32(tb_rate[NL80211_BITRATE_ATTR_RATE]);
-            n_rates++;
-        }
-
-        if (n_rates) {
-            lband->rates = malloc(n_rates * 2);	// lband->rates is 16bit
-            if (!lband->rates)
-                return -ENOMEM;
-            memcpy(lband->rates, sup_rates, n_rates * 2);
-            lband->n_bitrates = n_rates;
-        }
+    if (tb_band[NL80211_BAND_ATTR_HT_MCS_SET]) {
+      assert(
+          sizeof(lband->ht_cap.mcs) ==
+          nla_len(tb_band[NL80211_BAND_ATTR_HT_MCS_SET]));
+      lband->ht_cap.ht_supported = true;
+      memcpy(
+          &lband->ht_cap.mcs,
+          nla_data(tb_band[NL80211_BAND_ATTR_HT_MCS_SET]),
+          nla_len(tb_band[NL80211_BAND_ATTR_HT_MCS_SET]));
+      lband->ht_cap.cap = nla_get_u16(tb_band[NL80211_BAND_ATTR_HT_CAPA]);
+      lband->ht_cap.ampdu_factor =
+          nla_get_u8(tb_band[NL80211_BAND_ATTR_HT_AMPDU_FACTOR]);
+      lband->ht_cap.ampdu_density =
+          nla_get_u8(tb_band[NL80211_BAND_ATTR_HT_AMPDU_DENSITY]);
     }
-	return 0;
-}
 
-static int add_unauthenticated_sta(struct netlink_config_s *nlcfg,
-                                   unsigned char *peer,
-                                   struct info_elems *elems)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_NEW_STATION;
-    int ret;
-    char *pret;
-    struct nl80211_sta_flag_update flags;
+    n_rates = 0;
+    nla_for_each_nested(nl_rate, tb_band[NL80211_BAND_ATTR_RATES], rem_rate) {
+      nla_parse(
+          tb_rate,
+          NL80211_BITRATE_ATTR_MAX,
+          nla_data(nl_rate),
+          nla_len(nl_rate),
+          rate_policy);
+      if (!tb_rate[NL80211_BITRATE_ATTR_RATE])
+        continue;
+      sup_rates[n_rates] = nla_get_u32(tb_rate[NL80211_BITRATE_ATTR_RATE]);
+      n_rates++;
+    }
 
-    if (!peer)
-        return -EINVAL;
-
-    msg = nlmsg_alloc();
-
-    if (!msg)
+    if (n_rates) {
+      lband->rates = malloc(n_rates * 2); // lband->rates is 16bit
+      if (!lband->rates)
         return -ENOMEM;
-
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
-
-    if (pret == NULL)
-        goto nla_put_failure;
-
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-    NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
-
-    if (elems->sup_rates) {
-        NLA_PUT(msg, NL80211_ATTR_STA_SUPPORTED_RATES, elems->sup_rates_len,
-                elems->sup_rates);
+      memcpy(lband->rates, sup_rates, n_rates * 2);
+      lband->n_bitrates = n_rates;
     }
-
-    flags.mask = (1 << NL80211_STA_FLAG_AUTHENTICATED) |
-                 (1 << NL80211_STA_FLAG_WME);
-    flags.set = (1 << NL80211_STA_FLAG_WME);
-
-    NLA_PUT(msg, NL80211_ATTR_STA_FLAGS2, sizeof(flags), &flags);
-
-    uint16_t peer_aid = find_peer(peer, /* accept */ 0)->association_id;
-    NLA_PUT_U16(msg, NL80211_ATTR_STA_AID, peer_aid);
-
-    NLA_PUT_U16(msg, NL80211_ATTR_STA_LISTEN_INTERVAL, 100);
-
-    /* unset 20/40mhz in ht_cap if ht op ie indicates this is a 20mhz STA */
-    if (elems->ht_info &&
-        !(((struct ht_op_ie *) elems->ht_info)->ht_param & IEEE80211_HT_PARAM_CHAN_WIDTH_ANY))
-            ((struct ht_cap_ie *) elems->ht_cap)->cap_info &= ~IEEE80211_HT_CAP_SUP_WIDTH_20_40;
-
-    if (elems->ht_cap)
-        NLA_PUT(msg, NL80211_ATTR_HT_CAPABILITY, elems->ht_cap_len, elems->ht_cap);
-
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    sae_debug(MESHD_DEBUG, "new unauthed sta (seq num=%d)\n",
-            nlmsg_hdr(msg)->nlmsg_seq);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        fprintf(stderr, "add station failed: %d (%s)\n", ret, strerror(-ret));
-    else
-        ret = 0;
-
-    return ret;
-nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  }
+  return 0;
 }
 
-static int new_candidate_handler(struct nl_msg *msg, void *arg)
-{
-    struct nlattr *tb[NL80211_ATTR_MAX + 1];
-    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-    unsigned char *ie;
-    size_t ie_len;
-    struct ieee80211_mgmt_frame bcn;
-    struct info_elems elems;
-    struct candidate *peer;
+static int add_unauthenticated_sta(
+    struct netlink_config_s *nlcfg,
+    unsigned char *peer,
+    struct info_elems *elems) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_NEW_STATION;
+  int ret;
+  char *pret;
+  struct nl80211_sta_flag_update flags;
 
-    /* check that all the required info exists: source address
-     * (arrives as bssid), meshid, mesh config(TODO!) and RSN
-     * */
-    nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-            genlmsg_attrlen(gnlh, 0), NULL);
+  if (!peer)
+    return -EINVAL;
 
-    if (!tb[NL80211_ATTR_MAC] || !tb[NL80211_ATTR_IE])
-        return NL_SKIP;
+  msg = nlmsg_alloc();
 
-    ie = nla_data(tb[NL80211_ATTR_IE]);
-    ie_len = nla_len(tb[NL80211_ATTR_IE]);
+  if (!msg)
+    return -ENOMEM;
 
-    parse_ies(ie, ie_len, &elems);
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
 
-    if (elems.mesh_id == NULL || elems.mesh_id_len != meshd_conf.meshid_len ||
-            memcmp(elems.mesh_id, meshd_conf.meshid, meshd_conf.meshid_len) != 0) {
-        sae_debug(MESHD_DEBUG, "Candidate from different Mesh ID\n");
-        return NL_SKIP;
-    }
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    if (!elems.rsn && meshd_conf.is_secure) {
-        sae_debug(MESHD_DEBUG, "No RSN IE from this candidate\n");
-        return NL_SKIP;
-    }
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
 
-    memset(&bcn, 0, sizeof(bcn));
-    bcn.frame_control = htole16(
-            (IEEE802_11_FC_TYPE_MGMT << 2 |
-             IEEE802_11_FC_STYPE_BEACON << 4));
-    memcpy(bcn.sa, nla_data(tb[NL80211_ATTR_MAC]), ETH_ALEN);
+  if (elems->sup_rates) {
+    NLA_PUT(
+        msg,
+        NL80211_ATTR_STA_SUPPORTED_RATES,
+        elems->sup_rates_len,
+        elems->sup_rates);
+  }
 
-    if (process_mgmt_frame(&bcn, sizeof(bcn), mesh.mymacaddr, &nlcfg, !meshd_conf.is_secure) != 0) {
-        fprintf(stderr, "libsae: process_mgmt_frame failed\n");
-        return NL_SKIP;
-    }
+  flags.mask =
+      (1 << NL80211_STA_FLAG_AUTHENTICATED) | (1 << NL80211_STA_FLAG_WME);
+  flags.set = (1 << NL80211_STA_FLAG_WME);
 
-    /* if peer now exists, we know it was created by process_mgmt_frame, or if
-     * we received two NEW_PEER_CANDIDATE events for the same peer, this will fail
-     */
-    if ((peer = find_peer(bcn.sa, 0))) {
-        peer->ch_type = ht_op_to_channel_type((struct ht_op_ie *) elems.ht_info);
-        if (!peer->in_kernel &&
-            add_unauthenticated_sta(&nlcfg, bcn.sa, &elems) == 0) {
-            peer->in_kernel = true;
-        }
-    }
+  NLA_PUT(msg, NL80211_ATTR_STA_FLAGS2, sizeof(flags), &flags);
 
+  uint16_t peer_aid = find_peer(peer, /* accept */ 0)->association_id;
+  NLA_PUT_U16(msg, NL80211_ATTR_STA_AID, peer_aid);
+
+  NLA_PUT_U16(msg, NL80211_ATTR_STA_LISTEN_INTERVAL, 100);
+
+  /* unset 20/40mhz in ht_cap if ht op ie indicates this is a 20mhz STA */
+  if (elems->ht_info &&
+      !(((struct ht_op_ie *)elems->ht_info)->ht_param &
+        IEEE80211_HT_PARAM_CHAN_WIDTH_ANY))
+    ((struct ht_cap_ie *)elems->ht_cap)->cap_info &=
+        ~IEEE80211_HT_CAP_SUP_WIDTH_20_40;
+
+  if (elems->ht_cap)
+    NLA_PUT(msg, NL80211_ATTR_HT_CAPABILITY, elems->ht_cap_len, elems->ht_cap);
+
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  sae_debug(
+      MESHD_DEBUG,
+      "new unauthed sta (seq num=%d)\n",
+      nlmsg_hdr(msg)->nlmsg_seq);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    fprintf(stderr, "add station failed: %d (%s)\n", ret, strerror(-ret));
+  else
+    ret = 0;
+
+  return ret;
+nla_put_failure:
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
+}
+
+static int new_candidate_handler(struct nl_msg *msg, void *arg) {
+  struct nlattr *tb[NL80211_ATTR_MAX + 1];
+  struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+  unsigned char *ie;
+  size_t ie_len;
+  struct ieee80211_mgmt_frame bcn;
+  struct info_elems elems;
+  struct candidate *peer;
+
+  /* check that all the required info exists: source address
+   * (arrives as bssid), meshid, mesh config(TODO!) and RSN
+   * */
+  nla_parse(
+      tb,
+      NL80211_ATTR_MAX,
+      genlmsg_attrdata(gnlh, 0),
+      genlmsg_attrlen(gnlh, 0),
+      NULL);
+
+  if (!tb[NL80211_ATTR_MAC] || !tb[NL80211_ATTR_IE])
     return NL_SKIP;
-}
 
-static int register_for_plink_frames(struct netlink_config_s *nlcfg)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_REGISTER_FRAME;
-    int i;
-#define IEEE80211_FTYPE_MGMT            0x0000
-#define IEEE80211_STYPE_ACTION          0x00D0
-    uint16_t frame_type = IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ACTION;
-    int ret = 0;
-    char *pret;
-    char action_codes[3][2] = {{15, 1 }, {15, 2}, {15, 3}};  /* 11s draft 10.0, Table 7-24, Self-Protected */
+  ie = nla_data(tb[NL80211_ATTR_IE]);
+  ie_len = nla_len(tb[NL80211_ATTR_IE]);
 
-    for (i = 0; i < 3; i++) {
-        msg = nlmsg_alloc();
-        if (!msg)
-            return -ENOMEM;
+  parse_ies(ie, ie_len, &elems);
 
-        pret = genlmsg_put(msg, 0, 0,
-                genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
-        if (pret == NULL)
-            goto nla_put_failure;
+  if (elems.mesh_id == NULL || elems.mesh_id_len != meshd_conf.meshid_len ||
+      memcmp(elems.mesh_id, meshd_conf.meshid, meshd_conf.meshid_len) != 0) {
+    sae_debug(MESHD_DEBUG, "Candidate from different Mesh ID\n");
+    return NL_SKIP;
+  }
 
-        NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-        NLA_PUT_U16(msg, NL80211_ATTR_FRAME_TYPE, frame_type);
-        NLA_PUT(msg, NL80211_ATTR_FRAME_MATCH, sizeof(action_codes[i]), action_codes[i]);
+  if (!elems.rsn && meshd_conf.is_secure) {
+    sae_debug(MESHD_DEBUG, "No RSN IE from this candidate\n");
+    return NL_SKIP;
+  }
 
-        ret = send_nlmsg(nlcfg->nl_sock, msg);
-        nlmsg_free(msg);
-        msg = NULL;
-        if (ret < 0)
-            fprintf(stderr ,"Registering for auth frames failed: %d (%s)\n", ret,
-                    strerror(-ret));
-        else
-            ret = 0;
+  memset(&bcn, 0, sizeof(bcn));
+  bcn.frame_control =
+      htole16((IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_BEACON << 4));
+  memcpy(bcn.sa, nla_data(tb[NL80211_ATTR_MAC]), ETH_ALEN);
+
+  if (process_mgmt_frame(
+          &bcn, sizeof(bcn), mesh.mymacaddr, &nlcfg, !meshd_conf.is_secure) !=
+      0) {
+    fprintf(stderr, "libsae: process_mgmt_frame failed\n");
+    return NL_SKIP;
+  }
+
+  /* if peer now exists, we know it was created by process_mgmt_frame, or if
+   * we received two NEW_PEER_CANDIDATE events for the same peer, this will fail
+   */
+  if ((peer = find_peer(bcn.sa, 0))) {
+    peer->ch_type = ht_op_to_channel_type((struct ht_op_ie *)elems.ht_info);
+    if (!peer->in_kernel &&
+        add_unauthenticated_sta(&nlcfg, bcn.sa, &elems) == 0) {
+      peer->in_kernel = true;
     }
+  }
 
-    return ret;
-nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  return NL_SKIP;
 }
 
-static int register_for_auth_frames(struct netlink_config_s *nlcfg)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_REGISTER_FRAME;
-#define IEEE80211_FTYPE_MGMT            0x0000
-#define IEEE80211_STYPE_AUTH            0x00B0
-    uint16_t frame_type = IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_AUTH;
-    int ret;
-    char *pret;
-    char auth_algo[1] = { 0x3 };     /* SAE */
+static int register_for_plink_frames(struct netlink_config_s *nlcfg) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_REGISTER_FRAME;
+  int i;
+#define IEEE80211_FTYPE_MGMT 0x0000
+#define IEEE80211_STYPE_ACTION 0x00D0
+  uint16_t frame_type = IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ACTION;
+  int ret = 0;
+  char *pret;
+  char action_codes[3][2] = {
+      {15, 1},
+      {15, 2},
+      {15, 3}}; /* 11s draft 10.0, Table 7-24, Self-Protected */
 
+  for (i = 0; i < 3; i++) {
     msg = nlmsg_alloc();
     if (!msg)
-        return -ENOMEM;
+      return -ENOMEM;
 
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+    pret = genlmsg_put(
+        msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
     if (pret == NULL)
-        goto nla_put_failure;
+      goto nla_put_failure;
 
     NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
     NLA_PUT_U16(msg, NL80211_ATTR_FRAME_TYPE, frame_type);
-    NLA_PUT(msg, NL80211_ATTR_FRAME_MATCH, sizeof(auth_algo), auth_algo);
+    NLA_PUT(
+        msg,
+        NL80211_ATTR_FRAME_MATCH,
+        sizeof(action_codes[i]),
+        action_codes[i]);
 
     ret = send_nlmsg(nlcfg->nl_sock, msg);
     nlmsg_free(msg);
     msg = NULL;
     if (ret < 0)
-        fprintf(stderr ,"Registering for auth frames failed: %d (%s)\n", ret,
-                strerror(-ret));
+      fprintf(
+          stderr,
+          "Registering for auth frames failed: %d (%s)\n",
+          ret,
+          strerror(-ret));
     else
-        ret = 0;
+      ret = 0;
+  }
 
-    return ret;
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-static int get_wiphy(struct netlink_config_s *nlcfg)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_GET_WIPHY;
-    int ret;
-    char *pret;
+static int register_for_auth_frames(struct netlink_config_s *nlcfg) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_REGISTER_FRAME;
+#define IEEE80211_FTYPE_MGMT 0x0000
+#define IEEE80211_STYPE_AUTH 0x00B0
+  uint16_t frame_type = IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_AUTH;
+  int ret;
+  char *pret;
+  char auth_algo[1] = {0x3}; /* SAE */
 
-    assert(nlcfg);
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
 
-    msg = nlmsg_alloc();
-    if (!msg)
-        return -ENOMEM;
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, NLM_F_REQUEST, cmd, 0);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  NLA_PUT_U16(msg, NL80211_ATTR_FRAME_TYPE, frame_type);
+  NLA_PUT(msg, NL80211_ATTR_FRAME_MATCH, sizeof(auth_algo), auth_algo);
 
-    if (pret == NULL)
-        goto nla_put_failure;
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    fprintf(
+        stderr,
+        "Registering for auth frames failed: %d (%s)\n",
+        ret,
+        strerror(-ret));
+  else
+    ret = 0;
 
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        sae_debug(MESHD_DEBUG, "get wiphy failed: %d (%s)\n", ret,
-                strerror(-ret));
-    return ret;
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-static int install_key(struct netlink_config_s *nlcfg, unsigned char *peer, unsigned int cipher, unsigned int keytype, unsigned char keyidx, unsigned char *keydata)
-{
-    struct nl_msg *msg, *key=NULL;
-    uint8_t cmd = NL80211_CMD_NEW_KEY;
-    int ret;
-    char *pret;
-    unsigned char seq[6] = { 0 };
+static int get_wiphy(struct netlink_config_s *nlcfg) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_GET_WIPHY;
+  int ret;
+  char *pret;
 
-    assert(nlcfg);
+  assert(nlcfg);
 
-    msg = nlmsg_alloc();
-    if (!msg)
-        return -ENOMEM;
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
 
-    key = nlmsg_alloc();
-    if (!key)
-        goto nla_put_failure;
+  pret = genlmsg_put(
+      msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, NLM_F_REQUEST, cmd, 0);
 
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    if (pret == NULL)
-        goto nla_put_failure;
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
 
-    NLA_PUT_U32(key, NL80211_KEY_CIPHER, cipher);
-    NLA_PUT(key, NL80211_KEY_DATA, 16, keydata);
-    NLA_PUT_U8(key, NL80211_KEY_IDX, keyidx);
-    NLA_PUT(key, NL80211_KEY_SEQ, 6, seq);
-    NLA_PUT_U32(key, NL80211_KEY_TYPE, keytype);
-    ret = nla_put_nested(msg, NL80211_ATTR_KEY, key);
-    if (ret)
-        goto nla_put_failure;
-
-    nlmsg_free(key);
-    key = NULL;
-
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-    if (peer)
-        NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
-
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        sae_debug(MESHD_DEBUG, "install mesh keys failed: %d (%s)\n", ret,
-                strerror(-ret));
-
-    if (peer)
-        return 0;
-
-    msg = nlmsg_alloc();
-    if (!msg)
-        return -ENOMEM;
-
-    cmd = NL80211_CMD_SET_KEY;
-
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
-
-    if (pret == NULL)
-        goto nla_put_failure;
-
-    if (cipher == CIPHER_AES_CMAC)
-        NLA_PUT_FLAG(msg, NL80211_ATTR_KEY_DEFAULT_MGMT);
-    else
-        NLA_PUT_FLAG(msg, NL80211_ATTR_KEY_DEFAULT);
-
-    NLA_PUT_U8(msg, NL80211_ATTR_KEY_IDX, keyidx);
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        sae_debug(MESHD_DEBUG, "install mesh keys failed: %d (%s)\n", ret,
-                strerror(-ret));
-    return ret;
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    sae_debug(MESHD_DEBUG, "get wiphy failed: %d (%s)\n", ret, strerror(-ret));
+  return ret;
 nla_put_failure:
-    nlmsg_free(key);
-    nlmsg_free(msg);
-    key = NULL;
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-static void usage(void)
-{
-    sae_debug(SAE_DEBUG_ERR, "\n\n"
-"usage: meshd-nl80211 [options]\n\n"
-"    -h               print this message\n"
-"    -c <conffile>    configuration file (see authsae.sample.conf for example)\n"
-"    -o <outfile>     output log file\n"
-"    -B               run in the background (i.e., daemonize)\n"
-"    -i <interface>   override interface value in config file\n"
-"    -s <meshid>      override mesh id provided in config file\n"
-"\n"
-);
+static int install_key(
+    struct netlink_config_s *nlcfg,
+    unsigned char *peer,
+    unsigned int cipher,
+    unsigned int keytype,
+    unsigned char keyidx,
+    unsigned char *keydata) {
+  struct nl_msg *msg, *key = NULL;
+  uint8_t cmd = NL80211_CMD_NEW_KEY;
+  int ret;
+  char *pret;
+  unsigned char seq[6] = {0};
+
+  assert(nlcfg);
+
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
+
+  key = nlmsg_alloc();
+  if (!key)
+    goto nla_put_failure;
+
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+
+  if (pret == NULL)
+    goto nla_put_failure;
+
+  NLA_PUT_U32(key, NL80211_KEY_CIPHER, cipher);
+  NLA_PUT(key, NL80211_KEY_DATA, 16, keydata);
+  NLA_PUT_U8(key, NL80211_KEY_IDX, keyidx);
+  NLA_PUT(key, NL80211_KEY_SEQ, 6, seq);
+  NLA_PUT_U32(key, NL80211_KEY_TYPE, keytype);
+  ret = nla_put_nested(msg, NL80211_ATTR_KEY, key);
+  if (ret)
+    goto nla_put_failure;
+
+  nlmsg_free(key);
+  key = NULL;
+
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  if (peer)
+    NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
+
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    sae_debug(
+        MESHD_DEBUG,
+        "install mesh keys failed: %d (%s)\n",
+        ret,
+        strerror(-ret));
+
+  if (peer)
+    return 0;
+
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
+
+  cmd = NL80211_CMD_SET_KEY;
+
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+
+  if (pret == NULL)
+    goto nla_put_failure;
+
+  if (cipher == CIPHER_AES_CMAC)
+    NLA_PUT_FLAG(msg, NL80211_ATTR_KEY_DEFAULT_MGMT);
+  else
+    NLA_PUT_FLAG(msg, NL80211_ATTR_KEY_DEFAULT);
+
+  NLA_PUT_U8(msg, NL80211_ATTR_KEY_IDX, keyidx);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    sae_debug(
+        MESHD_DEBUG,
+        "install mesh keys failed: %d (%s)\n",
+        ret,
+        strerror(-ret));
+  return ret;
+nla_put_failure:
+  nlmsg_free(key);
+  nlmsg_free(msg);
+  key = NULL;
+  msg = NULL;
+  return -ENOBUFS;
+}
+
+static void usage(void) {
+  sae_debug(
+      SAE_DEBUG_ERR,
+      "\n\n"
+      "usage: meshd-nl80211 [options]\n\n"
+      "    -h               print this message\n"
+      "    -c <conffile>    configuration file (see authsae.sample.conf for "
+      "example)\n"
+      "    -o <outfile>     output log file\n"
+      "    -B               run in the background (i.e., daemonize)\n"
+      "    -i <interface>   override interface value in config file\n"
+      "    -s <meshid>      override mesh id provided in config file\n"
+      "\n");
 }
 
 static int init(struct netlink_config_s *nlcfg, struct mesh_node *mesh);
 
-static int event_handler(struct nl_msg *msg, void *arg)
-{
-    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-    struct nlattr *tb[NL80211_ATTR_MAX + 1];
-    struct ieee80211_mgmt_frame *frame;
-    int frame_len;
-    unsigned short frame_control;
-    struct timeval now;
+static int event_handler(struct nl_msg *msg, void *arg) {
+  struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+  struct nlattr *tb[NL80211_ATTR_MAX + 1];
+  struct ieee80211_mgmt_frame *frame;
+  int frame_len;
+  unsigned short frame_control;
+  struct timeval now;
 
-    gettimeofday(&now, NULL);
+  gettimeofday(&now, NULL);
 
-    nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-            genlmsg_attrlen(gnlh, 0), NULL);
+  nla_parse(
+      tb,
+      NL80211_ATTR_MAX,
+      genlmsg_attrdata(gnlh, 0),
+      genlmsg_attrlen(gnlh, 0),
+      NULL);
 
-    /* Ignore events for other interfaces */
-    if (tb[NL80211_ATTR_IFINDEX] && nlcfg.ifindex != *(uint32_t *)nla_data(tb[NL80211_ATTR_IFINDEX]))
-        return NL_SKIP;
-
-    switch (gnlh->cmd) {
-	    /* test */
-        case NL80211_CMD_NEW_WIPHY:
-            assert(tb[NL80211_ATTR_SUPPORT_MESH_AUTH]);
-            if (handle_wiphy(&mesh, msg, arg))
-                sae_debug(MESHD_DEBUG, "error getting wiphy info! \n");
-            /* wiphy handled, we are now ready start the mesh */
-            init(&nlcfg, &mesh);
-            break;
-        case NL80211_CMD_DEL_STATION:
-            handle_del_peer(&nlcfg, msg, arg);
-            break;
-        case NL80211_CMD_FRAME:
-            if (tb[NL80211_ATTR_FRAME] && nla_len(tb[NL80211_ATTR_FRAME])) {
-                sae_debug(MESHD_DEBUG, "NL80211_CMD_FRAME (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
-                frame = nla_data(tb[NL80211_ATTR_FRAME]);
-                frame_len = nla_len(tb[NL80211_ATTR_FRAME]);
-                frame_control = ieee_order(frame->frame_control);
-                sae_hexdump(MESHD_DEBUG, "rx frame", (unsigned char *) frame, frame_len);
-                /* Auth frames go to SAE */
-                if (IEEE802_11_FC_GET_TYPE(frame_control) == IEEE802_11_FC_TYPE_MGMT &&
-                     (IEEE802_11_FC_GET_STYPE(frame_control) == IEEE802_11_FC_STYPE_ACTION ||
-                      IEEE802_11_FC_GET_STYPE(frame_control) == IEEE802_11_FC_STYPE_AUTH)) {
-                    if (process_mgmt_frame(frame, frame_len, mesh.mymacaddr, &nlcfg, !meshd_conf.is_secure))
-                        fprintf(stderr, "libsae: process_mgmt_frame failed\n");
-                } else
-                    sae_debug(MESHD_DEBUG, "got unexpected frame (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
-            }
-            break;
-        case NL80211_CMD_NEW_STATION:
-            sae_debug(MESHD_DEBUG, "NL80211_CMD_NEW_STATION (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
-            break;
-        case NL80211_CMD_NEW_PEER_CANDIDATE:
-            sae_debug(MESHD_DEBUG, "NL80211_CMD_NEW_PEER_CANDIDATE(%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
-            new_candidate_handler(msg, arg);
-            break;
-        case NL80211_CMD_FRAME_TX_STATUS:
-            sae_debug(MESHD_DEBUG, "NL80211_CMD_TX_STATUS (%lld.%ld)\n", (long long) now.tv_sec, (long) now.tv_usec);
-            if (!tb[NL80211_ATTR_ACK] || !tb[NL80211_ATTR_FRAME])
-                sae_debug(MESHD_DEBUG, "tx frame failed!");
-            break;
-        default:
-            sae_debug(MESHD_DEBUG, "Ignored event (%d)\n", gnlh->cmd);
-            break;
-    }
-
+  /* Ignore events for other interfaces */
+  if (tb[NL80211_ATTR_IFINDEX] &&
+      nlcfg.ifindex != *(uint32_t *)nla_data(tb[NL80211_ATTR_IFINDEX]))
     return NL_SKIP;
+
+  switch (gnlh->cmd) {
+    /* test */
+    case NL80211_CMD_NEW_WIPHY:
+      assert(tb[NL80211_ATTR_SUPPORT_MESH_AUTH]);
+      if (handle_wiphy(&mesh, msg, arg))
+        sae_debug(MESHD_DEBUG, "error getting wiphy info! \n");
+      /* wiphy handled, we are now ready start the mesh */
+      init(&nlcfg, &mesh);
+      break;
+    case NL80211_CMD_DEL_STATION:
+      handle_del_peer(&nlcfg, msg, arg);
+      break;
+    case NL80211_CMD_FRAME:
+      if (tb[NL80211_ATTR_FRAME] && nla_len(tb[NL80211_ATTR_FRAME])) {
+        sae_debug(
+            MESHD_DEBUG,
+            "NL80211_CMD_FRAME (%lld.%ld)\n",
+            (long long)now.tv_sec,
+            (long)now.tv_usec);
+        frame = nla_data(tb[NL80211_ATTR_FRAME]);
+        frame_len = nla_len(tb[NL80211_ATTR_FRAME]);
+        frame_control = ieee_order(frame->frame_control);
+        sae_hexdump(MESHD_DEBUG, "rx frame", (unsigned char *)frame, frame_len);
+        /* Auth frames go to SAE */
+        if (IEEE802_11_FC_GET_TYPE(frame_control) == IEEE802_11_FC_TYPE_MGMT &&
+            (IEEE802_11_FC_GET_STYPE(frame_control) ==
+                 IEEE802_11_FC_STYPE_ACTION ||
+             IEEE802_11_FC_GET_STYPE(frame_control) ==
+                 IEEE802_11_FC_STYPE_AUTH)) {
+          if (process_mgmt_frame(
+                  frame,
+                  frame_len,
+                  mesh.mymacaddr,
+                  &nlcfg,
+                  !meshd_conf.is_secure))
+            fprintf(stderr, "libsae: process_mgmt_frame failed\n");
+        } else
+          sae_debug(
+              MESHD_DEBUG,
+              "got unexpected frame (%lld.%ld)\n",
+              (long long)now.tv_sec,
+              (long)now.tv_usec);
+      }
+      break;
+    case NL80211_CMD_NEW_STATION:
+      sae_debug(
+          MESHD_DEBUG,
+          "NL80211_CMD_NEW_STATION (%lld.%ld)\n",
+          (long long)now.tv_sec,
+          (long)now.tv_usec);
+      break;
+    case NL80211_CMD_NEW_PEER_CANDIDATE:
+      sae_debug(
+          MESHD_DEBUG,
+          "NL80211_CMD_NEW_PEER_CANDIDATE(%lld.%ld)\n",
+          (long long)now.tv_sec,
+          (long)now.tv_usec);
+      new_candidate_handler(msg, arg);
+      break;
+    case NL80211_CMD_FRAME_TX_STATUS:
+      sae_debug(
+          MESHD_DEBUG,
+          "NL80211_CMD_TX_STATUS (%lld.%ld)\n",
+          (long long)now.tv_sec,
+          (long)now.tv_usec);
+      if (!tb[NL80211_ATTR_ACK] || !tb[NL80211_ATTR_FRAME])
+        sae_debug(MESHD_DEBUG, "tx frame failed!");
+      break;
+    default:
+      sae_debug(MESHD_DEBUG, "Ignored event (%d)\n", gnlh->cmd);
+      break;
+  }
+
+  return NL_SKIP;
 }
 
-static int set_authenticated_flag(struct netlink_config_s *nlcfg, unsigned char *peer)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_SET_STATION;
-    int ret;
-    char *pret;
-    struct nl80211_sta_flag_update flags;
+static int set_authenticated_flag(
+    struct netlink_config_s *nlcfg,
+    unsigned char *peer) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_SET_STATION;
+  int ret;
+  char *pret;
+  struct nl80211_sta_flag_update flags;
 
-    if (!peer)
-        return -EINVAL;
+  if (!peer)
+    return -EINVAL;
 
-    msg = nlmsg_alloc();
+  msg = nlmsg_alloc();
 
-    if (!msg)
-        return -ENOMEM;
+  if (!msg)
+    return -ENOMEM;
 
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
 
-    if (pret == NULL)
-        goto nla_put_failure;
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-    NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
-    flags.mask = flags.set = (1 << NL80211_STA_FLAG_AUTHENTICATED) |
-                             (1 << NL80211_STA_FLAG_MFP) |
-                             (1 << NL80211_STA_FLAG_AUTHORIZED);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
+  flags.mask = flags.set = (1 << NL80211_STA_FLAG_AUTHENTICATED) |
+      (1 << NL80211_STA_FLAG_MFP) | (1 << NL80211_STA_FLAG_AUTHORIZED);
 
-    if (!meshd_conf.is_secure || !meshd_conf.pmf) {
-        flags.set &= ~(1 << NL80211_STA_FLAG_MFP);
-    }
+  if (!meshd_conf.is_secure || !meshd_conf.pmf) {
+    flags.set &= ~(1 << NL80211_STA_FLAG_MFP);
+  }
 
-    NLA_PUT(msg, NL80211_ATTR_STA_FLAGS2, sizeof(flags), &flags);
+  NLA_PUT(msg, NL80211_ATTR_STA_FLAGS2, sizeof(flags), &flags);
 
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  sae_debug(
+      MESHD_DEBUG, "set auth flag (seq num=%d)\n", nlmsg_hdr(msg)->nlmsg_seq);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    fprintf(
+        stderr,
+        "Failed to set auth flag on station: %d (%s)\n",
+        ret,
+        strerror(-ret));
+  else
+    ret = 0;
 
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    sae_debug(MESHD_DEBUG, "set auth flag (seq num=%d)\n",
-            nlmsg_hdr(msg)->nlmsg_seq);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        fprintf(stderr,"Failed to set auth flag on station: %d (%s)\n", ret, strerror(-ret));
-    else
-        ret = 0;
-
-    return ret;
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-int set_plink_state(unsigned char *peer, int state, void *cookie)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_SET_STATION;
-    int ret;
-    char *pret;
+int set_plink_state(unsigned char *peer, int state, void *cookie) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_SET_STATION;
+  int ret;
+  char *pret;
 
-    assert(cookie == &nlcfg);
+  assert(cookie == &nlcfg);
 
-    if (!peer)
-        return -EINVAL;
+  if (!peer)
+    return -EINVAL;
 
-    msg = nlmsg_alloc();
+  msg = nlmsg_alloc();
 
-    if (!msg)
-        return -ENOMEM;
+  if (!msg)
+    return -ENOMEM;
 
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg.nl80211), 0, 0, cmd, 0);
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg.nl80211), 0, 0, cmd, 0);
 
-    if (pret == NULL)
-        goto nla_put_failure;
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg.ifindex);
-    NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
-    NLA_PUT_U8(msg, NL80211_ATTR_STA_PLINK_STATE, state);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg.ifindex);
+  NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
+  NLA_PUT_U8(msg, NL80211_ATTR_STA_PLINK_STATE, state);
 
-    ret = send_nlmsg(nlcfg.nl_sock, msg);
-    sae_debug(MESHD_DEBUG, "set plink state (seq num=%d)\n",
-            nlmsg_hdr(msg)->nlmsg_seq);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        fprintf(stderr,"Peer link command failed: %d (%s)\n", ret, strerror(-ret));
-    else
-        ret = 0;
+  ret = send_nlmsg(nlcfg.nl_sock, msg);
+  sae_debug(
+      MESHD_DEBUG, "set plink state (seq num=%d)\n", nlmsg_hdr(msg)->nlmsg_seq);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    fprintf(stderr, "Peer link command failed: %d (%s)\n", ret, strerror(-ret));
+  else
+    ret = 0;
 
-    return ret;
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
 #if 0
@@ -972,344 +1077,367 @@ nla_put_failure:
 }
 #endif
 
-static int leave_mesh(struct netlink_config_s *nlcfg)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_LEAVE_MESH;
-    int ret;
-    char *pret;
+static int leave_mesh(struct netlink_config_s *nlcfg) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_LEAVE_MESH;
+  int ret;
+  char *pret;
 
-    msg = nlmsg_alloc();
-    if (!msg)
-        return -ENOMEM;
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
 
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
-    if (pret == NULL)
-        goto nla_put_failure;
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
 
-    /*  Suppress netlink error in case we are not connected to mesh */
-    nlcfg->supress_error = -ENOTCONN;
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        fprintf(stderr,"Mesh leave failed: %d (%s)\n", ret, strerror(-ret));
-    else
-        ret = 0;
+  /*  Suppress netlink error in case we are not connected to mesh */
+  nlcfg->supress_error = -ENOTCONN;
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    fprintf(stderr, "Mesh leave failed: %d (%s)\n", ret, strerror(-ret));
+  else
+    ret = 0;
 
-    return ret;
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-static int join_mesh(struct netlink_config_s *nlcfg,
-                     struct mesh_node *mesh)
-{
-    struct nl_msg *msg;
-    struct meshd_config *mconf = mesh->conf;
-    uint8_t cmd = NL80211_CMD_JOIN_MESH;
-    uint8_t basic_rates[MAX_SUPP_RATES];
-    int rates = 0, i;
-    int ret;
-    char *pret;
+static int join_mesh(struct netlink_config_s *nlcfg, struct mesh_node *mesh) {
+  struct nl_msg *msg;
+  struct meshd_config *mconf = mesh->conf;
+  uint8_t cmd = NL80211_CMD_JOIN_MESH;
+  uint8_t basic_rates[MAX_SUPP_RATES];
+  int rates = 0, i;
+  int ret;
+  char *pret;
 
-    assert(rsn_ie[1] == sizeof(rsn_ie) - 2);
+  assert(rsn_ie[1] == sizeof(rsn_ie) - 2);
 
-    if (!mconf->meshid || !mconf->meshid_len)
-        return -EINVAL;
+  if (!mconf->meshid || !mconf->meshid_len)
+    return -EINVAL;
 
-    msg = nlmsg_alloc();
-    if (!msg)
-        return -ENOMEM;
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
 
-    sae_debug(MESHD_DEBUG, "meshd: Starting mesh with mesh id = %s\n", mconf->meshid);
+  sae_debug(
+      MESHD_DEBUG, "meshd: Starting mesh with mesh id = %s\n", mconf->meshid);
 
-    pret = genlmsg_put(msg, 0, 0,
-            genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
-    if (pret == NULL)
-        goto nla_put_failure;
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg->nl80211), 0, 0, cmd, 0);
+  if (pret == NULL)
+    goto nla_put_failure;
 
-    /* configure BSSBasicRateSet in kernel MPM, which has to know about this to
-     * select eligible candidates */
-    for (i = 0; i < sizeof(mconf->rates); i++) {
-        if (mconf->rates[i] & 0x80) {
-            basic_rates[rates] = mconf->rates[i];
-            rates++;
-        }
+  /* configure BSSBasicRateSet in kernel MPM, which has to know about this to
+   * select eligible candidates */
+  for (i = 0; i < sizeof(mconf->rates); i++) {
+    if (mconf->rates[i] & 0x80) {
+      basic_rates[rates] = mconf->rates[i];
+      rates++;
     }
+  }
 
-    sae_hexdump(MESHD_DEBUG, "basic rates:", basic_rates, rates);
-    NLA_PUT(msg, NL80211_ATTR_BSS_BASIC_RATES, rates, basic_rates);
+  sae_hexdump(MESHD_DEBUG, "basic rates:", basic_rates, rates);
+  NLA_PUT(msg, NL80211_ATTR_BSS_BASIC_RATES, rates, basic_rates);
 
-    struct nlattr *container = nla_nest_start(msg,
-            NL80211_ATTR_MESH_CONFIG);
+  struct nlattr *container = nla_nest_start(msg, NL80211_ATTR_MESH_CONFIG);
 
-    if (!container)
-        goto nla_put_failure;
+  if (!container)
+    goto nla_put_failure;
 
-    NLA_PUT_U8(msg, NL80211_MESHCONF_AUTO_OPEN_PLINKS, 0);
-    if(mconf->path_refresh_time > 0) {
-        NLA_PUT_U32(msg,NL80211_MESHCONF_PATH_REFRESH_TIME,
-                mconf->path_refresh_time);
-     }
+  NLA_PUT_U8(msg, NL80211_MESHCONF_AUTO_OPEN_PLINKS, 0);
+  if (mconf->path_refresh_time > 0) {
+    NLA_PUT_U32(
+        msg, NL80211_MESHCONF_PATH_REFRESH_TIME, mconf->path_refresh_time);
+  }
 
-    if(mconf->min_discovery_timeout > 0){
-        NLA_PUT_U16(msg,NL80211_MESHCONF_MIN_DISCOVERY_TIMEOUT,
-                mconf->min_discovery_timeout);
-    }
+  if (mconf->min_discovery_timeout > 0) {
+    NLA_PUT_U16(
+        msg,
+        NL80211_MESHCONF_MIN_DISCOVERY_TIMEOUT,
+        mconf->min_discovery_timeout);
+  }
 
-    if(mconf->hwmp_active_path_timeout > 0){
-        NLA_PUT_U32(msg,NL80211_MESHCONF_HWMP_ACTIVE_PATH_TIMEOUT,
-                mconf->hwmp_active_path_timeout);
-    }
+  if (mconf->hwmp_active_path_timeout > 0) {
+    NLA_PUT_U32(
+        msg,
+        NL80211_MESHCONF_HWMP_ACTIVE_PATH_TIMEOUT,
+        mconf->hwmp_active_path_timeout);
+  }
 
-    if(mconf->hwmp_net_diameter_traversal_time > 0){
-        NLA_PUT_U16(msg,NL80211_MESHCONF_HWMP_NET_DIAM_TRVS_TIME,
-                mconf->hwmp_net_diameter_traversal_time);
-     }
+  if (mconf->hwmp_net_diameter_traversal_time > 0) {
+    NLA_PUT_U16(
+        msg,
+        NL80211_MESHCONF_HWMP_NET_DIAM_TRVS_TIME,
+        mconf->hwmp_net_diameter_traversal_time);
+  }
 
-    if(mconf->hwmp_rootmode > 0) {
-        NLA_PUT_U8(msg,NL80211_MESHCONF_HWMP_ROOTMODE,mconf->hwmp_rootmode);
-    }
+  if (mconf->hwmp_rootmode > 0) {
+    NLA_PUT_U8(msg, NL80211_MESHCONF_HWMP_ROOTMODE, mconf->hwmp_rootmode);
+  }
 
-    if(mconf->hwmp_rann_interval > 0){
-        NLA_PUT_U16(msg,NL80211_MESHCONF_HWMP_RANN_INTERVAL,
-                mconf->hwmp_rann_interval);
-    }
+  if (mconf->hwmp_rann_interval > 0) {
+    NLA_PUT_U16(
+        msg, NL80211_MESHCONF_HWMP_RANN_INTERVAL, mconf->hwmp_rann_interval);
+  }
 
-    if(mconf->gate_announcements >= 0) {
-        NLA_PUT_U8(msg,NL80211_MESHCONF_GATE_ANNOUNCEMENTS,
-                mconf->gate_announcements);
-    }
+  if (mconf->gate_announcements >= 0) {
+    NLA_PUT_U8(
+        msg, NL80211_MESHCONF_GATE_ANNOUNCEMENTS, mconf->gate_announcements);
+  }
 
-    if(mconf->hwmp_active_path_to_root_timeout > 0){
-        NLA_PUT_U32(msg,NL80211_MESHCONF_HWMP_PATH_TO_ROOT_TIMEOUT,
-                mconf->hwmp_active_path_to_root_timeout);
-    }
+  if (mconf->hwmp_active_path_to_root_timeout > 0) {
+    NLA_PUT_U32(
+        msg,
+        NL80211_MESHCONF_HWMP_PATH_TO_ROOT_TIMEOUT,
+        mconf->hwmp_active_path_to_root_timeout);
+  }
 
-    if(mconf->hwmp_root_interval > 0){
-        NLA_PUT_U16(msg,NL80211_MESHCONF_HWMP_ROOT_INTERVAL,
-                mconf->hwmp_root_interval);
-    }
+  if (mconf->hwmp_root_interval > 0) {
+    NLA_PUT_U16(
+        msg, NL80211_MESHCONF_HWMP_ROOT_INTERVAL, mconf->hwmp_root_interval);
+  }
 
-    nla_nest_end(msg, container);
+  nla_nest_end(msg, container);
 
-    container = nla_nest_start(msg,
-            NL80211_ATTR_MESH_SETUP);
+  container = nla_nest_start(msg, NL80211_ATTR_MESH_SETUP);
 
-    if (!container)
-        goto nla_put_failure;
+  if (!container)
+    goto nla_put_failure;
 
-    /* We'll be creating stations, not the kernel */
-    NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_MPM);
+  /* We'll be creating stations, not the kernel */
+  NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_MPM);
 
-    if (mconf->is_secure) {
-        /* Tell the kernel we're using SAE */
-        NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AUTH);
-        NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AMPE);
-        NLA_PUT_U8(msg, NL80211_MESH_SETUP_AUTH_PROTOCOL, 0x1);
-        NLA_PUT(msg, NL80211_MESH_SETUP_IE, sizeof(rsn_ie), rsn_ie);
-    }
+  if (mconf->is_secure) {
+    /* Tell the kernel we're using SAE */
+    NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AUTH);
+    NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AMPE);
+    NLA_PUT_U8(msg, NL80211_MESH_SETUP_AUTH_PROTOCOL, 0x1);
+    NLA_PUT(msg, NL80211_MESH_SETUP_IE, sizeof(rsn_ie), rsn_ie);
+  }
 
-    nla_nest_end(msg, container);
+  nla_nest_end(msg, container);
 
-    NLA_PUT_U32(msg, NL80211_ATTR_WIPHY_FREQ, mesh->freq);
-    if (mesh->channel_type != CHAN_NO_HT)
-        NLA_PUT_U32(msg, NL80211_ATTR_WIPHY_CHANNEL_TYPE, mesh->channel_type);
+  NLA_PUT_U32(msg, NL80211_ATTR_WIPHY_FREQ, mesh->freq);
+  if (mesh->channel_type != CHAN_NO_HT)
+    NLA_PUT_U32(msg, NL80211_ATTR_WIPHY_CHANNEL_TYPE, mesh->channel_type);
 
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-    NLA_PUT(msg, NL80211_ATTR_MESH_ID, mconf->meshid_len, mconf->meshid);
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  NLA_PUT(msg, NL80211_ATTR_MESH_ID, mconf->meshid_len, mconf->meshid);
 
-    if (mconf->mcast_rate > 0)
-        NLA_PUT_U32(msg, NL80211_ATTR_MCAST_RATE, mconf->mcast_rate);
+  if (mconf->mcast_rate > 0)
+    NLA_PUT_U32(msg, NL80211_ATTR_MCAST_RATE, mconf->mcast_rate);
 
-    if (mconf->beacon_interval > 0)
-        NLA_PUT_U32(msg, NL80211_ATTR_BEACON_INTERVAL, mconf->beacon_interval);
+  if (mconf->beacon_interval > 0)
+    NLA_PUT_U32(msg, NL80211_ATTR_BEACON_INTERVAL, mconf->beacon_interval);
 
-    sae_debug(MESHD_DEBUG, "joining mesh %s on freq %d, mode %d\n",
-                        mconf->meshid, mesh->freq, mesh->channel_type);
+  sae_debug(
+      MESHD_DEBUG,
+      "joining mesh %s on freq %d, mode %d\n",
+      mconf->meshid,
+      mesh->freq,
+      mesh->channel_type);
 
-    ret = send_nlmsg(nlcfg->nl_sock, msg);
-    nlmsg_free(msg);
-    msg = NULL;
-    if (ret < 0)
-        fprintf(stderr,"Mesh start failed: %d (%s)\n", ret, strerror(-ret));
-    else
-        ret = 0;
+  ret = send_nlmsg(nlcfg->nl_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret < 0)
+    fprintf(stderr, "Mesh start failed: %d (%s)\n", ret, strerror(-ret));
+  else
+    ret = 0;
 
-    return ret;
+  return ret;
 nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-    return -ENOBUFS;
+  nlmsg_free(msg);
+  msg = NULL;
+  return -ENOBUFS;
 }
 
-void estab_peer_link(unsigned char *peer,
-        unsigned char *mtk, int mtk_len,
-        unsigned char *peer_mgtk, int peer_mgtk_len,
-        unsigned int mgtk_expiration,
-        unsigned char *peer_igtk, int peer_igtk_len, int peer_igtk_keyid,
-        unsigned char *rates,
-        unsigned short rates_len,
-        void *cookie)
-{
-    struct meshd_config *mconf;
-    struct candidate *cand;
-    int ret;
+void estab_peer_link(
+    unsigned char *peer,
+    unsigned char *mtk,
+    int mtk_len,
+    unsigned char *peer_mgtk,
+    int peer_mgtk_len,
+    unsigned int mgtk_expiration,
+    unsigned char *peer_igtk,
+    int peer_igtk_len,
+    int peer_igtk_keyid,
+    unsigned char *rates,
+    unsigned short rates_len,
+    void *cookie) {
+  struct meshd_config *mconf;
+  struct candidate *cand;
+  int ret;
 
-    assert(cookie == &nlcfg);
+  assert(cookie == &nlcfg);
 
-    if (!peer)
-        return;
-
-    cand = find_peer(peer, 0);
-    if (!cand)
-        return;
-
-    mconf = cand->conf->mesh->conf;
-
-    if (mconf->is_secure) {
-        if (mtk_len != KEY_LEN_AES_CCMP || peer_mgtk_len != KEY_LEN_AES_CCMP)
-            return;
-
-        if (peer_igtk && peer_igtk_len != KEY_LEN_AES_CMAC)
-            return;
-    }
-
-    sae_debug(MESHD_DEBUG, "estab with " MACSTR "\n", MAC2STR(peer));
-
-    if (!cand->in_kernel) {
-        struct info_elems elems = {};
-
-        elems.sup_rates = cand->sup_rates;
-        elems.sup_rates_len = cand->sup_rates_len;
-
-        elems.ht_cap = (unsigned char *) &cand->ht_cap;
-        elems.ht_cap_len = sizeof(cand->ht_cap);
-
-        elems.ht_info = (unsigned char *) &cand->ht_info;
-        elems.ht_info_len = sizeof(cand->ht_info);
-
-        ret = add_unauthenticated_sta(&nlcfg, peer, &elems);
-        if (ret)
-            return;
-
-        cand->in_kernel = true;
-    }
-
-    set_authenticated_flag(&nlcfg, peer);
-
-    if (mconf->is_secure) {
-        /* key to encrypt/decrypt unicast data AND mgmt traffic to/from this peer */
-        install_key(&nlcfg, peer, CIPHER_CCMP, NL80211_KEYTYPE_PAIRWISE, 0, mtk);
-
-        /* key to decrypt multicast data traffic from this peer */
-        install_key(&nlcfg, peer, CIPHER_CCMP, NL80211_KEYTYPE_GROUP, 1, peer_mgtk);
-
-        /* to check integrity of multicast mgmt frames from this peer */
-        if (peer_igtk) {
-            install_key(&nlcfg, peer, CIPHER_AES_CMAC, NL80211_KEYTYPE_GROUP, peer_igtk_keyid, peer_igtk);
-        }
-    }
-}
-
-void peer_created(unsigned char *peer)
-{
-    struct candidate *cand;
-    /*
-     * We don't have to do anything here:
-     *
-     *  - if peer was created from SAE state machine, then
-     *    it will be added to kernel when the IEs are known (e.g.
-     *    on estab plink)
-     *
-     *  - if peer is created from a beacon, we will know the IEs
-     *    and will go ahead and create the peer in new_candidate_handler.
-     *
-     * Validate the invariant that this is only called before the
-     * is updated.
-     */
-    cand = find_peer(peer, 0);
-    if (!cand)
-        return;
-
-    if (cand->in_kernel) {
-        sae_debug(SAE_DEBUG_ERR, "attempting to create peer that is already in kernel: " MACSTR "\n", MAC2STR(peer));
-    }
-}
-
-void peer_deleted(unsigned char *peer)
-{
-    struct nl_msg *msg;
-    uint8_t cmd = NL80211_CMD_DEL_STATION;
-    int ret;
-    char *pret;
-
-    if (!peer)
-        return;
-
-    msg = nlmsg_alloc();
-
-    if (!msg)
-        return;
-
-    pret = genlmsg_put(msg, 0, 0,
-                       genl_family_get_id(nlcfg.nl80211), 0, 0, cmd, 0);
-
-    if (pret == NULL)
-        goto nla_put_failure;
-
-    NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg.ifindex);
-    NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
-
-    ret = send_nlmsg(nlcfg.nl_sock, msg);
-    nlmsg_free(msg);
-    msg = NULL;
-    sae_debug(MESHD_DEBUG, "removing peer candidate " MACSTR "\n",
-              MAC2STR(peer));
-    if (ret < 0)
-        fprintf(stderr, "Remove candidate failed: %d (%s)\n", ret, strerror(-ret));
-
+  if (!peer)
     return;
-nla_put_failure:
-    nlmsg_free(msg);
-    msg = NULL;
-}
 
-void fin(unsigned short reason, unsigned char *peer, unsigned char *buf, int len, void *cookie)
-{
-    sae_debug(MESHD_DEBUG, "fin: %d, key len:%d peer:"
-            MACSTR " me:" MACSTR "\n", reason, len, MAC2STR(peer),
-            MAC2STR(mesh.mymacaddr));
-    if (!reason && len) {
-        if (meshd_conf.is_secure) {
-            sae_hexdump(AMPE_DEBUG_KEYS, "pmk", buf, len % 80);
-        }
-        start_peer_link(peer, (unsigned char *) mesh.mymacaddr, cookie);
-    } else if (reason) {
-        peer_deleted(peer);
+  cand = find_peer(peer, 0);
+  if (!cand)
+    return;
+
+  mconf = cand->conf->mesh->conf;
+
+  if (mconf->is_secure) {
+    if (mtk_len != KEY_LEN_AES_CCMP || peer_mgtk_len != KEY_LEN_AES_CCMP)
+      return;
+
+    if (peer_igtk && peer_igtk_len != KEY_LEN_AES_CMAC)
+      return;
+  }
+
+  sae_debug(MESHD_DEBUG, "estab with " MACSTR "\n", MAC2STR(peer));
+
+  if (!cand->in_kernel) {
+    struct info_elems elems = {};
+
+    elems.sup_rates = cand->sup_rates;
+    elems.sup_rates_len = cand->sup_rates_len;
+
+    elems.ht_cap = (unsigned char *)&cand->ht_cap;
+    elems.ht_cap_len = sizeof(cand->ht_cap);
+
+    elems.ht_info = (unsigned char *)&cand->ht_info;
+    elems.ht_info_len = sizeof(cand->ht_info);
+
+    ret = add_unauthenticated_sta(&nlcfg, peer, &elems);
+    if (ret)
+      return;
+
+    cand->in_kernel = true;
+  }
+
+  set_authenticated_flag(&nlcfg, peer);
+
+  if (mconf->is_secure) {
+    /* key to encrypt/decrypt unicast data AND mgmt traffic to/from this peer */
+    install_key(&nlcfg, peer, CIPHER_CCMP, NL80211_KEYTYPE_PAIRWISE, 0, mtk);
+
+    /* key to decrypt multicast data traffic from this peer */
+    install_key(&nlcfg, peer, CIPHER_CCMP, NL80211_KEYTYPE_GROUP, 1, peer_mgtk);
+
+    /* to check integrity of multicast mgmt frames from this peer */
+    if (peer_igtk) {
+      install_key(
+          &nlcfg,
+          peer,
+          CIPHER_AES_CMAC,
+          NL80211_KEYTYPE_GROUP,
+          peer_igtk_keyid,
+          peer_igtk);
     }
+  }
 }
 
-void term_handle(int i)
-{
-    srv_cancel_main_loop(srvctx);
+void peer_created(unsigned char *peer) {
+  struct candidate *cand;
+  /*
+   * We don't have to do anything here:
+   *
+   *  - if peer was created from SAE state machine, then
+   *    it will be added to kernel when the IEs are known (e.g.
+   *    on estab plink)
+   *
+   *  - if peer is created from a beacon, we will know the IEs
+   *    and will go ahead and create the peer in new_candidate_handler.
+   *
+   * Validate the invariant that this is only called before the
+   * is updated.
+   */
+  cand = find_peer(peer, 0);
+  if (!cand)
+    return;
+
+  if (cand->in_kernel) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "attempting to create peer that is already in kernel: " MACSTR "\n",
+        MAC2STR(peer));
+  }
+}
+
+void peer_deleted(unsigned char *peer) {
+  struct nl_msg *msg;
+  uint8_t cmd = NL80211_CMD_DEL_STATION;
+  int ret;
+  char *pret;
+
+  if (!peer)
+    return;
+
+  msg = nlmsg_alloc();
+
+  if (!msg)
+    return;
+
+  pret =
+      genlmsg_put(msg, 0, 0, genl_family_get_id(nlcfg.nl80211), 0, 0, cmd, 0);
+
+  if (pret == NULL)
+    goto nla_put_failure;
+
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg.ifindex);
+  NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
+
+  ret = send_nlmsg(nlcfg.nl_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  sae_debug(MESHD_DEBUG, "removing peer candidate " MACSTR "\n", MAC2STR(peer));
+  if (ret < 0)
+    fprintf(stderr, "Remove candidate failed: %d (%s)\n", ret, strerror(-ret));
+
+  return;
+nla_put_failure:
+  nlmsg_free(msg);
+  msg = NULL;
+}
+
+void fin(
+    unsigned short reason,
+    unsigned char *peer,
+    unsigned char *buf,
+    int len,
+    void *cookie) {
+  sae_debug(
+      MESHD_DEBUG,
+      "fin: %d, key len:%d peer:" MACSTR " me:" MACSTR "\n",
+      reason,
+      len,
+      MAC2STR(peer),
+      MAC2STR(mesh.mymacaddr));
+  if (!reason && len) {
+    if (meshd_conf.is_secure) {
+      sae_hexdump(AMPE_DEBUG_KEYS, "pmk", buf, len % 80);
+    }
+    start_peer_link(peer, (unsigned char *)mesh.mymacaddr, cookie);
+  } else if (reason) {
+    peer_deleted(peer);
+  }
+}
+
+void term_handle(int i) {
+  srv_cancel_main_loop(srvctx);
 }
 
 #if defined(__linux__) && !defined(__ANDROID__)
-__attribute__((noreturn))
-static void segv_handle(int sig) {
-
+__attribute__((noreturn)) static void segv_handle(int sig) {
 #ifdef __GLIBC__
   void *bt_array[64];
   size_t bt_size;
   size_t bt_index = 0;
-  char ** bt_syms;
+  char **bt_syms;
 
   bt_size = backtrace(bt_array, 64);
   bt_syms = backtrace_symbols(bt_array, bt_size);
@@ -1319,181 +1447,217 @@ static void segv_handle(int sig) {
     sae_debug(SAE_DEBUG_ERR, "%s\n", bt_syms[bt_index++]);
   }
 #else
-  sae_debug(SAE_DEBUG_ERR, "crash (logging a stack trace is not supported on this platform)", message);
+  sae_debug(
+      SAE_DEBUG_ERR,
+      "crash (logging a stack trace is not supported on this platform)",
+      message);
 #endif
 
   exit(126);
 }
 #endif /* defined(__linux__) && !defined(__ANDROID__) */
 
-void hup_handle(int i)
-{
-    rekey_reopen_sockets();
+void hup_handle(int i) {
+  rekey_reopen_sockets();
 }
 
 /* TODO: This config stuff should be in a common file to be shared by other
  * meshd implementations
  */
 
-static int
-meshd_parse_libconfig (struct config_setting_t *meshd_section,
-                       struct meshd_config *config)
-{
-    char *str;
+static int meshd_parse_libconfig(
+    struct config_setting_t *meshd_section,
+    struct meshd_config *config) {
+  char *str;
 
-    memset(config, 0, sizeof(struct meshd_config));
+  memset(config, 0, sizeof(struct meshd_config));
 
-    if (config_setting_lookup_string(meshd_section, "interface",  (const char **)&str)) {
-        strncpy(config->interface, str, IFNAMSIZ + 1);
-        if (config->interface[IFNAMSIZ] != 0) {
-            fprintf(stderr, "Interface name is too long\n");
-            return -1;
-        }
-    }
-
-    if (config_setting_lookup_string(meshd_section, "meshid", (const char **)&str)) {
-        strncpy(config->meshid, str, MESHD_MAX_SSID_LEN + 1);
-        if (config->meshid[MESHD_MAX_SSID_LEN] != 0) {
-            fprintf(stderr, "WARNING: Truncating meshid\n");
-            config->meshid[MESHD_MAX_SSID_LEN] = 0;
-        }
-        config->meshid_len = strlen(config->meshid);
-    }
-
-#define CONFIG_LOOKUP(name, config_val, dflt) \
-    if (CONFIG_FALSE == config_setting_lookup_int(meshd_section, #name, (config_int_t *)&config->config_val)) \
-        config->config_val = dflt;
-
-    CONFIG_LOOKUP(channel, channel, -1);
-    CONFIG_LOOKUP(mcast-rate, mcast_rate, -1);
-    CONFIG_LOOKUP(beacon-interval,beacon_interval, -1);
-
-    CONFIG_LOOKUP(is-secure, is_secure, 1);
-
-    config_setting_lookup_int(meshd_section, "pmf",
-            (config_int_t *) &config->pmf);
-
-    /* Get mesh parameter */
-    CONFIG_LOOKUP(path-refresh-time,path_refresh_time, -1);
-    CONFIG_LOOKUP(min-discovery-timeout,min_discovery_timeout, -1);
-    CONFIG_LOOKUP(gate-announcements,gate_announcements, -1);
-    CONFIG_LOOKUP(hwmp-active-path-timeout,hwmp_active_path_timeout, -1);
-    CONFIG_LOOKUP(hwmp-net-diameter-traversal-time,
-            hwmp_net_diameter_traversal_time, -1);
-    CONFIG_LOOKUP(hwmp-rootmode,hwmp_rootmode, -1);
-    CONFIG_LOOKUP(hwmp-rann-interval,hwmp_rann_interval, -1);
-    CONFIG_LOOKUP(hwmp-active-path-to-root-timeout,
-            hwmp_active_path_to_root_timeout, -1);
-    CONFIG_LOOKUP(hwmp-root-interval,hwmp_root_interval, -1);
-
-    config->band = MESHD_11b;
-
-    if (config_setting_lookup_string(meshd_section, "band", (const char **)&str)) {
-        if (strncmp(str, "11a", 3) == 0) {
-            config->band = MESHD_11a;
-        } else if (strncmp(str, "11b", 3) == 0) {
-            config->band = MESHD_11b;
-        } else if (strncmp(str, "11g", 3) == 0) {
-            config->band = MESHD_11g;
-        } else {
-            fprintf(stderr, "Invalid meshd band %s\n", str);
-        }
-    }
-
-    config->channel_type = NL80211_CHAN_NO_HT;
-    if (config_setting_lookup_string(meshd_section, "htmode", (const char **)&str)) {
-        if (strncmp(str, "none", 4) == 0) {
-            config->channel_type = NL80211_CHAN_NO_HT;
-        } else if (strncmp(str, "HT20", 4) == 0) {
-            config->channel_type = NL80211_CHAN_HT20;
-        } else if (strncmp(str, "HT40+", 5) == 0) {
-            config->channel_type = NL80211_CHAN_HT40PLUS;
-        } else if (strncmp(str, "HT40-", 5) == 0) {
-            config->channel_type = NL80211_CHAN_HT40MINUS;
-        } else {
-            sae_debug(MESHD_DEBUG, "unknown HT mode \"%s\", disabling\n", str);
-        }
-    }
-
-    CONFIG_LOOKUP(rekey_enable, rekey_enable, REKEY_ENABLE_DEF);
-    config->rekey_enable = (config->rekey_enable != 0);
-
-    if (config_setting_lookup_string(meshd_section, "bridge", (const char **) &str)) {
-      strncpy(config->bridge, str, sizeof(config->bridge));
-      if (config->bridge[sizeof(config->bridge) - 1]) {
-        fprintf(stderr, "Bridge name is too long\n");
-        return -1;
-      }
-    }
-
-    config->rekey_multicast_group_family = REKEY_MULTICAST_GROUP_FAMILY_DEF;
-    config->rekey_multicast_group_address.v4.s_addr = REKEY_MULTICAST_GROUP_ADDRESS_DEF;
-    bool groupValid = true;
-
-    if (config_setting_lookup_string(meshd_section, "rekey_multicast_group", (const char **) &str)) {
-      if (inet_pton(AF_INET, str, &config->rekey_multicast_group_address.v4)) {
-        config->rekey_multicast_group_family = AF_INET;
-        groupValid = IN_MULTICAST(ntohl(config->rekey_multicast_group_address.v4.s_addr));
-      } else if (inet_pton(AF_INET6, str, &config->rekey_multicast_group_address.v6)) {
-        config->rekey_multicast_group_family = AF_INET6;
-        groupValid = IN6_IS_ADDR_MULTICAST(&config->rekey_multicast_group_address.v6);
-      } else {
-        groupValid = false;
-      }
-    }
-
-    if (!groupValid) {
-      fprintf(stderr, "Invalid rekey multicast group '%s'\n", str);
+  if (config_setting_lookup_string(
+          meshd_section, "interface", (const char **)&str)) {
+    strncpy(config->interface, str, IFNAMSIZ + 1);
+    if (config->interface[IFNAMSIZ] != 0) {
+      fprintf(stderr, "Interface name is too long\n");
       return -1;
     }
+  }
 
-    CONFIG_LOOKUP(rekey_ping_port, rekey_ping_port, REKEY_PING_PORT_DEF);
-    if ((config->rekey_ping_port <= 0) || (config->rekey_ping_port >= 65536)) {
-      fprintf(stderr, "Invalid rekey ping port %d\n", config->rekey_ping_port);
+  if (config_setting_lookup_string(
+          meshd_section, "meshid", (const char **)&str)) {
+    strncpy(config->meshid, str, MESHD_MAX_SSID_LEN + 1);
+    if (config->meshid[MESHD_MAX_SSID_LEN] != 0) {
+      fprintf(stderr, "WARNING: Truncating meshid\n");
+      config->meshid[MESHD_MAX_SSID_LEN] = 0;
+    }
+    config->meshid_len = strlen(config->meshid);
+  }
+
+#define CONFIG_LOOKUP(name, config_val, dflt)                         \
+  if (CONFIG_FALSE ==                                                 \
+      config_setting_lookup_int(                                      \
+          meshd_section, #name, (config_int_t *)&config->config_val)) \
+    config->config_val = dflt;
+
+  CONFIG_LOOKUP(channel, channel, -1);
+  CONFIG_LOOKUP(mcast-rate, mcast_rate, -1);
+  CONFIG_LOOKUP(beacon-interval, beacon_interval, -1);
+
+  CONFIG_LOOKUP(is-secure, is_secure, 1);
+
+  config_setting_lookup_int(meshd_section, "pmf", (config_int_t *)&config->pmf);
+
+  /* Get mesh parameter */
+  CONFIG_LOOKUP(path-refresh-time, path_refresh_time, -1);
+  CONFIG_LOOKUP(min-discovery-timeout, min_discovery_timeout, -1);
+  CONFIG_LOOKUP(gate-announcements, gate_announcements, -1);
+  CONFIG_LOOKUP(hwmp-active-path-timeout, hwmp_active_path_timeout, -1);
+  CONFIG_LOOKUP(
+      hwmp-net-diameter-traversal-time,
+      hwmp_net_diameter_traversal_time,
+      -1);
+  CONFIG_LOOKUP(hwmp-rootmode, hwmp_rootmode, -1);
+  CONFIG_LOOKUP(hwmp-rann-interval, hwmp_rann_interval, -1);
+  CONFIG_LOOKUP(
+      hwmp-active-path-to-root-timeout,
+      hwmp_active_path_to_root_timeout,
+      -1);
+  CONFIG_LOOKUP(hwmp-root-interval, hwmp_root_interval, -1);
+
+  config->band = MESHD_11b;
+
+  if (config_setting_lookup_string(
+          meshd_section, "band", (const char **)&str)) {
+    if (strncmp(str, "11a", 3) == 0) {
+      config->band = MESHD_11a;
+    } else if (strncmp(str, "11b", 3) == 0) {
+      config->band = MESHD_11b;
+    } else if (strncmp(str, "11g", 3) == 0) {
+      config->band = MESHD_11g;
+    } else {
+      fprintf(stderr, "Invalid meshd band %s\n", str);
+    }
+  }
+
+  config->channel_type = NL80211_CHAN_NO_HT;
+  if (config_setting_lookup_string(
+          meshd_section, "htmode", (const char **)&str)) {
+    if (strncmp(str, "none", 4) == 0) {
+      config->channel_type = NL80211_CHAN_NO_HT;
+    } else if (strncmp(str, "HT20", 4) == 0) {
+      config->channel_type = NL80211_CHAN_HT20;
+    } else if (strncmp(str, "HT40+", 5) == 0) {
+      config->channel_type = NL80211_CHAN_HT40PLUS;
+    } else if (strncmp(str, "HT40-", 5) == 0) {
+      config->channel_type = NL80211_CHAN_HT40MINUS;
+    } else {
+      sae_debug(MESHD_DEBUG, "unknown HT mode \"%s\", disabling\n", str);
+    }
+  }
+
+  CONFIG_LOOKUP(rekey_enable, rekey_enable, REKEY_ENABLE_DEF);
+  config->rekey_enable = (config->rekey_enable != 0);
+
+  if (config_setting_lookup_string(
+          meshd_section, "bridge", (const char **)&str)) {
+    strncpy(config->bridge, str, sizeof(config->bridge));
+    if (config->bridge[sizeof(config->bridge) - 1]) {
+      fprintf(stderr, "Bridge name is too long\n");
       return -1;
     }
-    config->rekey_ping_port = htons(config->rekey_ping_port);
+  }
 
-    CONFIG_LOOKUP(rekey_pong_port, rekey_pong_port, REKEY_PONG_PORT_DEF);
-    if ((config->rekey_pong_port <= 0) || (config->rekey_pong_port >= 65536)) {
-      fprintf(stderr, "Invalid rekey pong port %d\n", config->rekey_pong_port);
-      return -1;
-    }
-    config->rekey_pong_port = htons(config->rekey_pong_port);
+  config->rekey_multicast_group_family = REKEY_MULTICAST_GROUP_FAMILY_DEF;
+  config->rekey_multicast_group_address.v4.s_addr =
+      REKEY_MULTICAST_GROUP_ADDRESS_DEF;
+  bool groupValid = true;
 
-    CONFIG_LOOKUP(rekey_ping_count_max, rekey_ping_count_max, REKEY_PING_COUNT_MAX_DEF);
-    if (config->rekey_ping_count_max <= 0) {
-      fprintf(stderr, "Invalid rekey ping count maximum %d\n", config->rekey_ping_count_max);
-      return -1;
+  if (config_setting_lookup_string(
+          meshd_section, "rekey_multicast_group", (const char **)&str)) {
+    if (inet_pton(AF_INET, str, &config->rekey_multicast_group_address.v4)) {
+      config->rekey_multicast_group_family = AF_INET;
+      groupValid =
+          IN_MULTICAST(ntohl(config->rekey_multicast_group_address.v4.s_addr));
+    } else if (
+        inet_pton(AF_INET6, str, &config->rekey_multicast_group_address.v6)) {
+      config->rekey_multicast_group_family = AF_INET6;
+      groupValid =
+          IN6_IS_ADDR_MULTICAST(&config->rekey_multicast_group_address.v6);
+    } else {
+      groupValid = false;
     }
+  }
 
-    CONFIG_LOOKUP(rekey_ping_timeout, rekey_ping_timeout, REKEY_PING_TIMEOUT_MSECS_DEF);
-    if (config->rekey_ping_timeout <= 0) {
-      fprintf(stderr, "Invalid rekey ping timeout %d\n", config->rekey_ping_timeout);
-      return -1;
-    }
+  if (!groupValid) {
+    fprintf(stderr, "Invalid rekey multicast group '%s'\n", str);
+    return -1;
+  }
 
-    CONFIG_LOOKUP(rekey_ping_jitter, rekey_ping_jitter, REKEY_PING_JITTER_MSECS_DEF);
-    if (config->rekey_ping_jitter <= 0) {
-      fprintf(stderr, "Invalid rekey ping jitter %d\n", config->rekey_ping_jitter);
-      return -1;
-    }
+  CONFIG_LOOKUP(rekey_ping_port, rekey_ping_port, REKEY_PING_PORT_DEF);
+  if ((config->rekey_ping_port <= 0) || (config->rekey_ping_port >= 65536)) {
+    fprintf(stderr, "Invalid rekey ping port %d\n", config->rekey_ping_port);
+    return -1;
+  }
+  config->rekey_ping_port = htons(config->rekey_ping_port);
 
-    CONFIG_LOOKUP(rekey_reauth_count_max, rekey_reauth_count_max, REKEY_REAUTH_COUNT_MAX_DEF);
-    if (config->rekey_reauth_count_max <= 0) {
-      fprintf(stderr, "Invalid rekey reauthorisation count maximum %d\n", config->rekey_reauth_count_max);
-      return -1;
-    }
+  CONFIG_LOOKUP(rekey_pong_port, rekey_pong_port, REKEY_PONG_PORT_DEF);
+  if ((config->rekey_pong_port <= 0) || (config->rekey_pong_port >= 65536)) {
+    fprintf(stderr, "Invalid rekey pong port %d\n", config->rekey_pong_port);
+    return -1;
+  }
+  config->rekey_pong_port = htons(config->rekey_pong_port);
 
-    CONFIG_LOOKUP(rekey_ok_ping_count_max, rekey_ok_ping_count_max, REKEY_OK_PING_COUNT_MAX_DEF);
-    if (config->rekey_ok_ping_count_max <= 0) {
-      fprintf(stderr, "Invalid rekey ok ping count maximum %d\n", config->rekey_ok_ping_count_max);
-      return -1;
-    }
+  CONFIG_LOOKUP(
+      rekey_ping_count_max, rekey_ping_count_max, REKEY_PING_COUNT_MAX_DEF);
+  if (config->rekey_ping_count_max <= 0) {
+    fprintf(
+        stderr,
+        "Invalid rekey ping count maximum %d\n",
+        config->rekey_ping_count_max);
+    return -1;
+  }
+
+  CONFIG_LOOKUP(
+      rekey_ping_timeout, rekey_ping_timeout, REKEY_PING_TIMEOUT_MSECS_DEF);
+  if (config->rekey_ping_timeout <= 0) {
+    fprintf(
+        stderr, "Invalid rekey ping timeout %d\n", config->rekey_ping_timeout);
+    return -1;
+  }
+
+  CONFIG_LOOKUP(
+      rekey_ping_jitter, rekey_ping_jitter, REKEY_PING_JITTER_MSECS_DEF);
+  if (config->rekey_ping_jitter <= 0) {
+    fprintf(
+        stderr, "Invalid rekey ping jitter %d\n", config->rekey_ping_jitter);
+    return -1;
+  }
+
+  CONFIG_LOOKUP(
+      rekey_reauth_count_max,
+      rekey_reauth_count_max,
+      REKEY_REAUTH_COUNT_MAX_DEF);
+  if (config->rekey_reauth_count_max <= 0) {
+    fprintf(
+        stderr,
+        "Invalid rekey reauthorisation count maximum %d\n",
+        config->rekey_reauth_count_max);
+    return -1;
+  }
+
+  CONFIG_LOOKUP(
+      rekey_ok_ping_count_max,
+      rekey_ok_ping_count_max,
+      REKEY_OK_PING_COUNT_MAX_DEF);
+  if (config->rekey_ok_ping_count_max <= 0) {
+    fprintf(
+        stderr,
+        "Invalid rekey ok ping count maximum %d\n",
+        config->rekey_ok_ping_count_max);
+    return -1;
+  }
 
 #undef CONFIG_LOOKUP
 
-    return 0;
+  return 0;
 }
 
 /* given the channel, find the freq in megahertz.  Borrowed from iw:
@@ -1502,317 +1666,329 @@ meshd_parse_libconfig (struct config_setting_t *meshd_section,
  * Copyright (c) 2007		Mike Kershaw
  * Copyright (c) 2008-2009		Luis R. Rodriguez
  */
-static int channel_to_freq(int chan)
-{
-	if (chan < 14)
-		return 2407 + chan * 5;
+static int channel_to_freq(int chan) {
+  if (chan < 14)
+    return 2407 + chan * 5;
 
-	if (chan == 14)
-		return 2484;
+  if (chan == 14)
+    return 2484;
 
-	/* FIXME: dot11ChannelStartingFactor (802.11-2007 17.3.8.3.2) */
-	return (chan + 1000) * 5;
+  /* FIXME: dot11ChannelStartingFactor (802.11-2007 17.3.8.3.2) */
+  return (chan + 1000) * 5;
 }
 
-static struct ampe_cb *get_ampe_cbs()
-{
-    static struct ampe_cb cb;
-    cb.meshd_write_mgmt = meshd_write_mgmt;
-    cb.meshd_set_mesh_conf = meshd_set_mesh_conf;
-    cb.set_plink_state = set_plink_state;
-    cb.estab_peer_link = estab_peer_link;
-    cb.evl = get_evl_ops();
-    return &cb;
+static struct ampe_cb *get_ampe_cbs() {
+  static struct ampe_cb cb;
+  cb.meshd_write_mgmt = meshd_write_mgmt;
+  cb.meshd_set_mesh_conf = meshd_set_mesh_conf;
+  cb.set_plink_state = set_plink_state;
+  cb.estab_peer_link = estab_peer_link;
+  cb.evl = get_evl_ops();
+  return &cb;
 }
 
-static struct sae_cb *get_sae_cbs()
-{
-    static struct sae_cb cb;
-    cb.meshd_write_mgmt = meshd_write_mgmt;
-    cb.peer_created = peer_created;
-    cb.fin = fin;
-    cb.evl = get_evl_ops();
-    return &cb;
+static struct sae_cb *get_sae_cbs() {
+  static struct sae_cb cb;
+  cb.meshd_write_mgmt = meshd_write_mgmt;
+  cb.peer_created = peer_created;
+  cb.fin = fin;
+  cb.evl = get_evl_ops();
+  return &cb;
 }
 
-static int init(struct netlink_config_s *nlcfg, struct mesh_node *mesh)
-{
-    int exitcode = 0;
+static int init(struct netlink_config_s *nlcfg, struct mesh_node *mesh) {
+  int exitcode = 0;
 
-    leave_mesh(nlcfg);
+  leave_mesh(nlcfg);
 
-    sae_hexdump(MESHD_DEBUG, "nlcfg rates", (const unsigned char *) mesh->bands[mesh->band].rates,
-                              mesh->bands[mesh->band].n_bitrates * 2); // .rates is 16bit
+  sae_hexdump(
+      MESHD_DEBUG,
+      "nlcfg rates",
+      (const unsigned char *)mesh->bands[mesh->band].rates,
+      mesh->bands[mesh->band].n_bitrates * 2); // .rates is 16bit
 
-    /* shouldn't happen */
-    if (!mesh->bands[mesh->band].rates) {
-        fprintf(stderr, "wiphy reported no rates!\n");
-        exit(EXIT_FAILURE);
+  /* shouldn't happen */
+  if (!mesh->bands[mesh->band].rates) {
+    fprintf(stderr, "wiphy reported no rates!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  /* configure BSSBasicRateSet */
+  set_sup_basic_rates(
+      mesh->conf,
+      mesh->bands[mesh->band].rates,
+      mesh->bands[mesh->band].n_bitrates);
+
+  if (ampe_initialize(mesh, get_ampe_cbs()) < 0) {
+    fprintf(stderr, "cannot configure AMPE!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  exitcode = join_mesh(nlcfg, mesh);
+  if (exitcode) {
+    fprintf(stderr, "Failed to join mesh\n");
+    goto out;
+  }
+
+  exitcode = register_for_auth_frames(nlcfg);
+  if (exitcode)
+    goto out;
+
+  exitcode = register_for_plink_frames(nlcfg);
+  if (exitcode) {
+    fprintf(stderr, "cannot register for plink frame!\n");
+    goto out;
+  }
+
+  if (mesh->conf->is_secure) {
+    if (mesh->conf->pmf) {
+      /* key to protect integrity of multicast mgmt frames tx*/
+      install_key(
+          nlcfg,
+          NULL,
+          CIPHER_AES_CMAC,
+          NL80211_KEYTYPE_GROUP,
+          mesh->igtk_keyid,
+          mesh->igtk_tx);
     }
 
-    /* configure BSSBasicRateSet */
-    set_sup_basic_rates(mesh->conf, mesh->bands[mesh->band].rates,
-                        mesh->bands[mesh->band].n_bitrates);
-
-    if (ampe_initialize(mesh, get_ampe_cbs()) < 0) {
-        fprintf(stderr, "cannot configure AMPE!\n");
-        exit(EXIT_FAILURE);
-    }
-
-    exitcode = join_mesh(nlcfg, mesh);
-    if (exitcode) {
-        fprintf(stderr, "Failed to join mesh\n");
-        goto out;
-    }
-
-    exitcode = register_for_auth_frames(nlcfg);
-    if (exitcode)
-        goto out;
-
-    exitcode = register_for_plink_frames(nlcfg);
-    if (exitcode) {
-        fprintf(stderr, "cannot register for plink frame!\n");
-        goto out;
-    }
-
-    if (mesh->conf->is_secure) {
-        if (mesh->conf->pmf) {
-            /* key to protect integrity of multicast mgmt frames tx*/
-            install_key(nlcfg, NULL, CIPHER_AES_CMAC, NL80211_KEYTYPE_GROUP, mesh->igtk_keyid, mesh->igtk_tx);
-        }
-
-        /* key to encrypt multicast data traffic */
-        install_key(nlcfg, NULL, CIPHER_CCMP, NL80211_KEYTYPE_GROUP, 1, mgtk_tx);
-    }
+    /* key to encrypt multicast data traffic */
+    install_key(nlcfg, NULL, CIPHER_CCMP, NL80211_KEYTYPE_GROUP, 1, mgtk_tx);
+  }
 
 out:
-    return 0;
+  return 0;
 }
 
-static int
-sae_parse_libconfig (struct config_setting_t *sae_section, struct sae_config* config)
-{
-    struct config_setting_t *setting, *group;
-    char *pwd;
+static int sae_parse_libconfig(
+    struct config_setting_t *sae_section,
+    struct sae_config *config) {
+  struct config_setting_t *setting, *group;
+  char *pwd;
 
-    memset(config, 0, sizeof(struct sae_config));
-    config_setting_lookup_int(sae_section, "debug", (config_int_t *)&config->debug);
-    setting = config_setting_get_member(sae_section, "group");
-    if (setting != NULL) {
-        while (1) {
-            group = config_setting_get_elem(setting, config->num_groups);
-            if (!group)
-                break;
-            config->group[config->num_groups] =
-                config_setting_get_int_elem(setting, config->num_groups);
-            config->num_groups++;
-            if (config->num_groups == SAE_MAX_EC_GROUPS)
-                break;
-        }
+  memset(config, 0, sizeof(struct sae_config));
+  config_setting_lookup_int(
+      sae_section, "debug", (config_int_t *)&config->debug);
+  setting = config_setting_get_member(sae_section, "group");
+  if (setting != NULL) {
+    while (1) {
+      group = config_setting_get_elem(setting, config->num_groups);
+      if (!group)
+        break;
+      config->group[config->num_groups] =
+          config_setting_get_int_elem(setting, config->num_groups);
+      config->num_groups++;
+      if (config->num_groups == SAE_MAX_EC_GROUPS)
+        break;
     }
-    if (config_setting_lookup_string(sae_section, "password", (const char **)&pwd)) {
-        strncpy(config->pwd, pwd, SAE_MAX_PASSWORD_LEN);
-        if (config->pwd[SAE_MAX_PASSWORD_LEN - 1] != 0) {
-            fprintf(stderr, "WARNING: Truncating password\n");
-            config->pwd[SAE_MAX_PASSWORD_LEN - 1] = 0;
-        }
+  }
+  if (config_setting_lookup_string(
+          sae_section, "password", (const char **)&pwd)) {
+    strncpy(config->pwd, pwd, SAE_MAX_PASSWORD_LEN);
+    if (config->pwd[SAE_MAX_PASSWORD_LEN - 1] != 0) {
+      fprintf(stderr, "WARNING: Truncating password\n");
+      config->pwd[SAE_MAX_PASSWORD_LEN - 1] = 0;
     }
-    config_setting_lookup_int(sae_section, "retrans", (config_int_t *)&config->retrans);
-    config_setting_lookup_int(sae_section, "lifetime", (config_int_t *)&config->pmk_expiry);
-    config_setting_lookup_int(sae_section, "thresh", (config_int_t *)&config->open_threshold);
-    config_setting_lookup_int(sae_section, "blacklist", (config_int_t *)&config->blacklist_timeout);
-    config_setting_lookup_int(sae_section, "giveup", (config_int_t *)&config->giveup_threshold);
-    return 0;
+  }
+  config_setting_lookup_int(
+      sae_section, "retrans", (config_int_t *)&config->retrans);
+  config_setting_lookup_int(
+      sae_section, "lifetime", (config_int_t *)&config->pmk_expiry);
+  config_setting_lookup_int(
+      sae_section, "thresh", (config_int_t *)&config->open_threshold);
+  config_setting_lookup_int(
+      sae_section, "blacklist", (config_int_t *)&config->blacklist_timeout);
+  config_setting_lookup_int(
+      sae_section, "giveup", (config_int_t *)&config->giveup_threshold);
+  return 0;
 }
 
+int main(int argc, char *argv[]) {
+  int c;
+  int exitcode = 0;
+  char *mesh_id = NULL;
+  struct nl_sock *nlsock;
+  int daemonize = 0;
+  char *outfile = NULL;
+  char *conffile = NULL;
+  struct sae_config sae_conf;
+  char *ifname = NULL;
 
-int main(int argc, char *argv[])
-{
-    int c;
-    int exitcode = 0;
-    char *mesh_id = NULL;
-    struct nl_sock *nlsock;
-    int daemonize = 0;
-    char *outfile = NULL;
-    char *conffile = NULL;
-    struct sae_config sae_conf;
-    char *ifname = NULL;
+  sae_debug_mask = SAE_DEBUG_ERR;
+  signal(SIGTERM, term_handle);
+  signal(SIGINT, term_handle);
+  signal(SIGSEGV, segv_handle);
+  signal(SIGHUP, hup_handle);
 
-    sae_debug_mask = SAE_DEBUG_ERR;
-    signal(SIGTERM, term_handle);
-    signal(SIGINT, term_handle);
-    signal(SIGSEGV, segv_handle);
-    signal(SIGHUP, hup_handle);
+  memset(&nlcfg, 0, sizeof(nlcfg));
 
-    memset(&nlcfg, 0, sizeof(nlcfg));
-
-    for (;;) {
-        c = getopt(argc, argv, "hc:o:Bi:s:");
-        if (c < 0)
-            break;
-        switch (c) {
-            case 'h':
-                usage();
-                return 0;
-            case 'B':
-                daemonize = 1;
-                break;
-            case 'o':
-                outfile = optarg;
-                break;
-            case 'i':
-                ifname = optarg;
-                break;
-            case 's':
-                mesh_id = optarg;
-                break;
-            case 'c':
-                conffile = optarg;
-                break;
-            default:
-                usage();
-                goto out;
-        }
-    }
-
-    if (conffile) {
-        struct config_t cfg;
-        struct config_setting_t *section;
-
-        config_init(&cfg);
-        if (!config_read_file(&cfg, conffile)) {
-            fprintf(stderr, "Failed to load config file %s: %s\n", conffile,
-                    config_error_text(&cfg));
-            return -1;
-        }
-        section = config_lookup(&cfg, "authsae.sae");
-        if (section == NULL) {
-            fprintf(stderr, "Config file has not sae section\n");
-            return -1;
-        }
-
-        if (sae_parse_libconfig(section, &sae_conf) != 0) {
-            fprintf(stderr, "Failed to parse SAE configuration.\n");
-            return -1;
-        }
-
-        section = config_lookup(&cfg, "authsae.meshd");
-        if (section == NULL) {
-            fprintf(stderr, "Config file has not meshd section\n");
-            return -1;
-        }
-        if (meshd_parse_libconfig(section, &meshd_conf) != 0) {
-            fprintf(stderr, "Failed to parse meshd configuration.\n");
-            return -1;
-        }
-
-        config_destroy(&cfg);
-    }
-
-    /* command line args override config file */
-    if (mesh_id) {
-        if (strlen(mesh_id) > MESHD_MAX_SSID_LEN) {
-            fprintf(stderr, "mesh id %s is too long\n", mesh_id);
-            return -1;
-        }
-        strcpy(meshd_conf.meshid, mesh_id);
-        meshd_conf.meshid_len = strlen(mesh_id);
-    }
-
-    if (ifname) {
-        if (strlen(ifname) > IFNAMSIZ) {
-            fprintf(stderr, "ifname %s is too long\n", ifname);
-            return -1;
-        }
-        strcpy(meshd_conf.interface, ifname);
-    }
-    nlcfg.ifindex = if_nametoindex(meshd_conf.interface);
-
-    /* default to channel 1 */
-    if (meshd_conf.channel <= 0)
-        meshd_conf.channel = 1;
-
-    /* default to mcast-rate of 12 Mbps */
-    if (meshd_conf.mcast_rate <= 0)
-        meshd_conf.mcast_rate = 12;
-
-    mesh.freq = channel_to_freq(meshd_conf.channel);
-    if (mesh.freq == -1)
-        return -1;
-    mesh.channel_type = meshd_conf.channel_type;
-    mesh.band = meshd_conf.band == MESHD_11a ? IEEE80211_BAND_5GHZ
-                                              : IEEE80211_BAND_2GHZ;
-
-    meshd_conf.mcast_rate = meshd_conf.mcast_rate * 10;
-
-    /* this is the default in kernel as well, so no need to do anything else */
-    meshd_conf.ht_prot_mode = IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED;
-
-    /* TODO: Check if ifname is of type mesh and if it's up.
-     * For now this is assumed to be true.
-     */
-
-    if (!strlen(meshd_conf.interface)) {
-        fprintf(stderr, "%s: No interface specified\n", argv[0]);
-        exit(EXIT_FAILURE);
-    }
-
-    exitcode = get_mac_addr(meshd_conf.interface, mesh.mymacaddr);
-    if (exitcode)
-        goto out;
-
-    if (sae_initialize(meshd_conf.meshid, &sae_conf, get_sae_cbs()) < 0) {
-        fprintf(stderr, "%s: cannot configure SAE, check config file!\n", argv[0]);
-        exit(EXIT_FAILURE);
-    }
-
-    /* conf is good */
-    mesh.conf = &meshd_conf;
-
-    if (daemonize) {
-        if (daemon(1, 0) == -1) {
-            exitcode = errno;
-            goto out;
-        }
-    }
-
-    if (outfile) {
-        if (freopen(outfile, "w", stdout) == NULL) {
-            exitcode = errno;
-            goto out;
-        }
-        dup2(fileno(stdout), fileno(stderr));
-    }
-
-    if (netlink_init(&nlcfg, event_handler)) {
-        exitcode = -ESOCKTNOSUPPORT;
+  for (;;) {
+    c = getopt(argc, argv, "hc:o:Bi:s:");
+    if (c < 0)
+      break;
+    switch (c) {
+      case 'h':
+        usage();
+        return 0;
+      case 'B':
+        daemonize = 1;
+        break;
+      case 'o':
+        outfile = optarg;
+        break;
+      case 'i':
+        ifname = optarg;
+        break;
+      case 's':
+        mesh_id = optarg;
+        break;
+      case 'c':
+        conffile = optarg;
+        break;
+      default:
+        usage();
         goto out;
     }
+  }
 
-    if ((srvctx = srv_create_context()) == NULL) {
-        fprintf(stderr, "%s: cannot create service context!\n",
-                argv[0]);
-        exitcode = -ENOMEM;
-        goto out;
+  if (conffile) {
+    struct config_t cfg;
+    struct config_setting_t *section;
+
+    config_init(&cfg);
+    if (!config_read_file(&cfg, conffile)) {
+      fprintf(
+          stderr,
+          "Failed to load config file %s: %s\n",
+          conffile,
+          config_error_text(&cfg));
+      return -1;
+    }
+    section = config_lookup(&cfg, "authsae.sae");
+    if (section == NULL) {
+      fprintf(stderr, "Config file has not sae section\n");
+      return -1;
     }
 
-    rekey_init(&mesh, get_evl_ops());
-    watch_ips_init(&mesh);
+    if (sae_parse_libconfig(section, &sae_conf) != 0) {
+      fprintf(stderr, "Failed to parse SAE configuration.\n");
+      return -1;
+    }
 
-    /* Add netlink sockets to our event loop */
-    nlsock = nlcfg.nl_sock;
-    srv_add_input(srvctx, nl_socket_get_fd(nlsock), nlsock,
-            srv_handler_wrapper);
-    nlsock = nlcfg.nl_sock_event;
-    srv_add_input(srvctx, nl_socket_get_fd(nlsock), nlsock,
-            srv_handler_wrapper);
+    section = config_lookup(&cfg, "authsae.meshd");
+    if (section == NULL) {
+      fprintf(stderr, "Config file has not meshd section\n");
+      return -1;
+    }
+    if (meshd_parse_libconfig(section, &meshd_conf) != 0) {
+      fprintf(stderr, "Failed to parse meshd configuration.\n");
+      return -1;
+    }
 
-    get_wiphy(&nlcfg);
+    config_destroy(&cfg);
+  }
 
-    srv_main_loop(srvctx);
-    leave_mesh(&nlcfg);
+  /* command line args override config file */
+  if (mesh_id) {
+    if (strlen(mesh_id) > MESHD_MAX_SSID_LEN) {
+      fprintf(stderr, "mesh id %s is too long\n", mesh_id);
+      return -1;
+    }
+    strcpy(meshd_conf.meshid, mesh_id);
+    meshd_conf.meshid_len = strlen(mesh_id);
+  }
+
+  if (ifname) {
+    if (strlen(ifname) > IFNAMSIZ) {
+      fprintf(stderr, "ifname %s is too long\n", ifname);
+      return -1;
+    }
+    strcpy(meshd_conf.interface, ifname);
+  }
+  nlcfg.ifindex = if_nametoindex(meshd_conf.interface);
+
+  /* default to channel 1 */
+  if (meshd_conf.channel <= 0)
+    meshd_conf.channel = 1;
+
+  /* default to mcast-rate of 12 Mbps */
+  if (meshd_conf.mcast_rate <= 0)
+    meshd_conf.mcast_rate = 12;
+
+  mesh.freq = channel_to_freq(meshd_conf.channel);
+  if (mesh.freq == -1)
+    return -1;
+  mesh.channel_type = meshd_conf.channel_type;
+  mesh.band =
+      meshd_conf.band == MESHD_11a ? IEEE80211_BAND_5GHZ : IEEE80211_BAND_2GHZ;
+
+  meshd_conf.mcast_rate = meshd_conf.mcast_rate * 10;
+
+  /* this is the default in kernel as well, so no need to do anything else */
+  meshd_conf.ht_prot_mode = IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED;
+
+  /* TODO: Check if ifname is of type mesh and if it's up.
+   * For now this is assumed to be true.
+   */
+
+  if (!strlen(meshd_conf.interface)) {
+    fprintf(stderr, "%s: No interface specified\n", argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  exitcode = get_mac_addr(meshd_conf.interface, mesh.mymacaddr);
+  if (exitcode)
+    goto out;
+
+  if (sae_initialize(meshd_conf.meshid, &sae_conf, get_sae_cbs()) < 0) {
+    fprintf(stderr, "%s: cannot configure SAE, check config file!\n", argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  /* conf is good */
+  mesh.conf = &meshd_conf;
+
+  if (daemonize) {
+    if (daemon(1, 0) == -1) {
+      exitcode = errno;
+      goto out;
+    }
+  }
+
+  if (outfile) {
+    if (freopen(outfile, "w", stdout) == NULL) {
+      exitcode = errno;
+      goto out;
+    }
+    dup2(fileno(stdout), fileno(stderr));
+  }
+
+  if (netlink_init(&nlcfg, event_handler)) {
+    exitcode = -ESOCKTNOSUPPORT;
+    goto out;
+  }
+
+  if ((srvctx = srv_create_context()) == NULL) {
+    fprintf(stderr, "%s: cannot create service context!\n", argv[0]);
+    exitcode = -ENOMEM;
+    goto out;
+  }
+
+  rekey_init(&mesh, get_evl_ops());
+  watch_ips_init(&mesh);
+
+  /* Add netlink sockets to our event loop */
+  nlsock = nlcfg.nl_sock;
+  srv_add_input(srvctx, nl_socket_get_fd(nlsock), nlsock, srv_handler_wrapper);
+  nlsock = nlcfg.nl_sock_event;
+  srv_add_input(srvctx, nl_socket_get_fd(nlsock), nlsock, srv_handler_wrapper);
+
+  get_wiphy(&nlcfg);
+
+  srv_main_loop(srvctx);
+  leave_mesh(&nlcfg);
 out:
-    watch_ips_close();
-    rekey_close();
-    return exitcode;
+  watch_ips_close();
+  rekey_close();
+  return exitcode;
 }

--- a/linux/mon.c
+++ b/linux/mon.c
@@ -52,233 +52,240 @@
 #include "service.h"
 
 struct interface {
-    TAILQ_ENTRY(interface) entry;
-    char ifname[IFNAMSIZ];
-    int fd;     /* BPF socket */
+  TAILQ_ENTRY(interface) entry;
+  char ifname[IFNAMSIZ];
+  int fd; /* BPF socket */
 };
 TAILQ_HEAD(bar, interface) interfaces;
 
 service_context srvctx;
 
-static void
-mgmt_frame_in (int fd, void *data)
-{
-    struct interface *inf = (struct interface *)data;
-    char el_id, el_len, ssid[33];
-    unsigned char buf[2048], *els;
-    struct ieee80211_mgmt_frame *frame;
-    unsigned short frame_control;
-    int type, stype, framesize, left;
-    struct sockaddr_ll from;
-    socklen_t fromlen;
+static void mgmt_frame_in(int fd, void *data) {
+  struct interface *inf = (struct interface *)data;
+  char el_id, el_len, ssid[33];
+  unsigned char buf[2048], *els;
+  struct ieee80211_mgmt_frame *frame;
+  unsigned short frame_control;
+  int type, stype, framesize, left;
+  struct sockaddr_ll from;
+  socklen_t fromlen;
 
-    fromlen = sizeof(from);
-    if ((framesize = recvfrom(fd, buf, sizeof(buf), MSG_TRUNC,
-                              (struct sockaddr *)&from, &fromlen)) < 0) {
-        fprintf(stderr, "can't read off bpf socket!\n");
-        perror("read");
-        return;
-    }
-    /*
-     * we don't want to see outgoing packets otherwise we'll see
-     * everything twice
-     */
-    if (from.sll_pkttype == PACKET_OUTGOING) {
-        return;
-    }
-
-    frame = (struct ieee80211_mgmt_frame *)buf;
-
-    frame_control = ieee_order(frame->frame_control);
-    type = IEEE802_11_FC_GET_TYPE(frame_control);
-    stype = IEEE802_11_FC_GET_STYPE(frame_control);
-    if (type == IEEE802_11_FC_TYPE_MGMT) {
-        switch (stype) {
-            case IEEE802_11_FC_STYPE_BEACON:
-                els = frame->beacon.u.var8;
-                left = framesize - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
-                /*
-                 * els is the next IE in the beacon,
-                 * left is how much is left to read in the beacon
-                 */
-                while (left > 2) {
-                    el_id = *els++;
-                    left--;
-                    el_len = *els++;
-                    left--;
-                    if (el_len > left) {
-                        /*
-                         * someone's trying to mess with us...
-                         */
-                        break;
-                    }
-                    if (el_id == IEEE802_11_IE_SSID) {
-                        if (el_len > 32) {
-                            /*
-                             * again with the messing...
-                             */
-                            break;
-                        }
-                        memset(ssid, 0, sizeof(ssid));
-                        memcpy(ssid, els, el_len);
-                        printf("received BEACON from " MACSTR " on %s\n",
-                               MAC2STR(frame->sa), inf->ifname);
-                        break;
-                    }
-                    els += el_len;
-                    left -= el_len;
-                }
-                break;
-            case IEEE802_11_FC_STYPE_AUTH:
-                printf("received %s frame from " MACSTR " to " MACSTR " on %s\n",
-                       frame->authenticate.auth_seq == SAE_AUTH_COMMIT ? "COMMIT" : "CONFIRM",
-                       MAC2STR(frame->sa), MAC2STR(frame->da), inf->ifname);
-                break;
-            case IEEE802_11_FC_STYPE_ACTION:
-                /* APE exchange */
-                printf("received ACTION frame from " MACSTR " to " MACSTR "\n",
-                       MAC2STR(frame->sa), MAC2STR(frame->da));
-                break;
-        }
-    }
-}
-
-static void
-add_interface (char *ptr)
-{
-    struct interface *inf;
-    struct ifreq ifr;
-    struct sockaddr_ll sll;
-
-    TAILQ_FOREACH(inf, &interfaces, entry) {
-        if (memcmp(&inf->ifname, ptr, strlen(ptr)) == 0) {
-            printf("%s is already on the list!\n", ptr);
-            return;
-        }
-    }
-    if ((inf = (struct interface *)malloc(sizeof(struct interface))) == NULL) {
-        fprintf(stderr, "failed to malloc space for new interface %s!\n", ptr);
-        return;
-    }
-    strncpy(inf->ifname, ptr, strlen(ptr));
-
-    /*
-     * see if this is a loopback interface
-     */
-    if ((inf->fd = socket(PF_PACKET, SOCK_RAW, 0)) < 0) {
-        fprintf(stderr, "unable to get raw socket to determine interface flags!\n");
-        free(inf);
-        return;
-    }
-    memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
-    if (ioctl(inf->fd, SIOCGIFFLAGS, &ifr) < 0) {
-        fprintf(stderr, "unable to get ifflags for %s!\n", ptr);
-        /*
-         * should this be fatal? Dunno, let's just assume it's _not_ loopback
-         */
-        ifr.ifr_flags = 0;
-    }
-    if ((ifr.ifr_flags & IFF_LOOPBACK) == 0) {
-        fprintf(stderr, "only works on loopback for now!\n");
-        free(inf);
-        return;
-    }
-
-    memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
-    if (ioctl(inf->fd, SIOCGIFINDEX, &ifr) < 0) {
-        fprintf(stderr, "unable to get if index on %s\n", inf->ifname);
-        free(inf);
-        return;
-    }
-
-    memset(&sll, 0, sizeof(sll));
-    sll.sll_family = AF_PACKET;
-    sll.sll_ifindex = ifr.ifr_ifindex;
-    sll.sll_protocol = htons(ETH_P_ALL);
-    if (bind(inf->fd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
-        fprintf(stderr, "unable to bind socket to %s\n", inf->ifname);
-        free(inf);
-        return;
-    }
-
-    srv_add_input(srvctx, inf->fd, inf, mgmt_frame_in);
-    TAILQ_INSERT_TAIL(&interfaces, inf, entry);
+  fromlen = sizeof(from);
+  if ((framesize = recvfrom(
+           fd,
+           buf,
+           sizeof(buf),
+           MSG_TRUNC,
+           (struct sockaddr *)&from,
+           &fromlen)) < 0) {
+    fprintf(stderr, "can't read off bpf socket!\n");
+    perror("read");
     return;
+  }
+  /*
+   * we don't want to see outgoing packets otherwise we'll see
+   * everything twice
+   */
+  if (from.sll_pkttype == PACKET_OUTGOING) {
+    return;
+  }
+
+  frame = (struct ieee80211_mgmt_frame *)buf;
+
+  frame_control = ieee_order(frame->frame_control);
+  type = IEEE802_11_FC_GET_TYPE(frame_control);
+  stype = IEEE802_11_FC_GET_STYPE(frame_control);
+  if (type == IEEE802_11_FC_TYPE_MGMT) {
+    switch (stype) {
+      case IEEE802_11_FC_STYPE_BEACON:
+        els = frame->beacon.u.var8;
+        left = framesize - (IEEE802_11_HDR_LEN + sizeof(frame->beacon));
+        /*
+         * els is the next IE in the beacon,
+         * left is how much is left to read in the beacon
+         */
+        while (left > 2) {
+          el_id = *els++;
+          left--;
+          el_len = *els++;
+          left--;
+          if (el_len > left) {
+            /*
+             * someone's trying to mess with us...
+             */
+            break;
+          }
+          if (el_id == IEEE802_11_IE_SSID) {
+            if (el_len > 32) {
+              /*
+               * again with the messing...
+               */
+              break;
+            }
+            memset(ssid, 0, sizeof(ssid));
+            memcpy(ssid, els, el_len);
+            printf(
+                "received BEACON from " MACSTR " on %s\n",
+                MAC2STR(frame->sa),
+                inf->ifname);
+            break;
+          }
+          els += el_len;
+          left -= el_len;
+        }
+        break;
+      case IEEE802_11_FC_STYPE_AUTH:
+        printf(
+            "received %s frame from " MACSTR " to " MACSTR " on %s\n",
+            frame->authenticate.auth_seq == SAE_AUTH_COMMIT ? "COMMIT"
+                                                            : "CONFIRM",
+            MAC2STR(frame->sa),
+            MAC2STR(frame->da),
+            inf->ifname);
+        break;
+      case IEEE802_11_FC_STYPE_ACTION:
+        /* APE exchange */
+        printf(
+            "received ACTION frame from " MACSTR " to " MACSTR "\n",
+            MAC2STR(frame->sa),
+            MAC2STR(frame->da));
+        break;
+    }
+  }
 }
 
-int
-main (int argc, char **argv)
-{
-    int c, ret;
-    char confdir[80], conffile[80], mesh_interface[10];
-    char str[80], *ptr;
-    FILE *fp;
+static void add_interface(char *ptr) {
+  struct interface *inf;
+  struct ifreq ifr;
+  struct sockaddr_ll sll;
 
-    strcpy(confdir, "/usr/local/config");
-    for (;;) {
-        c = getopt(argc, argv, "hI:b");
-        if (c < 0) {
-            break;
-        }
-        switch (c) {
-            case 'I':
-                snprintf(confdir, sizeof(confdir), "%s", optarg);
-                break;
-            case 'b':
-                /*
-                 * detach from controlling terminal and redirect output to /dev/null.
-                 * meshd will not cd to "/" to allow -I to specify relative directories.
-                 */
-                if (daemon(1, 0)) {
-                    perror("daemon");
-                    fprintf(stderr, "%s: unable to daemonize!\n", argv[0]);
-                    exit(1);
-                }
-                break;
-            default:
-            case 'h':
-                fprintf(stderr,
-                        "USAGE: %s [-hIb]\n\t-h  show usage, and exit\n"
-                        "\t-I  directory of config files\n"
-                        "\t-b  run in the background\n",
-                        argv[0]);
-                exit(1);
-
-        }
+  TAILQ_FOREACH(inf, &interfaces, entry) {
+    if (memcmp(&inf->ifname, ptr, strlen(ptr)) == 0) {
+      printf("%s is already on the list!\n", ptr);
+      return;
     }
+  }
+  if ((inf = (struct interface *)malloc(sizeof(struct interface))) == NULL) {
+    fprintf(stderr, "failed to malloc space for new interface %s!\n", ptr);
+    return;
+  }
+  strncpy(inf->ifname, ptr, strlen(ptr));
 
-    TAILQ_INIT(&interfaces);
-    if ((srvctx = srv_create_context()) == NULL) {
-        fprintf(stderr, "%s: cannot create service context!\n", argv[0]);
+  /*
+   * see if this is a loopback interface
+   */
+  if ((inf->fd = socket(PF_PACKET, SOCK_RAW, 0)) < 0) {
+    fprintf(stderr, "unable to get raw socket to determine interface flags!\n");
+    free(inf);
+    return;
+  }
+  memset(&ifr, 0, sizeof(ifr));
+  strncpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
+  if (ioctl(inf->fd, SIOCGIFFLAGS, &ifr) < 0) {
+    fprintf(stderr, "unable to get ifflags for %s!\n", ptr);
+    /*
+     * should this be fatal? Dunno, let's just assume it's _not_ loopback
+     */
+    ifr.ifr_flags = 0;
+  }
+  if ((ifr.ifr_flags & IFF_LOOPBACK) == 0) {
+    fprintf(stderr, "only works on loopback for now!\n");
+    free(inf);
+    return;
+  }
+
+  memset(&ifr, 0, sizeof(ifr));
+  strncpy(ifr.ifr_name, inf->ifname, IFNAMSIZ);
+  if (ioctl(inf->fd, SIOCGIFINDEX, &ifr) < 0) {
+    fprintf(stderr, "unable to get if index on %s\n", inf->ifname);
+    free(inf);
+    return;
+  }
+
+  memset(&sll, 0, sizeof(sll));
+  sll.sll_family = AF_PACKET;
+  sll.sll_ifindex = ifr.ifr_ifindex;
+  sll.sll_protocol = htons(ETH_P_ALL);
+  if (bind(inf->fd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
+    fprintf(stderr, "unable to bind socket to %s\n", inf->ifname);
+    free(inf);
+    return;
+  }
+
+  srv_add_input(srvctx, inf->fd, inf, mgmt_frame_in);
+  TAILQ_INSERT_TAIL(&interfaces, inf, entry);
+  return;
+}
+
+int main(int argc, char **argv) {
+  int c, ret;
+  char confdir[80], conffile[80], mesh_interface[10];
+  char str[80], *ptr;
+  FILE *fp;
+
+  strcpy(confdir, "/usr/local/config");
+  for (;;) {
+    c = getopt(argc, argv, "hI:b");
+    if (c < 0) {
+      break;
+    }
+    switch (c) {
+      case 'I':
+        snprintf(confdir, sizeof(confdir), "%s", optarg);
+        break;
+      case 'b':
+        /*
+         * detach from controlling terminal and redirect output to /dev/null.
+         * meshd will not cd to "/" to allow -I to specify relative directories.
+         */
+        if (daemon(1, 0)) {
+          perror("daemon");
+          fprintf(stderr, "%s: unable to daemonize!\n", argv[0]);
+          exit(1);
+        }
+        break;
+      default:
+      case 'h':
+        fprintf(
+            stderr,
+            "USAGE: %s [-hIb]\n\t-h  show usage, and exit\n"
+            "\t-I  directory of config files\n"
+            "\t-b  run in the background\n",
+            argv[0]);
         exit(1);
     }
+  }
 
-    snprintf(conffile, sizeof(conffile), "%s/mon.conf", confdir);
-    strcpy(mesh_interface, "lo0");
-    if ((fp = fopen(conffile, "r")) != NULL) {
-        while (!feof(fp)) {
-            if (fgets(str, sizeof(str), fp) == 0) {
-                continue;
-            }
-            if ((ret = parse_buffer(str, &ptr)) < 0) {
-                break;
-            }
-            if (ret == 0) {
-                continue;
-            }
-            if (strncmp(str, "interface", strlen("interface")) == 0) {
-                add_interface(ptr);
-            }
-        }
-    }
-
-    if (TAILQ_EMPTY(&interfaces)) {
-        fprintf(stderr, "%s: no interfaces defined!\n", argv[0]);
-        add_interface("lo");
-    }
-    srv_main_loop(srvctx);
-
+  TAILQ_INIT(&interfaces);
+  if ((srvctx = srv_create_context()) == NULL) {
+    fprintf(stderr, "%s: cannot create service context!\n", argv[0]);
     exit(1);
+  }
+
+  snprintf(conffile, sizeof(conffile), "%s/mon.conf", confdir);
+  strcpy(mesh_interface, "lo0");
+  if ((fp = fopen(conffile, "r")) != NULL) {
+    while (!feof(fp)) {
+      if (fgets(str, sizeof(str), fp) == 0) {
+        continue;
+      }
+      if ((ret = parse_buffer(str, &ptr)) < 0) {
+        break;
+      }
+      if (ret == 0) {
+        continue;
+      }
+      if (strncmp(str, "interface", strlen("interface")) == 0) {
+        add_interface(ptr);
+      }
+    }
+  }
+
+  if (TAILQ_EMPTY(&interfaces)) {
+    fprintf(stderr, "%s: no interfaces defined!\n", argv[0]);
+    add_interface("lo");
+  }
+  srv_main_loop(srvctx);
+
+  exit(1);
 }

--- a/linux/nlutils.c
+++ b/linux/nlutils.c
@@ -24,268 +24,290 @@
 #include <netlink/genl/ctrl.h>
 #include <netlink/genl/genl.h>
 
-static int ack_handler(struct nl_msg *msg, void *arg)
-{
-    int *err = arg;
-    *err = 0;
-    return NL_STOP;
+static int ack_handler(struct nl_msg *msg, void *arg) {
+  int *err = arg;
+  *err = 0;
+  return NL_STOP;
 }
 
-static int finish_handler(struct nl_msg *msg, void *arg)
-{
-    int *ret = arg;
-    *ret = 0;
-    return NL_SKIP;
+static int finish_handler(struct nl_msg *msg, void *arg) {
+  int *ret = arg;
+  *ret = 0;
+  return NL_SKIP;
 }
 
-static int error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err,
-        void *arg)
-{
-    struct netlink_config_s *nlcfg = arg;
-    struct genlmsghdr *gnlh = nlmsg_data(&err->msg);
+static int
+error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err, void *arg) {
+  struct netlink_config_s *nlcfg = arg;
+  struct genlmsghdr *gnlh = nlmsg_data(&err->msg);
 
-    if (arg && err && nlcfg->supress_error) {
-        if (nlcfg->supress_error != err->error) {
-            fprintf(stderr, "Unexpected error %d ", err->error);
-            fprintf(stderr, "(expected %d)\n", nlcfg->supress_error);
-        } else {
-            /* do nothing: this was an expected error */
-        }
+  if (arg && err && nlcfg->supress_error) {
+    if (nlcfg->supress_error != err->error) {
+      fprintf(stderr, "Unexpected error %d ", err->error);
+      fprintf(stderr, "(expected %d)\n", nlcfg->supress_error);
     } else {
-	    fprintf(stderr, "nlerror, cmd %d, seq %d: %s\n", gnlh->cmd, err->msg.nlmsg_seq,
-							     strerror(abs(err->error)));
+      /* do nothing: this was an expected error */
     }
-    nlcfg->supress_error = 0;
-    return NL_SKIP;
+  } else {
+    fprintf(
+        stderr,
+        "nlerror, cmd %d, seq %d: %s\n",
+        gnlh->cmd,
+        err->msg.nlmsg_seq,
+        strerror(abs(err->error)));
+  }
+  nlcfg->supress_error = 0;
+  return NL_SKIP;
 }
 
-static int simple_error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err,
-                                void *arg)
-{
-    int *ret = arg;
-    *ret = 0;
-    if (arg && err) {
-        *ret = err->error;
-        if (*ret != 0)
-            return NL_STOP;
-    }
-    return NL_SKIP;
+static int
+simple_error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err, void *arg) {
+  int *ret = arg;
+  *ret = 0;
+  if (arg && err) {
+    *ret = err->error;
+    if (*ret != 0)
+      return NL_STOP;
+  }
+  return NL_SKIP;
 }
 
-int send_nlmsg(struct nl_sock *nl_sock, struct nl_msg *msg)
-{
-        int err = -ENOMEM;
+int send_nlmsg(struct nl_sock *nl_sock, struct nl_msg *msg) {
+  int err = -ENOMEM;
 
-        err = nl_send_auto_complete(nl_sock, msg);
+  err = nl_send_auto_complete(nl_sock, msg);
 
-        return err;
+  return err;
 }
 
-static int send_and_recv(struct nl_sock *nl_sock, struct nl_msg *msg,
-                         int (*valid_handler)(struct nl_msg *, void *),
-                         void *valid_data)
-{
-        struct nl_cb *cb;
-        int err = -ENOMEM;
+static int send_and_recv(
+    struct nl_sock *nl_sock,
+    struct nl_msg *msg,
+    int (*valid_handler)(struct nl_msg *, void *),
+    void *valid_data) {
+  struct nl_cb *cb;
+  int err = -ENOMEM;
 
-        cb = nl_cb_clone(nl_socket_get_cb(nl_sock));
-        if (!cb)
-                goto out;
+  cb = nl_cb_clone(nl_socket_get_cb(nl_sock));
+  if (!cb)
+    goto out;
 
-        err = nl_send_auto_complete(nl_sock, msg);
-        if (err < 0)
-                goto out;
+  err = nl_send_auto_complete(nl_sock, msg);
+  if (err < 0)
+    goto out;
 
-        err = 1;
+  err = 1;
 
-        nl_cb_err(cb, NL_CB_CUSTOM, simple_error_handler, &err);
-        nl_cb_set(cb, NL_CB_FINISH, NL_CB_CUSTOM, finish_handler, &err);
-        nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, ack_handler, &err);
+  nl_cb_err(cb, NL_CB_CUSTOM, simple_error_handler, &err);
+  nl_cb_set(cb, NL_CB_FINISH, NL_CB_CUSTOM, finish_handler, &err);
+  nl_cb_set(cb, NL_CB_ACK, NL_CB_CUSTOM, ack_handler, &err);
 
+  if (valid_handler)
+    nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, valid_handler, valid_data);
 
-        if (valid_handler)
-                nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM,
-                          valid_handler, valid_data);
-
-        while (err > 0)
-                nl_recvmsgs(nl_sock, cb);
- out:
-        nl_cb_put(cb);
-        return err;
+  while (err > 0)
+    nl_recvmsgs(nl_sock, cb);
+out:
+  nl_cb_put(cb);
+  return err;
 }
 
 struct family_data {
-        const char *group;
-        int id;
+  const char *group;
+  int id;
 };
 
-static int family_handler(struct nl_msg *msg, void *arg)
-{
-        struct family_data *res = arg;
-        struct nlattr *tb[CTRL_ATTR_MAX + 1];
-        struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-        struct nlattr *mcgrp;
-        int i;
+static int family_handler(struct nl_msg *msg, void *arg) {
+  struct family_data *res = arg;
+  struct nlattr *tb[CTRL_ATTR_MAX + 1];
+  struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+  struct nlattr *mcgrp;
+  int i;
 
-        nla_parse(tb, CTRL_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-                  genlmsg_attrlen(gnlh, 0), NULL);
-        if (!tb[CTRL_ATTR_MCAST_GROUPS])
-                return NL_SKIP;
+  nla_parse(
+      tb,
+      CTRL_ATTR_MAX,
+      genlmsg_attrdata(gnlh, 0),
+      genlmsg_attrlen(gnlh, 0),
+      NULL);
+  if (!tb[CTRL_ATTR_MCAST_GROUPS])
+    return NL_SKIP;
 
-        nla_for_each_nested(mcgrp, tb[CTRL_ATTR_MCAST_GROUPS], i) {
-                struct nlattr *tb2[CTRL_ATTR_MCAST_GRP_MAX + 1];
-                nla_parse(tb2, CTRL_ATTR_MCAST_GRP_MAX, nla_data(mcgrp),
-                          nla_len(mcgrp), NULL);
-                if (!tb2[CTRL_ATTR_MCAST_GRP_NAME] ||
-                    !tb2[CTRL_ATTR_MCAST_GRP_ID] ||
-                    strncmp(nla_data(tb2[CTRL_ATTR_MCAST_GRP_NAME]),
-                               res->group,
-                               nla_len(tb2[CTRL_ATTR_MCAST_GRP_NAME])) != 0)
-                        continue;
-                res->id = nla_get_u32(tb2[CTRL_ATTR_MCAST_GRP_ID]);
-                break;
-        };
+  nla_for_each_nested(mcgrp, tb[CTRL_ATTR_MCAST_GROUPS], i) {
+    struct nlattr *tb2[CTRL_ATTR_MCAST_GRP_MAX + 1];
+    nla_parse(
+        tb2, CTRL_ATTR_MCAST_GRP_MAX, nla_data(mcgrp), nla_len(mcgrp), NULL);
+    if (!tb2[CTRL_ATTR_MCAST_GRP_NAME] || !tb2[CTRL_ATTR_MCAST_GRP_ID] ||
+        strncmp(
+            nla_data(tb2[CTRL_ATTR_MCAST_GRP_NAME]),
+            res->group,
+            nla_len(tb2[CTRL_ATTR_MCAST_GRP_NAME])) != 0)
+      continue;
+    res->id = nla_get_u32(tb2[CTRL_ATTR_MCAST_GRP_ID]);
+    break;
+  };
 
-        return NL_SKIP;
+  return NL_SKIP;
 }
 
-static int nl_get_multicast_id(struct nl_sock *nl_sock, const char
-        *family, const char *group) {
-	struct nl_msg *msg;
-	int ret = -1;
-	struct family_data res = { group, -ENOENT };
+static int nl_get_multicast_id(
+    struct nl_sock *nl_sock,
+    const char *family,
+    const char *group) {
+  struct nl_msg *msg;
+  int ret = -1;
+  struct family_data res = {group, -ENOENT};
 
-	msg = nlmsg_alloc();
-	if (!msg)
-		return -ENOMEM;
-	genlmsg_put(msg, 0, 0, genl_ctrl_resolve(nl_sock,
-		"nlctrl"), 0, 0, CTRL_CMD_GETFAMILY, 0);
-	NLA_PUT_STRING(msg, CTRL_ATTR_FAMILY_NAME, family);
+  msg = nlmsg_alloc();
+  if (!msg)
+    return -ENOMEM;
+  genlmsg_put(
+      msg,
+      0,
+      0,
+      genl_ctrl_resolve(nl_sock, "nlctrl"),
+      0,
+      0,
+      CTRL_CMD_GETFAMILY,
+      0);
+  NLA_PUT_STRING(msg, CTRL_ATTR_FAMILY_NAME, family);
 
-	ret = send_and_recv(nl_sock, msg, family_handler, &res);
-	nlmsg_free(msg);
-	msg = NULL;
-	if (ret == 0)
-		ret = res.id;
+  ret = send_and_recv(nl_sock, msg, family_handler, &res);
+  nlmsg_free(msg);
+  msg = NULL;
+  if (ret == 0)
+    ret = res.id;
 
 nla_put_failure:
-	return ret;
+  return ret;
 }
 
-int netlink_init(struct netlink_config_s *nlcfg, void *event_handler)
-{
-	int ret;
-    struct nl_cb *cb;
+int netlink_init(struct netlink_config_s *nlcfg, void *event_handler) {
+  int ret;
+  struct nl_cb *cb;
 
-    //nl_debug = 4;
+  // nl_debug = 4;
 
-    /* Allocate nl socket for commands with default callback */
-	nlcfg->nl_sock = nl_socket_alloc();
-	if (nlcfg->nl_sock == NULL) {
-		printf("Failed to allocate netlink socket");
-		goto err1;
-	}
+  /* Allocate nl socket for commands with default callback */
+  nlcfg->nl_sock = nl_socket_alloc();
+  if (nlcfg->nl_sock == NULL) {
+    printf("Failed to allocate netlink socket");
+    goto err1;
+  }
 
-    cb = nl_socket_get_cb(nlcfg->nl_sock);
+  cb = nl_socket_get_cb(nlcfg->nl_sock);
 
-    if (cb == NULL) {
-        goto err2;
-    }
+  if (cb == NULL) {
+    goto err2;
+  }
 
-    /* Allocate nl socket for events, same callback */
-	nlcfg->nl_sock_event = nl_socket_alloc_cb(cb);
+  /* Allocate nl socket for events, same callback */
+  nlcfg->nl_sock_event = nl_socket_alloc_cb(cb);
 
-	if (nlcfg->nl_sock_event == NULL) {
-		printf("Failed to allocate netlink event socket");
-		goto err2;
-	}
+  if (nlcfg->nl_sock_event == NULL) {
+    printf("Failed to allocate netlink event socket");
+    goto err2;
+  }
 
-    /* Connect both sockets to generic netlink on kernel side */
-	if (genl_connect(nlcfg->nl_sock)) {
-		printf("Failed to connect to generic netlink");
-		goto err3;
-	}
+  /* Connect both sockets to generic netlink on kernel side */
+  if (genl_connect(nlcfg->nl_sock)) {
+    printf("Failed to connect to generic netlink");
+    goto err3;
+  }
 
-	if (genl_connect(nlcfg->nl_sock_event)) {
-		printf("Failed to connect events to generic netlink");
-		goto err3;
-	}
+  if (genl_connect(nlcfg->nl_sock_event)) {
+    printf("Failed to connect events to generic netlink");
+    goto err3;
+  }
 
-    /* Increase the default buffer size on both sockets */
-#define NL_SOCKET_BUFFER_SIZE   (1024 * 256)
-    ret = nl_socket_set_buffer_size(nlcfg->nl_sock_event, NL_SOCKET_BUFFER_SIZE, NL_SOCKET_BUFFER_SIZE);
-    if (ret)
-        fprintf(stderr, "nl_socket_set_buffer_size failed with error %d, errno %d)\n", ret, errno);
+/* Increase the default buffer size on both sockets */
+#define NL_SOCKET_BUFFER_SIZE (1024 * 256)
+  ret = nl_socket_set_buffer_size(
+      nlcfg->nl_sock_event, NL_SOCKET_BUFFER_SIZE, NL_SOCKET_BUFFER_SIZE);
+  if (ret)
+    fprintf(
+        stderr,
+        "nl_socket_set_buffer_size failed with error %d, errno %d)\n",
+        ret,
+        errno);
 
-    ret = nl_socket_set_buffer_size(nlcfg->nl_sock, NL_SOCKET_BUFFER_SIZE, NL_SOCKET_BUFFER_SIZE);
-    if (ret)
-        fprintf(stderr, "nl_socket_set_buffer_size failed with error %d, errno %d)\n", ret, errno);
+  ret = nl_socket_set_buffer_size(
+      nlcfg->nl_sock, NL_SOCKET_BUFFER_SIZE, NL_SOCKET_BUFFER_SIZE);
+  if (ret)
+    fprintf(
+        stderr,
+        "nl_socket_set_buffer_size failed with error %d, errno %d)\n",
+        ret,
+        errno);
 
-    /* Allocate caches for each socket */
-	if (genl_ctrl_alloc_cache(nlcfg->nl_sock, &nlcfg->nl_cache) < 0) {
-		printf("Failed to allocate generic netlink cache");
-		goto err3;
-	}
+  /* Allocate caches for each socket */
+  if (genl_ctrl_alloc_cache(nlcfg->nl_sock, &nlcfg->nl_cache) < 0) {
+    printf("Failed to allocate generic netlink cache");
+    goto err3;
+  }
 
-	if (genl_ctrl_alloc_cache(nlcfg->nl_sock_event, &nlcfg->nl_cache_event) <
-	    0) {
-		printf("Failed to allocate events cache");
-		goto err3b;
-	}
+  if (genl_ctrl_alloc_cache(nlcfg->nl_sock_event, &nlcfg->nl_cache_event) < 0) {
+    printf("Failed to allocate events cache");
+    goto err3b;
+  }
 
-    /* Find nl80211 family in the generic netlink cache */
-	nlcfg->nl80211 = genl_ctrl_search_by_name(nlcfg->nl_cache, "nl80211");
-	if (nlcfg->nl80211 == NULL) {
-		printf("'nl80211' generic netlink not found");
-		goto err4;
-	}
+  /* Find nl80211 family in the generic netlink cache */
+  nlcfg->nl80211 = genl_ctrl_search_by_name(nlcfg->nl_cache, "nl80211");
+  if (nlcfg->nl80211 == NULL) {
+    printf("'nl80211' generic netlink not found");
+    goto err4;
+  }
 
-    /* Register events socket for multicast mlme events */
-	ret = nl_get_multicast_id(nlcfg->nl_sock, "nl80211", "mlme");
-	if (ret >= 0)
-		ret = nl_socket_add_membership(nlcfg->nl_sock_event, ret);
+  /* Register events socket for multicast mlme events */
+  ret = nl_get_multicast_id(nlcfg->nl_sock, "nl80211", "mlme");
+  if (ret >= 0)
+    ret = nl_socket_add_membership(nlcfg->nl_sock_event, ret);
 
-	if (ret < 0) {
-		printf("Could not add multicast "
-			   "membership for mlme events: %d (%s)",
-			   ret, strerror(-ret));
-		goto err4;
-	}
+  if (ret < 0) {
+    printf(
+        "Could not add multicast "
+        "membership for mlme events: %d (%s)",
+        ret,
+        strerror(-ret));
+    goto err4;
+  }
 
-    /* Register for scan events */
-	ret = nl_get_multicast_id(nlcfg->nl_sock, "nl80211", "scan");
-	if (ret >= 0)
-		ret = nl_socket_add_membership(nlcfg->nl_sock_event, ret);
+  /* Register for scan events */
+  ret = nl_get_multicast_id(nlcfg->nl_sock, "nl80211", "scan");
+  if (ret >= 0)
+    ret = nl_socket_add_membership(nlcfg->nl_sock_event, ret);
 
-	if (ret < 0) {
-		printf("Could not add multicast "
-			   "membership for scan events: %d (%s)",
-			   ret, strerror(-ret));
-		goto err4;
-	}
+  if (ret < 0) {
+    printf(
+        "Could not add multicast "
+        "membership for scan events: %d (%s)",
+        ret,
+        strerror(-ret));
+    goto err4;
+  }
 
-    /* Sequence checking needs to be disabled for events.  Note that
-     * this will also disable it for on the commands socket, given
-     * that they share the same callback. */
-    nl_socket_disable_seq_check(nlcfg->nl_sock);
+  /* Sequence checking needs to be disabled for events.  Note that
+   * this will also disable it for on the commands socket, given
+   * that they share the same callback. */
+  nl_socket_disable_seq_check(nlcfg->nl_sock);
 
-    /* Register our callback function for valid messages */
-    nl_socket_modify_cb(nlcfg->nl_sock, NL_CB_VALID, NL_CB_CUSTOM,
-            event_handler, &nlcfg);
+  /* Register our callback function for valid messages */
+  nl_socket_modify_cb(
+      nlcfg->nl_sock, NL_CB_VALID, NL_CB_CUSTOM, event_handler, &nlcfg);
 
-    /* print errors */
-    nl_cb_err(cb, NL_CB_CUSTOM, error_handler, nlcfg);
+  /* print errors */
+  nl_cb_err(cb, NL_CB_CUSTOM, error_handler, nlcfg);
 
-	return 0;
+  return 0;
 
 err4:
-	nl_cache_free(nlcfg->nl_cache_event);
+  nl_cache_free(nlcfg->nl_cache_event);
 err3b:
-	nl_cache_free(nlcfg->nl_cache);
+  nl_cache_free(nlcfg->nl_cache);
 err3:
-	nl_socket_free(nlcfg->nl_sock_event);
+  nl_socket_free(nlcfg->nl_sock_event);
 err2:
-	nl_socket_free(nlcfg->nl_sock);
+  nl_socket_free(nlcfg->nl_sock);
 err1:
-	return -1;
+  return -1;
 }

--- a/linux/nlutils.h
+++ b/linux/nlutils.h
@@ -32,19 +32,21 @@
 /* leave hw/kernel info here for now, maybe move to common.h? */
 
 struct netlink_config_s {
-	struct nl_sock *nl_sock;
-	struct nl_cache *nl_cache;
-	struct nl_sock *nl_sock_event;
-	struct nl_cache *nl_cache_event;
-	struct nl_cb *nl_cb;
-	struct genl_family *nl80211;
-	int supress_error;
-	int ifindex;
+  struct nl_sock *nl_sock;
+  struct nl_cache *nl_cache;
+  struct nl_sock *nl_sock_event;
+  struct nl_cache *nl_cache_event;
+  struct nl_cb *nl_cb;
+  struct genl_family *nl80211;
+  int supress_error;
+  int ifindex;
 };
 
 int netlink_init(struct netlink_config_s *nlcfg, void *event_handler);
 int send_nlmsg(struct nl_sock *nl_sock, struct nl_msg *msg);
-int send_nlmsg_suppress_error(struct nl_sock *nl_sock,
-        struct nl_msg *msg, int expect_err);
+int send_nlmsg_suppress_error(
+    struct nl_sock *nl_sock,
+    struct nl_msg *msg,
+    int expect_err);
 
 #endif /* _SAE_NLUTILS_H_ */

--- a/linux/service.c
+++ b/linux/service.c
@@ -48,10 +48,9 @@
 
 #define SRV_TICK 1000000
 
-#define IS_ZERO(t)	(!(t)->tv_sec && !(t)->tv_nsec)
+#define IS_ZERO(t) (!(t)->tv_sec && !(t)->tv_nsec)
 
 #define NANOSECONDS_PER_SEC (1000000000)
-
 
 static void timespec_to_timeval(struct timespec *spec, struct timeval *val) {
   val->tv_sec = spec->tv_sec;
@@ -59,16 +58,16 @@ static void timespec_to_timeval(struct timespec *spec, struct timeval *val) {
 }
 
 static void normalise_time(struct timespec *t) {
-   while (t->tv_nsec < 0) {
-     t->tv_sec--;
-     t->tv_nsec += NANOSECONDS_PER_SEC;
-   }
-   while (t->tv_nsec >= NANOSECONDS_PER_SEC) {
-     t->tv_sec++;
-     t->tv_nsec -= NANOSECONDS_PER_SEC;
-   }
+  while (t->tv_nsec < 0) {
+    t->tv_sec--;
+    t->tv_nsec += NANOSECONDS_PER_SEC;
+  }
+  while (t->tv_nsec >= NANOSECONDS_PER_SEC) {
+    t->tv_sec++;
+    t->tv_nsec -= NANOSECONDS_PER_SEC;
+  }
 
-   /* t.tv_nsec in [0, NANOSECONDS_PER_SEC) */
+  /* t.tv_nsec in [0, NANOSECONDS_PER_SEC) */
 }
 
 /*
@@ -130,10 +129,8 @@ static int cmp_time(struct timespec *t1, struct timespec *t2) {
  * cmp_timers()
  *	callback for qsort() to put timers in ascending order
  */
-static int
-cmp_timers (struct timer *t1, struct timer *t2)
-{
-    return (cmp_time(&(t1->to), &(t2->to)));
+static int cmp_timers(struct timer *t1, struct timer *t2) {
+  return (cmp_time(&(t1->to), &(t2->to)));
 }
 
 /*
@@ -142,79 +139,87 @@ cmp_timers (struct timer *t1, struct timer *t2)
  *      Returns a handle to the timer or 0 if we run out
  *      of timers.
  */
-timerid
-srv_add_timeout_with_jitter (service_context context, microseconds usec,
-		 timercb proc, void *data, microseconds jitter_usecs)
-{
-    struct timespec right_now;
-    timerid id;
-    int i;
+timerid srv_add_timeout_with_jitter(
+    service_context context,
+    microseconds usec,
+    timercb proc,
+    void *data,
+    microseconds jitter_usecs) {
+  struct timespec right_now;
+  timerid id;
+  int i;
 
-    if (jitter_usecs) {
-        long long rand_number, delta, new_usec;
-        i = RAND_bytes((unsigned char *) &rand_number, sizeof(rand_number));
-        if (i == 0) {
-            fprintf(stderr, "failed to generate random jitter!\n");
-            return 0;
-        }
-        delta = -(long long) jitter_usecs/2  + llabs(rand_number) % jitter_usecs;
-
-        new_usec = (long long) usec + delta;
-        if (new_usec < 0)
-            usec = 1;
-        else
-            usec = (microseconds) new_usec;
+  if (jitter_usecs) {
+    long long rand_number, delta, new_usec;
+    i = RAND_bytes((unsigned char *)&rand_number, sizeof(rand_number));
+    if (i == 0) {
+      fprintf(stderr, "failed to generate random jitter!\n");
+      return 0;
     }
+    delta = -(long long)jitter_usecs / 2 + llabs(rand_number) % jitter_usecs;
 
-    if (context->ntimers >= NTIMERS) {
-        sae_debug(SAE_DEBUG_ERR, "too many timers!\n");
-        return 0;
-    }
-    context->timers[context->ntimers].to.tv_sec = usec/SRV_TICK;
-    context->timers[context->ntimers].to.tv_nsec = 1000 * (usec - ((usec/SRV_TICK)*SRV_TICK));
-    id = context->timers[context->ntimers].id = ++(context->timer_id);
-    context->timers[context->ntimers].proc = proc;
-    context->timers[context->ntimers].data = data;
+    new_usec = (long long)usec + delta;
+    if (new_usec < 0)
+      usec = 1;
+    else
+      usec = (microseconds)new_usec;
+  }
 
-    clock_gettime(CLOCK_MONOTONIC, &right_now);
-    add_time(&(context->timers[context->ntimers].to), &right_now);
-    context->ntimers++;
-    qsort(context->timers, context->ntimers, sizeof(struct timer), (int (*)())cmp_timers);
+  if (context->ntimers >= NTIMERS) {
+    sae_debug(SAE_DEBUG_ERR, "too many timers!\n");
+    return 0;
+  }
+  context->timers[context->ntimers].to.tv_sec = usec / SRV_TICK;
+  context->timers[context->ntimers].to.tv_nsec =
+      1000 * (usec - ((usec / SRV_TICK) * SRV_TICK));
+  id = context->timers[context->ntimers].id = ++(context->timer_id);
+  context->timers[context->ntimers].proc = proc;
+  context->timers[context->ntimers].data = data;
 
-    return id;
+  clock_gettime(CLOCK_MONOTONIC, &right_now);
+  add_time(&(context->timers[context->ntimers].to), &right_now);
+  context->ntimers++;
+  qsort(
+      context->timers,
+      context->ntimers,
+      sizeof(struct timer),
+      (int (*)())cmp_timers);
+
+  return id;
 }
 
 /*
  * srv_rem_timer()
  *	given a handle remove the timer from a service context
  */
-int
-srv_rem_timeout (service_context context, timerid id)
-{
-    int i;
+int srv_rem_timeout(service_context context, timerid id) {
+  int i;
 
-    /*
-     * timer id's should always be non-zero so if someone is trying to
-     * cancel a zero timer it means he's trying to cancel an already
-     * cancelled timer. Don't locate a timer with id = 0 and erroneously
-     * decrement the number of timers, just return.
-     */
-    if (id == 0) {
-        return 0;
+  /*
+   * timer id's should always be non-zero so if someone is trying to
+   * cancel a zero timer it means he's trying to cancel an already
+   * cancelled timer. Don't locate a timer with id = 0 and erroneously
+   * decrement the number of timers, just return.
+   */
+  if (id == 0) {
+    return 0;
+  }
+  for (i = 0; i < NTIMERS; i++) {
+    if (context->timers[i].id == id) {
+      context->timers[i].id = 0;
+      context->timers[i].to.tv_sec = context->timers[i].to.tv_nsec = 0;
+      if (context->ntimers > 1) {
+        qsort(
+            context->timers,
+            context->ntimers,
+            sizeof(struct timer),
+            (int (*)())cmp_timers);
+      }
+      context->ntimers--;
+      break;
     }
-    for (i=0; i<NTIMERS; i++) {
-	if (context->timers[i].id == id) {
-	    context->timers[i].id = 0;
-	    context->timers[i].to.tv_sec = context->timers[i].to.tv_nsec = 0;
-	    if (context->ntimers > 1) {
-		qsort(context->timers, context->ntimers, sizeof(struct timer),
-		      (int (*)())cmp_timers);
-	    }
-	    context->ntimers--;
-	    break;
-	}
-    }
-    return (i < NTIMERS);
+  }
+  return (i < NTIMERS);
 }
 
 /*
@@ -222,62 +227,58 @@ srv_rem_timeout (service_context context, timerid id)
  *	add an input with callback and data to a service context
  *	Returns 0 on success, -1 and ERANGE if we run out of bits.
  */
-int
-srv_add_input (service_context context, int fd, void *data, fdcb proc)
-{
-    int i, next = -1;
+int srv_add_input(service_context context, int fd, void *data, fdcb proc) {
+  int i, next = -1;
 
-    /*
-     * first see if there's any available, if not we add to the end and
-     * bump the ninputs high-water-mark
-     */
+  /*
+   * first see if there's any available, if not we add to the end and
+   * bump the ninputs high-water-mark
+   */
 
-    for (i=0; i<context->ninputs; i++) {
-	if (context->inputs[i].fd == fd) {
-	    next = i;
-	    break;
-	}
+  for (i = 0; i < context->ninputs; i++) {
+    if (context->inputs[i].fd == fd) {
+      next = i;
+      break;
     }
-    if (next == -1) {
-	if (i < NFDS) {
-	    next = i;
-	    context->ninputs++;
-	} else {
-	    errno = ERANGE;
-	    return -1;
-	}
+  }
+  if (next == -1) {
+    if (i < NFDS) {
+      next = i;
+      context->ninputs++;
+    } else {
+      errno = ERANGE;
+      return -1;
     }
-    FD_SET(fd, &context->readfds);
-    FD_SET(fd, &context->exceptfds);
-    context->inputs[next].fd = fd;
-    context->inputs[next].proc = proc;
-    context->inputs[next].data = data;
-    return 0;
+  }
+  FD_SET(fd, &context->readfds);
+  FD_SET(fd, &context->exceptfds);
+  context->inputs[next].fd = fd;
+  context->inputs[next].proc = proc;
+  context->inputs[next].data = data;
+  return 0;
 }
 
 /*
  * srv_rem_input()
  *	remove an input from a service context
  */
-void
-srv_rem_input (service_context context, int fd)
-{
-    int i;
+void srv_rem_input(service_context context, int fd) {
+  int i;
 
-    for (i=0; i<context->ninputs; i++) {
-	if (context->inputs[i].fd == fd) {
-	    context->inputs[i].fd = 0;
-	    context->ninputs--;
-	    /*
-	     * swap structures so it's contiguous
-	     */
-	    context->inputs[i] = context->inputs[context->ninputs];
-	    FD_CLR(fd, &context->readfds);
-            FD_CLR(fd, &context->exceptfds);
-	    return;
-	}
+  for (i = 0; i < context->ninputs; i++) {
+    if (context->inputs[i].fd == fd) {
+      context->inputs[i].fd = 0;
+      context->ninputs--;
+      /*
+       * swap structures so it's contiguous
+       */
+      context->inputs[i] = context->inputs[context->ninputs];
+      FD_CLR(fd, &context->readfds);
+      FD_CLR(fd, &context->exceptfds);
+      return;
     }
-    return;
+  }
+  return;
 }
 
 /*
@@ -285,59 +286,55 @@ srv_rem_input (service_context context, int fd)
  *	add an output with callback and data to a service context
  *	Returns 0 on success, -1 and ERANGE if we run out of bits.
  */
-int
-srv_add_output (service_context context, int fd, void *data, fdcb proc)
-{
-    int i, next = -1;
+int srv_add_output(service_context context, int fd, void *data, fdcb proc) {
+  int i, next = -1;
 
-    /*
-     * first see if there's any available, if not we add to the end and
-     * bump the noutputs high-water-mark
-     */
-    for (i=0; i<context->noutputs; i++) {
-	if (context->outputs[i].fd == fd) {
-	    next = i;
-	    break;
-	}
+  /*
+   * first see if there's any available, if not we add to the end and
+   * bump the noutputs high-water-mark
+   */
+  for (i = 0; i < context->noutputs; i++) {
+    if (context->outputs[i].fd == fd) {
+      next = i;
+      break;
     }
-    if (next == -1) {
-	if (i < NFDS) {
-	    next = i;
-	    context->noutputs++;
-	} else {
-	    errno = ERANGE;
-	    return -1;
-	}
+  }
+  if (next == -1) {
+    if (i < NFDS) {
+      next = i;
+      context->noutputs++;
+    } else {
+      errno = ERANGE;
+      return -1;
     }
-    FD_SET(fd, &context->writefds);
-    context->outputs[next].fd = fd;
-    context->outputs[next].proc = proc;
-    context->outputs[next].data = data;
-    return 0;
+  }
+  FD_SET(fd, &context->writefds);
+  context->outputs[next].fd = fd;
+  context->outputs[next].proc = proc;
+  context->outputs[next].data = data;
+  return 0;
 }
 
 /*
  * srv_rem_output()
  *	remove an output from a service context
  */
-void
-srv_rem_output (service_context context, int fd)
-{
-    int i;
+void srv_rem_output(service_context context, int fd) {
+  int i;
 
-    for (i=0; i<context->noutputs; i++) {
-	if (context->outputs[i].fd == fd) {
-	    context->outputs[i].fd = 0;
-	    context->noutputs--;
-	    /*
-	     * swap structures so it's contiguous
-	     */
-	    context->outputs[i] = context->outputs[context->noutputs];
-	    FD_CLR(fd, &context->writefds);
-	    return;
-	}
+  for (i = 0; i < context->noutputs; i++) {
+    if (context->outputs[i].fd == fd) {
+      context->outputs[i].fd = 0;
+      context->noutputs--;
+      /*
+       * swap structures so it's contiguous
+       */
+      context->outputs[i] = context->outputs[context->noutputs];
+      FD_CLR(fd, &context->writefds);
+      return;
     }
-    return;
+  }
+  return;
 }
 
 /*
@@ -345,174 +342,165 @@ srv_rem_output (service_context context, int fd)
  *      add a callback to deal with a bad/stale/messed-up socket.
  *      The callback should remove the socket from the service context.
  */
-void
-srv_add_exceptor (service_context sc, fdcb proc)
-{
-    sc->exceptor = proc;
+void srv_add_exceptor(service_context sc, fdcb proc) {
+  sc->exceptor = proc;
 }
 
 /*
  * check_timers()
  *	internal routine to see if any timers have sprung
  */
-static void
-check_timers (service_context sc)
-{
-    struct timespec right_now, tdiff;
+static void check_timers(service_context sc) {
+  struct timespec right_now, tdiff;
 
-    if (sc->ntimers) {
-	/*
-	 * check to see if any sprung, they're sorted so check the
-	 * zeroth, if it went off call the callback and resort. Then
-	 * check the new zeroth....repeat until the zeroth is in the future.
-	 *
-         * zero out the timerid in the context and invoke the timercb
-         * with a copy. This prevents an overzealous application who
-         * does srv_rem_timeout() for this timer inside the timercb
-         * from screwing things up. Leave the time alone though in
-         * case the timercb ends up doing another qsort of the timers,
-         * we still want this one to be the 0th when the timercb returns.
-         *
-         * Don't recalculate "right_now" after dispatching an event
-         * because we want to ensure that timers added in a callback
-         * have to go through select() before being dispatched, that
-         * way we don't starve our file descriptors.
-	 */
-        clock_gettime(CLOCK_MONOTONIC, &right_now);
-        tdiff = sc->timers[0].to;
-        while (cmp_time(&tdiff, &right_now) < 1) {
-            sc->timers[0].id = 0;
-            (*sc->timers[0].proc)(sc->timers[0].data);
-            sc->timers[0].to.tv_sec = sc->timers[0].to.tv_nsec = 0;
-            qsort(sc->timers, sc->ntimers, sizeof(struct timer),
-                  (int (*)())cmp_timers);
-            sc->ntimers--;
-            tdiff = sc->timers[0].to;
-        }
-	/*
-	 * if there's any left the zero'th timer is the one that'll go off next
-	 */
-	if (sc->ntimers > 0) {
-	    tdiff = sc->timers[0].to;
-	    sub_time(&tdiff, &right_now);
-	    sc->gbl_timer = tdiff;
-	} else {
-	    sc->gbl_timer.tv_sec = 1000;
-	    sc->gbl_timer.tv_nsec = 0;
-	}
-    } else {
-	sc->gbl_timer.tv_sec = 1000;
-	sc->gbl_timer.tv_nsec = 0;
+  if (sc->ntimers) {
+    /*
+     * check to see if any sprung, they're sorted so check the
+     * zeroth, if it went off call the callback and resort. Then
+     * check the new zeroth....repeat until the zeroth is in the future.
+     *
+     * zero out the timerid in the context and invoke the timercb
+     * with a copy. This prevents an overzealous application who
+     * does srv_rem_timeout() for this timer inside the timercb
+     * from screwing things up. Leave the time alone though in
+     * case the timercb ends up doing another qsort of the timers,
+     * we still want this one to be the 0th when the timercb returns.
+     *
+     * Don't recalculate "right_now" after dispatching an event
+     * because we want to ensure that timers added in a callback
+     * have to go through select() before being dispatched, that
+     * way we don't starve our file descriptors.
+     */
+    clock_gettime(CLOCK_MONOTONIC, &right_now);
+    tdiff = sc->timers[0].to;
+    while (cmp_time(&tdiff, &right_now) < 1) {
+      sc->timers[0].id = 0;
+      (*sc->timers[0].proc)(sc->timers[0].data);
+      sc->timers[0].to.tv_sec = sc->timers[0].to.tv_nsec = 0;
+      qsort(
+          sc->timers, sc->ntimers, sizeof(struct timer), (int (*)())cmp_timers);
+      sc->ntimers--;
+      tdiff = sc->timers[0].to;
     }
-    return;
+    /*
+     * if there's any left the zero'th timer is the one that'll go off next
+     */
+    if (sc->ntimers > 0) {
+      tdiff = sc->timers[0].to;
+      sub_time(&tdiff, &right_now);
+      sc->gbl_timer = tdiff;
+    } else {
+      sc->gbl_timer.tv_sec = 1000;
+      sc->gbl_timer.tv_nsec = 0;
+    }
+  } else {
+    sc->gbl_timer.tv_sec = 1000;
+    sc->gbl_timer.tv_nsec = 0;
+  }
+  return;
 }
 
 /*
  * srv_main_loop()
  *	sit back, relax, let the service context do the work for you
  */
-int
-srv_main_loop(service_context sc)
-{
-    fd_set rfds, wfds, efds;
-    int i, active;
-    struct timeval timeval;
+int srv_main_loop(service_context sc) {
+  fd_set rfds, wfds, efds;
+  int i, active;
+  struct timeval timeval;
 
-    while (sc->keep_running) {
-	/*
-	 * first check whether any timers expired while we were doing other things
-	 */
-	check_timers(sc);
-	memcpy((char *)&rfds, (char *)&sc->readfds, sizeof(fd_set));
-	memcpy((char *)&wfds, (char *)&sc->writefds, sizeof(fd_set));
-        memcpy((char *)&efds, (char *)&sc->exceptfds, sizeof(fd_set));
-	/*
-	 * then wait for either inputs or the next scheduled timer to go off
-	 */
-	timespec_to_timeval(&sc->gbl_timer, &timeval);
-	if (sc->ninputs || sc->noutputs) {
-	    active = select(NFDS, &rfds, &wfds, &efds, &timeval);
-	} else {
-	    active = select(0, NULL, NULL, NULL, &timeval);
-	}
-	/*
-	 * if an fd is set then process...
-         *
-         * for the same reason that you should let people off the elevator before
-         * you try to get on the elevator (it's not only etiquette!) check the
-         * outputs before the inputs.
-	 */
-	if (active > 0) {
-	    for (i=0; i<sc->noutputs; i++) {
-		if (FD_ISSET(sc->outputs[i].fd, &wfds)) {
-		    (*sc->outputs[i].proc)(sc->outputs[i].fd, sc->outputs[i].data);
-		    FD_CLR(sc->outputs[i].fd, &wfds);
-		}
-	    }
-	    for (i=0; i<sc->ninputs; i++) {
-                if (FD_ISSET(sc->inputs[i].fd, &efds)) {
-                    /*
-                     * we could just remove the problematic socket from
-                     * the service context in here but it just doesn't
-                     * seem right to mask such an error. Invoke the exceptor,
-                     * if defined, orjust exit.
-                     */
-                    if (sc->exceptor == NULL) {
-                        return sc->inputs[i].fd;
-                    } else {
-                        (*sc->exceptor)(sc->inputs[i].fd, NULL);
-                    }
-                    continue;
-                }
-		if (FD_ISSET(sc->inputs[i].fd, &rfds)) {
-		    (*sc->inputs[i].proc)(sc->inputs[i].fd, sc->inputs[i].data);
-		    FD_CLR(sc->inputs[i].fd, &rfds);
-		}
-	    }
-	} else if ((active < 0) && (errno != EINTR)) {
-	    /*
-	     * if active < 0 and errno is EINTR we caught a signal
-	     * so just go back and enter select, otherwise there's
-	     * some error-- e.g. bad fd-- so return -1.
-	     */
-	    return -1;
-	}
-	/*
-	 * if active = 0 then the timer fired, go through the loop and handle
-	 * this condition in check_timers()
-	 */
+  while (sc->keep_running) {
+    /*
+     * first check whether any timers expired while we were doing other things
+     */
+    check_timers(sc);
+    memcpy((char *)&rfds, (char *)&sc->readfds, sizeof(fd_set));
+    memcpy((char *)&wfds, (char *)&sc->writefds, sizeof(fd_set));
+    memcpy((char *)&efds, (char *)&sc->exceptfds, sizeof(fd_set));
+    /*
+     * then wait for either inputs or the next scheduled timer to go off
+     */
+    timespec_to_timeval(&sc->gbl_timer, &timeval);
+    if (sc->ninputs || sc->noutputs) {
+      active = select(NFDS, &rfds, &wfds, &efds, &timeval);
+    } else {
+      active = select(0, NULL, NULL, NULL, &timeval);
     }
+    /*
+     * if an fd is set then process...
+     *
+     * for the same reason that you should let people off the elevator before
+     * you try to get on the elevator (it's not only etiquette!) check the
+     * outputs before the inputs.
+     */
+    if (active > 0) {
+      for (i = 0; i < sc->noutputs; i++) {
+        if (FD_ISSET(sc->outputs[i].fd, &wfds)) {
+          (*sc->outputs[i].proc)(sc->outputs[i].fd, sc->outputs[i].data);
+          FD_CLR(sc->outputs[i].fd, &wfds);
+        }
+      }
+      for (i = 0; i < sc->ninputs; i++) {
+        if (FD_ISSET(sc->inputs[i].fd, &efds)) {
+          /*
+           * we could just remove the problematic socket from
+           * the service context in here but it just doesn't
+           * seem right to mask such an error. Invoke the exceptor,
+           * if defined, orjust exit.
+           */
+          if (sc->exceptor == NULL) {
+            return sc->inputs[i].fd;
+          } else {
+            (*sc->exceptor)(sc->inputs[i].fd, NULL);
+          }
+          continue;
+        }
+        if (FD_ISSET(sc->inputs[i].fd, &rfds)) {
+          (*sc->inputs[i].proc)(sc->inputs[i].fd, sc->inputs[i].data);
+          FD_CLR(sc->inputs[i].fd, &rfds);
+        }
+      }
+    } else if ((active < 0) && (errno != EINTR)) {
+      /*
+       * if active < 0 and errno is EINTR we caught a signal
+       * so just go back and enter select, otherwise there's
+       * some error-- e.g. bad fd-- so return -1.
+       */
+      return -1;
+    }
+    /*
+     * if active = 0 then the timer fired, go through the loop and handle
+     * this condition in check_timers()
+     */
+  }
 
-    return 0;
+  return 0;
 }
-
 
 /*
  * srv_create_context()
  *	create a service context
  */
 static service_context srvctx;
-service_context
-srv_create_context(void)
-{
-    if ((srvctx = (service_context)malloc(sizeof(struct _servcxt))) == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "context was NULL\n");
-        return NULL;
-    }
-    srvctx->timer_id = 0;
-    FD_ZERO(&srvctx->readfds);
-    FD_ZERO(&srvctx->writefds);
-    FD_ZERO(&srvctx->exceptfds);
-    bzero((char *)srvctx->timers, (NTIMERS * sizeof(struct timer)));
-    bzero((char *)srvctx->inputs, (NFDS * sizeof(struct source)));
-    bzero((char *)srvctx->outputs, (NFDS * sizeof(struct source)));
-    srvctx->ntimers = srvctx->ninputs = srvctx->noutputs = 0;
-    srvctx->gbl_timer.tv_sec = 1000;
-    srvctx->gbl_timer.tv_nsec = 0;
-    srvctx->exceptor = NULL;
-    srvctx->keep_running = 1;
+service_context srv_create_context(void) {
+  if ((srvctx = (service_context)malloc(sizeof(struct _servcxt))) == NULL) {
+    sae_debug(SAE_DEBUG_ERR, "context was NULL\n");
+    return NULL;
+  }
+  srvctx->timer_id = 0;
+  FD_ZERO(&srvctx->readfds);
+  FD_ZERO(&srvctx->writefds);
+  FD_ZERO(&srvctx->exceptfds);
+  bzero((char *)srvctx->timers, (NTIMERS * sizeof(struct timer)));
+  bzero((char *)srvctx->inputs, (NFDS * sizeof(struct source)));
+  bzero((char *)srvctx->outputs, (NFDS * sizeof(struct source)));
+  srvctx->ntimers = srvctx->ninputs = srvctx->noutputs = 0;
+  srvctx->gbl_timer.tv_sec = 1000;
+  srvctx->gbl_timer.tv_nsec = 0;
+  srvctx->exceptor = NULL;
+  srvctx->keep_running = 1;
 
-    return srvctx;
+  return srvctx;
 }
 
 /*
@@ -522,45 +510,41 @@ srv_create_context(void)
  *	called from within signal handler
  *	context
  */
-void
-srv_cancel_main_loop(service_context context)
-{
-	context->keep_running = 0;
+void srv_cancel_main_loop(service_context context) {
+  context->keep_running = 0;
 }
 
 /* Definition of event loop operations for libsae */
-static timerid add_timeout_with_jitter(microseconds usec, timercb proc,
-                                   void *data, microseconds jitter_usecs)
-{
-    return srv_add_timeout_with_jitter(srvctx, usec, proc, data, jitter_usecs);
+static timerid add_timeout_with_jitter(
+    microseconds usec,
+    timercb proc,
+    void *data,
+    microseconds jitter_usecs) {
+  return srv_add_timeout_with_jitter(srvctx, usec, proc, data, jitter_usecs);
 }
 
-static timerid add_timeout(microseconds usec, timercb proc, void *data)
-{
-    return srv_add_timeout_with_jitter(srvctx, usec, proc, data, 0);
+static timerid add_timeout(microseconds usec, timercb proc, void *data) {
+  return srv_add_timeout_with_jitter(srvctx, usec, proc, data, 0);
 }
 
-static int rem_timeout(timerid tid)
-{
-    return srv_rem_timeout(srvctx, tid);
+static int rem_timeout(timerid tid) {
+  return srv_rem_timeout(srvctx, tid);
 }
 
-static int add_input(int fd, void * data, fdcb cb)
-{
-    return srv_add_input(srvctx, fd, data, cb);
+static int add_input(int fd, void *data, fdcb cb) {
+  return srv_add_input(srvctx, fd, data, cb);
 }
 
-static void rem_input(int fd)
-{
-    return srv_rem_input(srvctx, fd);
+static void rem_input(int fd) {
+  return srv_rem_input(srvctx, fd);
 }
 
-struct evl_ops* get_evl_ops() {
-    static struct evl_ops ops;
-    ops.add_timeout_with_jitter = add_timeout_with_jitter;
-    ops.add_timeout = add_timeout;
-    ops.rem_timeout = rem_timeout;
-    ops.add_input = add_input;
-    ops.rem_input = rem_input;
-    return &ops;
+struct evl_ops *get_evl_ops() {
+  static struct evl_ops ops;
+  ops.add_timeout_with_jitter = add_timeout_with_jitter;
+  ops.add_timeout = add_timeout;
+  ops.rem_timeout = rem_timeout;
+  ops.add_input = add_input;
+  ops.rem_input = rem_input;
+  return &ops;
 }

--- a/linux/service.h
+++ b/linux/service.h
@@ -54,45 +54,45 @@ typedef void (*dumpcb)(timerid id, int num, int secs, int usecs, char *msg);
  * a timer definition
  */
 struct timer {
-    struct timespec to;
-    timercb proc;
-    timerid id;
-    void *data;
+  struct timespec to;
+  timercb proc;
+  timerid id;
+  void *data;
 };
 
 /*
  * an I/O definition
  */
 struct source {
-    int fd;
-    fdcb proc;
-    void *data;
+  int fd;
+  fdcb proc;
+  void *data;
 };
 
 /*
  * the number of timers and file descriptors we'll dispatch
  * are fixed. If you hit that ceiling bump here.
  */
-#define NTIMERS		1024
-#define NFDS		128
+#define NTIMERS 1024
+#define NFDS 128
 
 /*
  * a service context
  */
 typedef struct _servcxt {
-    fd_set readfds;
-    fd_set writefds;
-    fd_set exceptfds;
-    timerid timer_id;
-    struct timespec gbl_timer;
-    fdcb exceptor;
-    int ntimers;
-    struct timer timers[NTIMERS];
-    int ninputs;
-    struct source inputs[NFDS];
-    int noutputs;
-    struct source outputs[NFDS];
-    volatile sig_atomic_t keep_running;
+  fd_set readfds;
+  fd_set writefds;
+  fd_set exceptfds;
+  timerid timer_id;
+  struct timespec gbl_timer;
+  fdcb exceptor;
+  int ntimers;
+  struct timer timers[NTIMERS];
+  int ninputs;
+  struct source inputs[NFDS];
+  int noutputs;
+  struct source outputs[NFDS];
+  volatile sig_atomic_t keep_running;
 } servcxt;
 
 typedef struct _servcxt *service_context;
@@ -100,11 +100,19 @@ typedef struct _servcxt *service_context;
 /*
  * service context APIs
  */
-timerid srv_add_timeout_with_jitter(service_context context, microseconds usec, timercb proc, void *data, microseconds jitter_usecs);
+timerid srv_add_timeout_with_jitter(
+    service_context context,
+    microseconds usec,
+    timercb proc,
+    void *data,
+    microseconds jitter_usecs);
 
-static inline timerid srv_add_timeout(service_context context, microseconds usec, timercb proc, void *data)
-{
-        return srv_add_timeout_with_jitter(context, usec, proc, data, 0);
+static inline timerid srv_add_timeout(
+    service_context context,
+    microseconds usec,
+    timercb proc,
+    void *data) {
+  return srv_add_timeout_with_jitter(context, usec, proc, data, 0);
 }
 
 int srv_rem_timeout(service_context, timerid);
@@ -127,6 +135,6 @@ service_context srv_create_context(void);
 
 void srv_cancel_main_loop(service_context);
 
-struct evl_ops* get_evl_ops();
+struct evl_ops *get_evl_ops();
 
-#endif	/* _SAE_SERVICE_H_ */
+#endif /* _SAE_SERVICE_H_ */

--- a/linux/watch_ips.h
+++ b/linux/watch_ips.h
@@ -45,4 +45,4 @@
 void watch_ips_init(struct mesh_node *config);
 void watch_ips_close();
 
-#endif  /* _SAE_WATCH_IPS_H_ */
+#endif /* _SAE_WATCH_IPS_H_ */

--- a/peer_lists.h
+++ b/peer_lists.h
@@ -8,7 +8,6 @@
 TAILQ_HEAD(blacklist, candidate) blacklist;
 TAILQ_HEAD(peers, candidate) peers;
 
-#define for_each_peer(peer) \
-    TAILQ_FOREACH(peer, &peers, entry)
+#define for_each_peer(peer) TAILQ_FOREACH(peer, &peers, entry)
 
 #endif /* _SAE_PEER_LISTS_H_ */

--- a/peers.h
+++ b/peers.h
@@ -7,83 +7,83 @@
 #include <sys/queue.h>
 
 #include "ampe.h"
-#include "crypto/siv.h"
 #include "common.h"
+#include "crypto/siv.h"
 #include "ieee802_11.h"
 
 typedef struct group_def_ {
-    unsigned short group_num;
-    EC_GROUP *group;
-    BIGNUM *order;
-    BIGNUM *prime;
-    char password[80];
-    struct group_def_ *next;
+  unsigned short group_num;
+  EC_GROUP *group;
+  BIGNUM *order;
+  BIGNUM *prime;
+  char password[80];
+  struct group_def_ *next;
 } GD;
 
 struct candidate {
-    TAILQ_ENTRY(candidate) entry;
-    GD *grp_def;
-    EC_POINT *pwe;
-    unsigned char pmkid[16];
-    unsigned char pmk[SHA256_DIGEST_LENGTH];
-    unsigned char kck[SHA256_DIGEST_LENGTH];
-    BIGNUM *private_val;
-    BIGNUM *peer_scalar;
-    BIGNUM *my_scalar;
-    EC_POINT *peer_element;
-    EC_POINT *my_element;
-    unsigned long beacons;
-    unsigned int failed_auth;
-    timerid t0;
-    timerid t1;
-#define SAE_NOTHING             0
-#define SAE_COMMITTED           1
-#define SAE_CONFIRMED           2
-#define SAE_ACCEPTED            3
-    unsigned short state;
-    unsigned short got_token;
-    unsigned short sync;
-    unsigned short sc;
-    unsigned short rc;
-    unsigned char peer_mac[ETH_ALEN];
-    unsigned char my_mac[ETH_ALEN];
-    /*  AMPE related fields */
-    timerid t2;
-    enum plink_state link_state;
-    le16 my_lid;
-    le16 peer_lid;
-    unsigned char my_nonce[32];
-    unsigned char peer_nonce[32];
-    unsigned short reason;
-    unsigned short retries;
-    unsigned int timeout;
-    unsigned char aek[SHA256_DIGEST_LENGTH];
-    unsigned char mtk[KEY_LEN_AES_CCMP];
-    unsigned char mgtk[KEY_LEN_AES_CCMP];
-    unsigned int mgtk_expiration;
+  TAILQ_ENTRY(candidate) entry;
+  GD *grp_def;
+  EC_POINT *pwe;
+  unsigned char pmkid[16];
+  unsigned char pmk[SHA256_DIGEST_LENGTH];
+  unsigned char kck[SHA256_DIGEST_LENGTH];
+  BIGNUM *private_val;
+  BIGNUM *peer_scalar;
+  BIGNUM *my_scalar;
+  EC_POINT *peer_element;
+  EC_POINT *my_element;
+  unsigned long beacons;
+  unsigned int failed_auth;
+  timerid t0;
+  timerid t1;
+#define SAE_NOTHING 0
+#define SAE_COMMITTED 1
+#define SAE_CONFIRMED 2
+#define SAE_ACCEPTED 3
+  unsigned short state;
+  unsigned short got_token;
+  unsigned short sync;
+  unsigned short sc;
+  unsigned short rc;
+  unsigned char peer_mac[ETH_ALEN];
+  unsigned char my_mac[ETH_ALEN];
+  /*  AMPE related fields */
+  timerid t2;
+  enum plink_state link_state;
+  le16 my_lid;
+  le16 peer_lid;
+  unsigned char my_nonce[32];
+  unsigned char peer_nonce[32];
+  unsigned short reason;
+  unsigned short retries;
+  unsigned int timeout;
+  unsigned char aek[SHA256_DIGEST_LENGTH];
+  unsigned char mtk[KEY_LEN_AES_CCMP];
+  unsigned char mgtk[KEY_LEN_AES_CCMP];
+  unsigned int mgtk_expiration;
 
-    unsigned char igtk[KEY_LEN_AES_CMAC];
-    u16 igtk_keyid;
-    bool has_igtk;
+  unsigned char igtk[KEY_LEN_AES_CMAC];
+  u16 igtk_keyid;
+  bool has_igtk;
 
-    unsigned char sup_rates[MAX_SUPP_RATES];
-    unsigned short sup_rates_len;
-    siv_ctx sivctx;
-    void *cookie;
-    struct ampe_config *conf;
-    unsigned int ch_type; /* nl80211_channel_type */
-    unsigned short association_id;
+  unsigned char sup_rates[MAX_SUPP_RATES];
+  unsigned short sup_rates_len;
+  siv_ctx sivctx;
+  void *cookie;
+  struct ampe_config *conf;
+  unsigned int ch_type; /* nl80211_channel_type */
+  unsigned short association_id;
 
-    timerid rekey_ping_timer;
-    unsigned int rekey_ping_count;
-    unsigned int rekey_reauth_count;
-    unsigned int rekey_ok;
-    unsigned int rekey_ok_ping_rx;
+  timerid rekey_ping_timer;
+  unsigned int rekey_ping_count;
+  unsigned int rekey_reauth_count;
+  unsigned int rekey_ok;
+  unsigned int rekey_ok_ping_rx;
 
-    struct ht_cap_ie ht_cap;
-    struct ht_op_ie ht_info;
+  struct ht_cap_ie ht_cap;
+  struct ht_op_ie ht_info;
 
-    bool in_kernel;
+  bool in_kernel;
 };
 
 struct candidate *find_peer(unsigned char *mac, int accept);

--- a/rekey.c
+++ b/rekey.c
@@ -54,8 +54,8 @@
 #include "ieee802_11.h"
 #include "sae.h"
 
-#define PACKET_TYPE_PING    (0x01)
-#define PACKET_TYPE_PONG    (0x02)
+#define PACKET_TYPE_PING (0x01)
+#define PACKET_TYPE_PONG (0x02)
 
 #define PACKET_VERSION_PING (0x01)
 #define PACKET_VERSION_PONG (0x01)
@@ -63,34 +63,35 @@
 typedef struct {
   uint8_t type;
   uint8_t version;
-}__attribute__((packed)) packet_header;
+} __attribute__((packed)) packet_header;
 
 typedef struct {
   packet_header header;
   uint8_t dst_mac[ETH_ALEN];
   uint8_t src_mac[ETH_ALEN];
   in_port_t src_port;
-}__attribute__((packed)) packet_ping;
+} __attribute__((packed)) packet_ping;
 
 typedef struct {
   packet_header header;
   uint8_t dst_mac[ETH_ALEN];
   uint8_t src_mac[ETH_ALEN];
-}__attribute__((packed)) packet_pong;
+} __attribute__((packed)) packet_pong;
 
 typedef union {
   packet_ping ping;
   packet_pong pong;
-}__attribute__((packed)) packet_struct;
+} __attribute__((packed)) packet_struct;
 
 static struct evl_ops *evl = NULL;
 static struct mesh_node *cfg = NULL;
 
-#define IPPROTO(af)   ((af == AF_INET) ? IPPROTO_IP : IPPROTO_IPV6)
-#define IPMCLOOP(af)  ((af == AF_INET) ? IP_MULTICAST_LOOP : IPV6_MULTICAST_LOOP)
-#define IPMCTTL(af)   ((af == AF_INET) ? IP_MULTICAST_TTL : IPV6_MULTICAST_HOPS)
-#define IPMCJOIN(af)  ((af == AF_INET) ? IP_ADD_MEMBERSHIP : IPV6_ADD_MEMBERSHIP)
-#define IPMCLEAVE(af) ((af == AF_INET) ? IP_DROP_MEMBERSHIP : IPV6_DROP_MEMBERSHIP)
+#define IPPROTO(af) ((af == AF_INET) ? IPPROTO_IP : IPPROTO_IPV6)
+#define IPMCLOOP(af) ((af == AF_INET) ? IP_MULTICAST_LOOP : IPV6_MULTICAST_LOOP)
+#define IPMCTTL(af) ((af == AF_INET) ? IP_MULTICAST_TTL : IPV6_MULTICAST_HOPS)
+#define IPMCJOIN(af) ((af == AF_INET) ? IP_ADD_MEMBERSHIP : IPV6_ADD_MEMBERSHIP)
+#define IPMCLEAVE(af) \
+  ((af == AF_INET) ? IP_DROP_MEMBERSHIP : IPV6_DROP_MEMBERSHIP)
 
 /*
  * helpers
@@ -98,13 +99,13 @@ static struct mesh_node *cfg = NULL;
 
 static void *get_socket_address_ip(struct sockaddr_storage *sa) {
   if (sa->ss_family == AF_INET) {
-    return &(((struct sockaddr_in*) sa)->sin_addr);
+    return &(((struct sockaddr_in *)sa)->sin_addr);
   }
 
-  return &(((struct sockaddr_in6*) sa)->sin6_addr);
+  return &(((struct sockaddr_in6 *)sa)->sin6_addr);
 }
 
-static bool bind_socket_to_interface(int sock, const char* iface) {
+static bool bind_socket_to_interface(int sock, const char *iface) {
   if (!iface) {
     return false;
   }
@@ -114,25 +115,27 @@ static bool bind_socket_to_interface(int sock, const char* iface) {
   strncpy(ifr.ifr_name, iface, sizeof(ifr.ifr_name));
   ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
 
-  return !setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, (void *) &ifr, sizeof(ifr));
+  return !setsockopt(
+      sock, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr));
 }
 
-static bool bind_socket_to_ip_and_port(int sock, int af, ip_address *ip, in_port_t port) {
+static bool
+bind_socket_to_ip_and_port(int sock, int af, ip_address *ip, in_port_t port) {
   struct sockaddr_storage addr;
   memset(&addr, 0, sizeof(addr));
   addr.ss_family = af;
 
   if (af == AF_INET) {
-    struct sockaddr_in *addr4 = (struct sockaddr_in *) &addr;
+    struct sockaddr_in *addr4 = (struct sockaddr_in *)&addr;
     addr4->sin_addr = ip->v4;
     addr4->sin_port = port;
   } else {
-    struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *) &addr;
+    struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&addr;
     addr6->sin6_addr = ip->v6;
     addr6->sin6_port = port;
   }
 
-  return !bind(sock, (struct sockaddr *) &addr, sizeof(addr));
+  return !bind(sock, (struct sockaddr *)&addr, sizeof(addr));
 }
 
 static int create_dgram_socket(int af) {
@@ -156,7 +159,8 @@ static int create_dgram_socket(int af) {
 
 static int pong_socket = -1;
 
-static void pong_tx(struct candidate *peer, struct sockaddr_storage *src, in_port_t port) {
+static void
+pong_tx(struct candidate *peer, struct sockaddr_storage *src, in_port_t port) {
   if (!peer || !src || !port || (pong_socket == -1)) {
     return;
   }
@@ -171,80 +175,122 @@ static void pong_tx(struct candidate *peer, struct sockaddr_storage *src, in_por
   memset(&dst, 0, sizeof(dst));
   dst.ss_family = src->ss_family;
   if (dst.ss_family == AF_INET) {
-    struct sockaddr_in *src4 = (struct sockaddr_in *) src;
-    struct sockaddr_in *dst4 = (struct sockaddr_in *) &dst;
+    struct sockaddr_in *src4 = (struct sockaddr_in *)src;
+    struct sockaddr_in *dst4 = (struct sockaddr_in *)&dst;
     dst4->sin_addr = src4->sin_addr;
     dst4->sin_port = port;
   } else {
-    struct sockaddr_in6 *src6 = (struct sockaddr_in6 *) src;
-    struct sockaddr_in6 *dst6 = (struct sockaddr_in6 *) &dst;
+    struct sockaddr_in6 *src6 = (struct sockaddr_in6 *)src;
+    struct sockaddr_in6 *dst6 = (struct sockaddr_in6 *)&dst;
     dst6->sin6_addr = src6->sin6_addr;
     dst6->sin6_port = port;
   }
 
   char str[INET6_ADDRSTRLEN];
-  sae_debug(SAE_DEBUG_REKEY, "rekey: pong to   " MACSTR " (%s)\n", MAC2STR(peer->peer_mac),
+  sae_debug(
+      SAE_DEBUG_REKEY,
+      "rekey: pong to   " MACSTR " (%s)\n",
+      MAC2STR(peer->peer_mac),
       inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)));
 
-  int bytes = sendto(pong_socket, &packet.pong, sizeof(packet.pong), 0, (struct sockaddr *) &dst, sizeof(dst));
+  int bytes = sendto(
+      pong_socket,
+      &packet.pong,
+      sizeof(packet.pong),
+      0,
+      (struct sockaddr *)&dst,
+      sizeof(dst));
 
   if (bytes == sizeof(packet.pong)) {
     return;
   }
 
   if (bytes == -1) {
-    sae_debug(SAE_DEBUG_ERR, "rekey: pong to   " MACSTR " (%s) failed: %s\n", MAC2STR(peer->peer_mac),
-        inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)), strerror(errno));
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "rekey: pong to   " MACSTR " (%s) failed: %s\n",
+        MAC2STR(peer->peer_mac),
+        inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)),
+        strerror(errno));
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: pong to   " MACSTR " (%s) sent %d bytes instead of %zu\n", MAC2STR(peer->peer_mac),
-      inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)), bytes, sizeof(packet.pong));
+  sae_debug(
+      SAE_DEBUG_REKEY,
+      "rekey: pong to   " MACSTR " (%s) sent %d bytes instead of %zu\n",
+      MAC2STR(peer->peer_mac),
+      inet_ntop(dst.ss_family, get_socket_address_ip(&dst), str, sizeof(str)),
+      bytes,
+      sizeof(packet.pong));
 }
 
 static void pong_rx(int sock, void *data) {
   char str[INET6_ADDRSTRLEN];
   uint8_t buffer[sizeof(packet_struct) + 1];
-  packet_struct *packet = (packet_struct *) buffer;
+  packet_struct *packet = (packet_struct *)buffer;
   struct sockaddr_storage src;
   socklen_t src_len = sizeof(src);
 
-  int bytes = recvfrom(sock, buffer, sizeof(buffer), 0, (struct sockaddr *) &src, &src_len);
+  int bytes = recvfrom(
+      sock, buffer, sizeof(buffer), 0, (struct sockaddr *)&src, &src_len);
 
   if (bytes == sizeof(packet->pong)) {
     if (packet->pong.header.type != PACKET_TYPE_PONG) {
-      sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent type %u instead of %u, ignored\n",
-          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->pong.header.type,
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: pong from %s sent type %u instead of %u, ignored\n",
+          inet_ntop(
+              src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          packet->pong.header.type,
           PACKET_TYPE_PONG);
       return;
     }
 
     if (packet->pong.header.version != PACKET_VERSION_PONG) {
-      sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent version %u instead of %u, ignored\n",
-          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->pong.header.version,
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: pong from %s sent version %u instead of %u, ignored\n",
+          inet_ntop(
+              src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          packet->pong.header.version,
           PACKET_VERSION_PONG);
       return;
     }
 
     struct candidate *peer = find_peer(packet->pong.src_mac, 1);
     if (!peer) {
-      sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent unknown accepted peer " MACSTR ", ignored\n",
-          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), MAC2STR(packet->pong.src_mac));
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: pong from %s sent unknown accepted peer " MACSTR
+          ", ignored\n",
+          inet_ntop(
+              src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          MAC2STR(packet->pong.src_mac));
       return;
     }
 
-    if (memcmp(packet->pong.dst_mac, peer->my_mac, sizeof(packet->pong.dst_mac))) {
-      sae_debug(SAE_DEBUG_REKEY,
-          "rekey: pong from " MACSTR " (%s) sent 'me' " MACSTR " instead of " MACSTR ", ignored\n",
-          MAC2STR(packet->pong.src_mac), inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
-          MAC2STR(packet->pong.dst_mac), MAC2STR(peer->my_mac));
+    if (memcmp(
+            packet->pong.dst_mac, peer->my_mac, sizeof(packet->pong.dst_mac))) {
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: pong from " MACSTR " (%s) sent 'me' " MACSTR
+          " instead of " MACSTR ", ignored\n",
+          MAC2STR(packet->pong.src_mac),
+          inet_ntop(
+              src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          MAC2STR(packet->pong.dst_mac),
+          MAC2STR(peer->my_mac));
       return;
     }
 
     /* keys are installed correctly */
 
-    sae_debug(SAE_DEBUG_REKEY, "rekey: pong from " MACSTR " (%s): keys are installed correctly\n",
-        MAC2STR(packet->pong.src_mac), inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
+    sae_debug(
+        SAE_DEBUG_REKEY,
+        "rekey: pong from " MACSTR " (%s): keys are installed correctly\n",
+        MAC2STR(packet->pong.src_mac),
+        inet_ntop(
+            src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
 
     evl->rem_timeout(peer->rekey_ping_timer);
     peer->rekey_ping_timer = 0;
@@ -260,8 +306,12 @@ static void pong_rx(int sock, void *data) {
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: pong from %s sent %d bytes instead of %zu\n",
-      inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), bytes, sizeof(packet->pong));
+  sae_debug(
+      SAE_DEBUG_REKEY,
+      "rekey: pong from %s sent %d bytes instead of %zu\n",
+      inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+      bytes,
+      sizeof(packet->pong));
 }
 
 static void pong_socket_close(void) {
@@ -275,7 +325,7 @@ static void pong_socket_close(void) {
   pong_socket = -1;
 }
 
-static void pong_socket_create(const char* iface, int af) {
+static void pong_socket_create(const char *iface, int af) {
   if (pong_socket != -1) {
     return;
   }
@@ -297,7 +347,8 @@ static void pong_socket_create(const char* iface, int af) {
     bind_ip.v6 = in6addr_any;
   }
 
-  if (!bind_socket_to_ip_and_port(pong_socket, af, &bind_ip, cfg->conf->rekey_pong_port)) {
+  if (!bind_socket_to_ip_and_port(
+          pong_socket, af, &bind_ip, cfg->conf->rekey_pong_port)) {
     goto err;
   }
 
@@ -311,7 +362,8 @@ static void pong_socket_create(const char* iface, int af) {
 
   return;
 
-  err: pong_socket_close();
+err:
+  pong_socket_close();
 }
 
 /*
@@ -325,50 +377,75 @@ static int ping_socket_rx = -1;
 static void ping_rx(int sock, void *data) {
   char str[INET6_ADDRSTRLEN];
   uint8_t buffer[sizeof(packet_struct) + 1];
-  packet_struct *packet = (packet_struct *) buffer;
+  packet_struct *packet = (packet_struct *)buffer;
   struct sockaddr_storage src;
   socklen_t src_len = sizeof(src);
 
-  int bytes = recvfrom(sock, buffer, sizeof(buffer), 0, (struct sockaddr *) &src, &src_len);
+  int bytes = recvfrom(
+      sock, buffer, sizeof(buffer), 0, (struct sockaddr *)&src, &src_len);
 
   if (bytes == sizeof(packet->ping)) {
     if (packet->ping.header.type != PACKET_TYPE_PING) {
-      sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent type %u instead of %u, ignored\n",
-          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->ping.header.type,
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: ping from %s sent type %u instead of %u, ignored\n",
+          inet_ntop(
+              src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          packet->ping.header.type,
           PACKET_TYPE_PING);
       return;
     }
 
     if (packet->ping.header.version != PACKET_VERSION_PING) {
-      sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent version %u instead of %u, ignored\n",
-          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), packet->ping.header.version,
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: ping from %s sent version %u instead of %u, ignored\n",
+          inet_ntop(
+              src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          packet->ping.header.version,
           PACKET_VERSION_PING);
       return;
     }
 
     struct candidate *peer = find_peer(packet->ping.src_mac, 1);
     if (!peer) {
-      sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent unknown accepted peer " MACSTR ", ignored\n",
-          inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), MAC2STR(packet->ping.src_mac));
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: ping from %s sent unknown accepted peer " MACSTR
+          ", ignored\n",
+          inet_ntop(
+              src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+          MAC2STR(packet->ping.src_mac));
       return;
     }
 
-    if (memcmp(packet->ping.dst_mac, peer->my_mac, sizeof(packet->ping.dst_mac))) {
+    if (memcmp(
+            packet->ping.dst_mac, peer->my_mac, sizeof(packet->ping.dst_mac))) {
       /* not meant for me */
       return;
     }
 
-    sae_debug(SAE_DEBUG_REKEY, "rekey: ping from " MACSTR " (%s)\n", MAC2STR(packet->ping.src_mac),
-        inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
+    sae_debug(
+        SAE_DEBUG_REKEY,
+        "rekey: ping from " MACSTR " (%s)\n",
+        MAC2STR(packet->ping.src_mac),
+        inet_ntop(
+            src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
 
-    /* re-authenticate when we concluded that keys are installed correctly but we are still receiving pings */
+    /* re-authenticate when we concluded that keys are installed correctly but
+     * we are still receiving pings */
     if (peer->rekey_ok) {
       peer->rekey_ok_ping_rx++;
       if (peer->rekey_ok_ping_rx > cfg->conf->rekey_ok_ping_count_max) {
-        sae_debug(SAE_DEBUG_REKEY,
-            "rekey: too many pings (%u) from " MACSTR " (%s) while considering keys correctly installed,"
-            " doing reauthentication\n", peer->rekey_ok_ping_rx, MAC2STR(packet->ping.src_mac),
-            inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
+        sae_debug(
+            SAE_DEBUG_REKEY,
+            "rekey: too many pings (%u) from " MACSTR
+            " (%s) while considering keys correctly installed,"
+            " doing reauthentication\n",
+            peer->rekey_ok_ping_rx,
+            MAC2STR(packet->ping.src_mac),
+            inet_ntop(
+                src.ss_family, get_socket_address_ip(&src), str, sizeof(str)));
         peer->rekey_ok_ping_rx = 0;
         do_reauth(peer);
         return;
@@ -384,8 +461,12 @@ static void ping_rx(int sock, void *data) {
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: ping from %s sent %d bytes instead of %zu\n",
-      inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)), bytes, sizeof(packet->ping));
+  sae_debug(
+      SAE_DEBUG_REKEY,
+      "rekey: ping from %s sent %d bytes instead of %zu\n",
+      inet_ntop(src.ss_family, get_socket_address_ip(&src), str, sizeof(str)),
+      bytes,
+      sizeof(packet->ping));
 }
 
 static void ping_socket_close_rx(void) {
@@ -399,15 +480,26 @@ static void ping_socket_close_rx(void) {
     if (ping_socket_rx_af == AF_INET) {
       struct ip_mreq mreq;
       memset(&mreq, 0, sizeof(mreq));
-      mreq.imr_multiaddr.s_addr = cfg->conf->rekey_multicast_group_address.v4.s_addr;
+      mreq.imr_multiaddr.s_addr =
+          cfg->conf->rekey_multicast_group_address.v4.s_addr;
       mreq.imr_interface.s_addr = htonl(INADDR_ANY);
-      (void) setsockopt(ping_socket_rx, IPPROTO(ping_socket_rx_af), IPMCLEAVE(ping_socket_rx_af), &mreq, sizeof(mreq));
+      (void)setsockopt(
+          ping_socket_rx,
+          IPPROTO(ping_socket_rx_af),
+          IPMCLEAVE(ping_socket_rx_af),
+          &mreq,
+          sizeof(mreq));
     } else {
       struct ipv6_mreq mreq;
       memset(&mreq, 0, sizeof(mreq));
       mreq.ipv6mr_multiaddr = cfg->conf->rekey_multicast_group_address.v6;
       mreq.ipv6mr_interface = ping_socket_rx_ifindex;
-      (void) setsockopt(ping_socket_rx, IPPROTO(ping_socket_rx_af), IPMCLEAVE(ping_socket_rx_af), &mreq, sizeof(mreq));
+      (void)setsockopt(
+          ping_socket_rx,
+          IPPROTO(ping_socket_rx_af),
+          IPMCLEAVE(ping_socket_rx_af),
+          &mreq,
+          sizeof(mreq));
     }
   }
 
@@ -416,7 +508,7 @@ static void ping_socket_close_rx(void) {
   ping_socket_rx_ifindex = 0;
 }
 
-static void ping_socket_create_rx(const char* iface, int af) {
+static void ping_socket_create_rx(const char *iface, int af) {
   if (ping_socket_rx != -1) {
     return;
   }
@@ -445,12 +537,18 @@ static void ping_socket_create_rx(const char* iface, int af) {
     bind_ip.v6 = in6addr_any;
   }
 
-  if (!bind_socket_to_ip_and_port(ping_socket_rx, af, &bind_ip, cfg->conf->rekey_ping_port)) {
+  if (!bind_socket_to_ip_and_port(
+          ping_socket_rx, af, &bind_ip, cfg->conf->rekey_ping_port)) {
     goto err;
   }
 
   uint8_t loopback = 0;
-  if (setsockopt(ping_socket_rx, IPPROTO(af), IPMCLOOP(af), &loopback, sizeof(loopback)) == -1) {
+  if (setsockopt(
+          ping_socket_rx,
+          IPPROTO(af),
+          IPMCLOOP(af),
+          &loopback,
+          sizeof(loopback)) == -1) {
     goto err;
   }
 
@@ -459,7 +557,9 @@ static void ping_socket_create_rx(const char* iface, int af) {
     memset(&mreq, 0, sizeof(mreq));
     mreq.imr_multiaddr = cfg->conf->rekey_multicast_group_address.v4;
     mreq.imr_interface.s_addr = htonl(INADDR_ANY);
-    if (setsockopt(ping_socket_rx, IPPROTO(af), IPMCJOIN(af), &mreq, sizeof(mreq)) == -1) {
+    if (setsockopt(
+            ping_socket_rx, IPPROTO(af), IPMCJOIN(af), &mreq, sizeof(mreq)) ==
+        -1) {
       goto err;
     }
   } else {
@@ -467,7 +567,9 @@ static void ping_socket_create_rx(const char* iface, int af) {
     memset(&mreq, 0, sizeof(mreq));
     mreq.ipv6mr_multiaddr = cfg->conf->rekey_multicast_group_address.v6;
     mreq.ipv6mr_interface = ping_socket_rx_ifindex;
-    if (setsockopt(ping_socket_rx, IPPROTO(af), IPMCJOIN(af), &mreq, sizeof(mreq)) == -1) {
+    if (setsockopt(
+            ping_socket_rx, IPPROTO(af), IPMCJOIN(af), &mreq, sizeof(mreq)) ==
+        -1) {
       goto err;
     }
   }
@@ -478,7 +580,8 @@ static void ping_socket_create_rx(const char* iface, int af) {
 
   return;
 
-  err: ping_socket_close_rx();
+err:
+  ping_socket_close_rx();
 }
 
 /*
@@ -492,13 +595,16 @@ static void ping_tx(void *data) {
     return;
   }
 
-  struct candidate *peer = (struct candidate *) data;
+  struct candidate *peer = (struct candidate *)data;
 
   peer->rekey_ping_count++;
 
   /* check whether we sent too many pings */
   if (peer->rekey_ping_count > cfg->conf->rekey_ping_count_max) {
-    sae_debug(SAE_DEBUG_REKEY, "rekey: too many pings (%u) to " MACSTR "\n", peer->rekey_ping_count,
+    sae_debug(
+        SAE_DEBUG_REKEY,
+        "rekey: too many pings (%u) to " MACSTR "\n",
+        peer->rekey_ping_count,
         MAC2STR(peer->peer_mac));
 
     evl->rem_timeout(peer->rekey_ping_timer);
@@ -509,13 +615,19 @@ static void ping_tx(void *data) {
     if (peer->rekey_reauth_count < cfg->conf->rekey_reauth_count_max) {
       rekey_reopen_sockets();
       peer->rekey_reauth_count++;
-      sae_debug(SAE_DEBUG_REKEY, "rekey: reauthentication %u with " MACSTR "\n", peer->rekey_reauth_count,
+      sae_debug(
+          SAE_DEBUG_REKEY,
+          "rekey: reauthentication %u with " MACSTR "\n",
+          peer->rekey_reauth_count,
           MAC2STR(peer->peer_mac));
       do_reauth(peer);
       return;
     }
 
-    sae_debug(SAE_DEBUG_REKEY, "rekey: too many reauthentications (%u) with " MACSTR "\n", peer->rekey_reauth_count,
+    sae_debug(
+        SAE_DEBUG_REKEY,
+        "rekey: too many reauthentications (%u) with " MACSTR "\n",
+        peer->rekey_reauth_count,
         MAC2STR(peer->peer_mac));
 
     return;
@@ -534,43 +646,67 @@ static void ping_tx(void *data) {
   struct sockaddr_storage dst;
   memset(&dst, 0, sizeof(dst));
   dst.ss_family = cfg->conf->rekey_multicast_group_family;
-  void * dst_addr;
+  void *dst_addr;
   if (dst.ss_family == AF_INET) {
-    struct sockaddr_in *dst4 = (struct sockaddr_in *) &dst;
+    struct sockaddr_in *dst4 = (struct sockaddr_in *)&dst;
     dst4->sin_addr = cfg->conf->rekey_multicast_group_address.v4;
     dst4->sin_port = cfg->conf->rekey_ping_port;
     dst_addr = &dst4->sin_addr;
   } else {
-    struct sockaddr_in6 *dst6 = (struct sockaddr_in6 *) &dst;
+    struct sockaddr_in6 *dst6 = (struct sockaddr_in6 *)&dst;
     dst6->sin6_addr = cfg->conf->rekey_multicast_group_address.v6;
     dst6->sin6_port = cfg->conf->rekey_ping_port;
     dst_addr = &dst6->sin6_addr;
   }
 
   char str[INET6_ADDRSTRLEN];
-  sae_debug(SAE_DEBUG_REKEY, "rekey: ping %u to " MACSTR " (%s)\n", peer->rekey_ping_count, MAC2STR(peer->peer_mac),
+  sae_debug(
+      SAE_DEBUG_REKEY,
+      "rekey: ping %u to " MACSTR " (%s)\n",
+      peer->rekey_ping_count,
+      MAC2STR(peer->peer_mac),
       inet_ntop(dst.ss_family, dst_addr, str, sizeof(str)));
 
-  int bytes = sendto(ping_socket_tx, &packet.ping, sizeof(packet.ping), 0, (struct sockaddr *) &dst, sizeof(dst));
+  int bytes = sendto(
+      ping_socket_tx,
+      &packet.ping,
+      sizeof(packet.ping),
+      0,
+      (struct sockaddr *)&dst,
+      sizeof(dst));
 
   if (bytes == sizeof(packet.ping)) {
     evl->rem_timeout(peer->rekey_ping_timer);
-    peer->rekey_ping_timer = evl->add_timeout(SRV_MSEC(cfg->conf->rekey_ping_timeout), ping_tx, peer);
+    peer->rekey_ping_timer = evl->add_timeout(
+        SRV_MSEC(cfg->conf->rekey_ping_timeout), ping_tx, peer);
     if (!peer->rekey_ping_timer) {
-      sae_debug(SAE_DEBUG_ERR, "rekey: ping %u to " MACSTR " failed to reschedule its ping timeout\n",
-          peer->rekey_ping_count, MAC2STR(peer->peer_mac));
+      sae_debug(
+          SAE_DEBUG_ERR,
+          "rekey: ping %u to " MACSTR
+          " failed to reschedule its ping timeout\n",
+          peer->rekey_ping_count,
+          MAC2STR(peer->peer_mac));
     }
     return;
   }
 
   if (bytes == -1) {
-    sae_debug(SAE_DEBUG_ERR, "rekey: ping %u to " MACSTR " failed: %s\n", peer->rekey_ping_count,
-        MAC2STR(peer->peer_mac), strerror(errno));
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "rekey: ping %u to " MACSTR " failed: %s\n",
+        peer->rekey_ping_count,
+        MAC2STR(peer->peer_mac),
+        strerror(errno));
     return;
   }
 
-  sae_debug(SAE_DEBUG_REKEY, "rekey: ping %u to " MACSTR " sent %d bytes instead of %zu\n", peer->rekey_ping_count,
-      MAC2STR(peer->peer_mac), bytes, sizeof(packet.ping));
+  sae_debug(
+      SAE_DEBUG_REKEY,
+      "rekey: ping %u to " MACSTR " sent %d bytes instead of %zu\n",
+      peer->rekey_ping_count,
+      MAC2STR(peer->peer_mac),
+      bytes,
+      sizeof(packet.ping));
 }
 
 static void ping_socket_close_tx(void) {
@@ -582,7 +718,7 @@ static void ping_socket_close_tx(void) {
   ping_socket_tx = -1;
 }
 
-static void ping_socket_create_tx(const char* iface, int af) {
+static void ping_socket_create_tx(const char *iface, int af) {
   if (ping_socket_tx != -1) {
     return;
   }
@@ -597,7 +733,12 @@ static void ping_socket_create_tx(const char* iface, int af) {
   }
 
   uint8_t loopback = 0;
-  if (setsockopt(ping_socket_tx, IPPROTO(af), IPMCLOOP(af), &loopback, sizeof(loopback)) == -1) {
+  if (setsockopt(
+          ping_socket_tx,
+          IPPROTO(af),
+          IPMCLOOP(af),
+          &loopback,
+          sizeof(loopback)) == -1) {
     goto err;
   }
 
@@ -612,14 +753,16 @@ static void ping_socket_create_tx(const char* iface, int af) {
 
   return;
 
-  err: ping_socket_close_tx();
+err:
+  ping_socket_close_tx();
 }
 
 /*
  * sockets
  */
 
-#define ALL_SOCKETS_OPEN ((ping_socket_tx != -1) && (ping_socket_rx != -1) && (pong_socket != -1))
+#define ALL_SOCKETS_OPEN \
+  ((ping_socket_tx != -1) && (ping_socket_rx != -1) && (pong_socket != -1))
 
 static void rekey_sockets_close(void) {
   sae_debug(SAE_DEBUG_REKEY, "rekey: closing sockets\n");
@@ -682,17 +825,29 @@ void rekey_verify_peer(struct candidate *peer) {
   }
 
   if (!peer->rekey_ping_timer) {
-    sae_debug(SAE_DEBUG_REKEY, "rekey: start rekey for " MACSTR "\n", MAC2STR(peer->peer_mac));
+    sae_debug(
+        SAE_DEBUG_REKEY,
+        "rekey: start rekey for " MACSTR "\n",
+        MAC2STR(peer->peer_mac));
     peer->rekey_ping_count = 0;
     peer->rekey_ok = 0;
     peer->rekey_ok_ping_rx = 0;
-    peer->rekey_ping_timer = evl->add_timeout_with_jitter(SRV_MSEC(cfg->conf->rekey_ping_timeout), ping_tx, peer,
+    peer->rekey_ping_timer = evl->add_timeout_with_jitter(
+        SRV_MSEC(cfg->conf->rekey_ping_timeout),
+        ping_tx,
+        peer,
         SRV_MSEC(cfg->conf->rekey_ping_jitter));
     if (!peer->rekey_ping_timer) {
-      sae_debug(SAE_DEBUG_ERR, "rekey: failed to schedule ping timeout for " MACSTR "\n", MAC2STR(peer->peer_mac));
+      sae_debug(
+          SAE_DEBUG_ERR,
+          "rekey: failed to schedule ping timeout for " MACSTR "\n",
+          MAC2STR(peer->peer_mac));
     }
   } else {
-    sae_debug(SAE_DEBUG_REKEY, "rekey: rekey already running for " MACSTR "\n", MAC2STR(peer->peer_mac));
+    sae_debug(
+        SAE_DEBUG_REKEY,
+        "rekey: rekey already running for " MACSTR "\n",
+        MAC2STR(peer->peer_mac));
   }
 }
 

--- a/rekey.h
+++ b/rekey.h
@@ -45,21 +45,22 @@
 #include "ampe.h"
 #include "peers.h"
 
-#define REKEY_ENABLE_DEF                   (false)
-#define REKEY_MULTICAST_GROUP_FAMILY_DEF   (AF_INET)
-#define REKEY_MULTICAST_GROUP_ADDRESS_DEF  (htonl(0xE00000C8)) /* 224.0.0.200 */
-#define REKEY_PING_PORT_DEF                (4875)
-#define REKEY_PONG_PORT_DEF                (4876)
-#define REKEY_PING_COUNT_MAX_DEF           (32)
-#define REKEY_PING_TIMEOUT_MSECS_DEF       (500)
-#define REKEY_PING_JITTER_MSECS_DEF        (100)
-#define REKEY_REAUTH_COUNT_MAX_DEF         (8)
-#define REKEY_OK_PING_COUNT_MAX_DEF        (16)
+#define REKEY_ENABLE_DEF (false)
+#define REKEY_MULTICAST_GROUP_FAMILY_DEF (AF_INET)
+#define REKEY_MULTICAST_GROUP_ADDRESS_DEF (htonl(0xE00000C8)) /* 224.0.0.200 \
+                                                                 */
+#define REKEY_PING_PORT_DEF (4875)
+#define REKEY_PONG_PORT_DEF (4876)
+#define REKEY_PING_COUNT_MAX_DEF (32)
+#define REKEY_PING_TIMEOUT_MSECS_DEF (500)
+#define REKEY_PING_JITTER_MSECS_DEF (100)
+#define REKEY_REAUTH_COUNT_MAX_DEF (8)
+#define REKEY_OK_PING_COUNT_MAX_DEF (16)
 
-void rekey_init(struct mesh_node *mesh, struct evl_ops* evl);
+void rekey_init(struct mesh_node *mesh, struct evl_ops *evl);
 void rekey_close(void);
 
 void rekey_verify_peer(struct candidate *peer);
 void rekey_reopen_sockets(void);
 
-#endif  /* _SAE_REKEY_H_ */
+#endif /* _SAE_REKEY_H_ */

--- a/sae.c
+++ b/sae.c
@@ -47,47 +47,46 @@
 #include "peer_lists.h"
 #include "peers.h"
 
-#define COUNTER_INFINITY        65535
-#define REAUTH_JITTER		30
+#define COUNTER_INFINITY 65535
+#define REAUTH_JITTER 30
 
+#define state_to_string(x)                                                     \
+  (x) == SAE_NOTHING ? "NOTHING" : (x) == SAE_COMMITTED ? "COMMITTED"          \
+                                                        : (x) == SAE_CONFIRMED \
+              ? "CONFIRMED"                                                    \
+              : (x) == SAE_ACCEPTED ? "ACCEPTED" : "unknown"
 
-#define state_to_string(x) (x) == SAE_NOTHING ? "NOTHING" : \
-                           (x) == SAE_COMMITTED ? "COMMITTED" : \
-                           (x) == SAE_CONFIRMED ? "CONFIRMED" : \
-                           (x) == SAE_ACCEPTED ? "ACCEPTED" : \
-                           "unknown"
+#define seq_to_string(x)                                                  \
+  (x) == SAE_AUTH_COMMIT ? "COMMIT" : (x) == SAE_AUTH_CONFIRM ? "CONFIRM" \
+                                                              : "unknown"
 
-#define seq_to_string(x) (x) == SAE_AUTH_COMMIT ? "COMMIT" : \
-                         (x) == SAE_AUTH_CONFIRM ? "CONFIRM" : \
-                         "unknown"
-
-#define status_to_string(x) (x) == WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED ? "TOKEN NEEDED" : \
-                            (x) == WLAN_STATUS_NOT_SUPPORTED_GROUP ? "REJECTION" : \
-                            "unknown"
+#define status_to_string(x)                     \
+  (x) == WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED \
+      ? "TOKEN NEEDED"                          \
+      : (x) == WLAN_STATUS_NOT_SUPPORTED_GROUP ? "REJECTION" : "unknown"
 
 /*
  * the functions H() and CN()
  */
-#define H_Init(ctx,x,l) HMAC_Init_ex((ctx), (x), (l), EVP_sha256(), NULL)
-#define H_Update(ctx,x,l) HMAC_Update((ctx),(x),(l))
-#define H_Final(ctx,x) HMAC_Final((ctx), (x), &function_mdlen)
+#define H_Init(ctx, x, l) HMAC_Init_ex((ctx), (x), (l), EVP_sha256(), NULL)
+#define H_Update(ctx, x, l) HMAC_Update((ctx), (x), (l))
+#define H_Final(ctx, x) HMAC_Final((ctx), (x), &function_mdlen)
 
-#define CN_Init(ctx,x,l) HMAC_Init_ex((ctx), (x), (l), EVP_sha256(), NULL)
-#define CN_Update(ctx,x,l) HMAC_Update((ctx),(x),(l))
-#define CN_Final(ctx,x) HMAC_Final((ctx), (x), &function_mdlen)
+#define CN_Init(ctx, x, l) HMAC_Init_ex((ctx), (x), (l), EVP_sha256(), NULL)
+#define CN_Update(ctx, x, l) HMAC_Update((ctx), (x), (l))
+#define CN_Final(ctx, x) HMAC_Final((ctx), (x), &function_mdlen)
 
 /* Pre 1.1.0 compatibility macros */
 #ifndef OPENSSL_API_COMPAT
-static HMAC_CTX* HMAC_CTX_new(void) {
-    return (HMAC_CTX*) calloc(sizeof(HMAC_CTX), 1);
+static HMAC_CTX *HMAC_CTX_new(void) {
+  return (HMAC_CTX *)calloc(sizeof(HMAC_CTX), 1);
 }
 
-static void HMAC_CTX_free(HMAC_CTX* ctx)
-{
-    if (ctx) {
-        HMAC_CTX_cleanup(ctx);
-        free(ctx);
-    }
+static void HMAC_CTX_free(HMAC_CTX *ctx) {
+  if (ctx) {
+    HMAC_CTX_cleanup(ctx);
+    free(ctx);
+  }
 }
 #endif
 
@@ -102,7 +101,7 @@ static void reauth(void *data);
  * global variables
  */
 BN_CTX *bnctx = NULL;
-GD *gd;                                 /* group definitions */
+GD *gd; /* group definitions */
 BIO *out;
 int curr_open, open_threshold, retrans;
 unsigned long blacklist_timeout, giveup_threshold, pmk_expiry;
@@ -110,2222 +109,2486 @@ unsigned long token_generator;
 char conffile[PATH_MAX], allzero[SHA256_DIGEST_LENGTH];
 unsigned int function_mdlen = SHA256_DIGEST_LENGTH;
 
-enum result {
-    NO_ERR,
-    ERR_NOT_FATAL,
-    ERR_FATAL,
-    ERR_BLACKLIST
-};
+enum result { NO_ERR, ERR_NOT_FATAL, ERR_FATAL, ERR_BLACKLIST };
 
-static void
-dump_buffer (unsigned char *buf, int len)
-{
-    int i;
+static void dump_buffer(unsigned char *buf, int len) {
+  int i;
 
-    for (i = 0; i < len; i++) {
-        if (i && (i%4 == 0)) {
-            printf(" ");
-        }
-        if (i && (i%32 == 0)) {
-            printf("\n");
-        }
-        printf("%02x", buf[i]);
+  for (i = 0; i < len; i++) {
+    if (i && (i % 4 == 0)) {
+      printf(" ");
     }
-    printf("\n");
+    if (i && (i % 32 == 0)) {
+      printf("\n");
+    }
+    printf("%02x", buf[i]);
+  }
+  printf("\n");
 }
 
-static void
-print_buffer (char *str, unsigned char *buf, int len)
-{
-    printf("%s:\n", str);
-    dump_buffer(buf, len);
-    printf("\n");
+static void print_buffer(char *str, unsigned char *buf, int len) {
+  printf("%s:\n", str);
+  dump_buffer(buf, len);
+  printf("\n");
 }
 
-static void
-pp_a_bignum (char *str, BIGNUM *bn)
-{
-    unsigned char *buf;
-    int len;
+static void pp_a_bignum(char *str, BIGNUM *bn) {
+  unsigned char *buf;
+  int len;
 
-    len = BN_num_bytes(bn);
-    if ((buf = malloc(len)) == NULL) {
-        return;
-    }
-    BN_bn2bin(bn, buf);
-    print_buffer(str, buf, len);
-    free(buf);
+  len = BN_num_bytes(bn);
+  if ((buf = malloc(len)) == NULL) {
+    return;
+  }
+  BN_bn2bin(bn, buf);
+  print_buffer(str, buf, len);
+  free(buf);
 }
 
-int
-prf (unsigned char *key, int keylen, unsigned char *label, int labellen,
-     unsigned char *context, int contextlen,
-     unsigned char *result, int resultbitlen)
-{
-    HMAC_CTX *ctx;
-    unsigned char digest[SHA256_DIGEST_LENGTH];
-    int resultlen, len = 0;
-    unsigned int mdlen = SHA256_DIGEST_LENGTH;
-    unsigned char mask = 0xff;
-    unsigned short reslength;
-    unsigned short i = 0, i_le;
-    reslength = ieee_order(resultbitlen);
-    resultlen = (resultbitlen + 7)/8;
-    do {
-        i++;
-        ctx = HMAC_CTX_new();
-        if (ctx == NULL)
-            return -1;
-        HMAC_Init_ex(ctx, key, keylen, EVP_sha256(), NULL);
-        i_le = ieee_order(i);
-        HMAC_Update(ctx, (unsigned char *) &i_le, sizeof(i_le));
-        HMAC_Update(ctx, label, labellen);
-        HMAC_Update(ctx, context, contextlen);
-        HMAC_Update(ctx, (unsigned char *)&reslength, sizeof(unsigned short));
-        HMAC_Final(ctx, digest, &mdlen);
-        HMAC_CTX_free(ctx);
-        ctx = NULL;
-        if ((len + mdlen) > resultlen) {
-            memcpy(result+len, digest, resultlen - len);
-        } else {
-            memcpy(result+len, digest, mdlen);
-        }
-        len += mdlen;
-    } while (len < resultlen);
-    /*
-     * we're expanding to a bit length, if this is not a
-     * multiple of 8 bits then mask off the excess.
-     */
-    if (resultbitlen % 8) {
-        mask <<= (8 - (resultbitlen % 8));
-        result[resultlen - 1] &= mask;
+int prf(
+    unsigned char *key,
+    int keylen,
+    unsigned char *label,
+    int labellen,
+    unsigned char *context,
+    int contextlen,
+    unsigned char *result,
+    int resultbitlen) {
+  HMAC_CTX *ctx;
+  unsigned char digest[SHA256_DIGEST_LENGTH];
+  int resultlen, len = 0;
+  unsigned int mdlen = SHA256_DIGEST_LENGTH;
+  unsigned char mask = 0xff;
+  unsigned short reslength;
+  unsigned short i = 0, i_le;
+  reslength = ieee_order(resultbitlen);
+  resultlen = (resultbitlen + 7) / 8;
+  do {
+    i++;
+    ctx = HMAC_CTX_new();
+    if (ctx == NULL)
+      return -1;
+    HMAC_Init_ex(ctx, key, keylen, EVP_sha256(), NULL);
+    i_le = ieee_order(i);
+    HMAC_Update(ctx, (unsigned char *)&i_le, sizeof(i_le));
+    HMAC_Update(ctx, label, labellen);
+    HMAC_Update(ctx, context, contextlen);
+    HMAC_Update(ctx, (unsigned char *)&reslength, sizeof(unsigned short));
+    HMAC_Final(ctx, digest, &mdlen);
+    HMAC_CTX_free(ctx);
+    ctx = NULL;
+    if ((len + mdlen) > resultlen) {
+      memcpy(result + len, digest, resultlen - len);
+    } else {
+      memcpy(result + len, digest, mdlen);
     }
-    return resultlen;
+    len += mdlen;
+  } while (len < resultlen);
+  /*
+   * we're expanding to a bit length, if this is not a
+   * multiple of 8 bits then mask off the excess.
+   */
+  if (resultbitlen % 8) {
+    mask <<= (8 - (resultbitlen % 8));
+    result[resultlen - 1] &= mask;
+  }
+  return resultlen;
 }
 
-static void
-remove_from_blacklist (void *data)
-{
-    struct candidate *peer, *delme;
+static void remove_from_blacklist(void *data) {
+  struct candidate *peer, *delme;
 
-    delme = (struct candidate *)data;
-    TAILQ_FOREACH(peer, &blacklist, entry) {
-        if (memcmp(delme->peer_mac, peer->peer_mac, ETH_ALEN) == 0) {
-            sae_debug(SAE_DEBUG_PROTOCOL_MSG, "removing " MACSTR " from blacklist\n", MAC2STR(peer->peer_mac));
-            TAILQ_REMOVE(&blacklist, peer, entry);
-            free(delme);
-            return;
-        }
+  delme = (struct candidate *)data;
+  TAILQ_FOREACH(peer, &blacklist, entry) {
+    if (memcmp(delme->peer_mac, peer->peer_mac, ETH_ALEN) == 0) {
+      sae_debug(
+          SAE_DEBUG_PROTOCOL_MSG,
+          "removing " MACSTR " from blacklist\n",
+          MAC2STR(peer->peer_mac));
+      TAILQ_REMOVE(&blacklist, peer, entry);
+      free(delme);
+      return;
     }
+  }
 }
 
-static void
-blacklist_peer (struct candidate *peer)
-{
-    struct candidate *fubar;
-    if ((fubar = (struct candidate *)malloc(sizeof(struct candidate))) != NULL) {
-        memcpy(fubar->peer_mac, peer->peer_mac, ETH_ALEN);
-        TAILQ_INSERT_TAIL(&blacklist, fubar, entry);
-        (void)cb->evl->add_timeout(SRV_SEC(blacklist_timeout), remove_from_blacklist, fubar);
-    }
+static void blacklist_peer(struct candidate *peer) {
+  struct candidate *fubar;
+  if ((fubar = (struct candidate *)malloc(sizeof(struct candidate))) != NULL) {
+    memcpy(fubar->peer_mac, peer->peer_mac, ETH_ALEN);
+    TAILQ_INSERT_TAIL(&blacklist, fubar, entry);
+    (void)cb->evl->add_timeout(
+        SRV_SEC(blacklist_timeout), remove_from_blacklist, fubar);
+  }
 }
 
 /*
  * delete_peer()
  *      Clean up state, remove peer from database, and free up memory.
  */
-void
-delete_peer (struct candidate **delme)
-{
-    struct candidate *peer;
+void delete_peer(struct candidate **delme) {
+  struct candidate *peer;
 
-    TAILQ_FOREACH(peer, &peers, entry) {
-        if (memcmp(*delme, peer, sizeof(struct candidate)) == 0) {
-            sae_debug(SAE_DEBUG_PROTOCOL_MSG, "deleting peer at " MACSTR " in state %s\n",
-                      MAC2STR(peer->peer_mac), state_to_string(peer->state));
-            if ((peer->state == SAE_COMMITTED) || (peer->state == SAE_CONFIRMED)) {
-                curr_open--;
-                if (curr_open < 0) {
-                    /*
-                     * one of those "should not happen" kinds of things
-                     */
-                    sae_debug(SAE_DEBUG_ERR, "***ERROR*** we have %d currently open sessions\n", curr_open);
-                }
-            }
-            cb->evl->rem_timeout(peer->t0);     /* no harm if not set */
-            peer->t0 = 0;
-            cb->evl->rem_timeout(peer->t1);     /*      ditto         */
-            peer->t1 = 0;
-            cb->evl->rem_timeout(peer->t2);     /*      ditto         */
-            peer->t2 = 0;
-            cb->evl->rem_timeout(peer->rekey_ping_timer);
-            peer->rekey_ping_timer = 0;
-            TAILQ_REMOVE(&peers, peer, entry);
-            /*
-             * PWE, the private value, the PMK and KCK are all secret so
-             * take some special care when deleting them.
-             */
-            EC_POINT_clear_free(peer->pwe);
-            BN_clear_free(peer->private_val);
-            memset(peer->pmk, 0, SHA256_DIGEST_LENGTH);
-            memset(peer->kck, 0, SHA256_DIGEST_LENGTH);
-            BN_free(peer->peer_scalar);
-            EC_POINT_free(peer->peer_element);
-            BN_free(peer->my_scalar);
-            EC_POINT_free(peer->my_element);
-            aid_free(peer->association_id);
-            free(*delme);
-            *delme = NULL;
-            return;
+  TAILQ_FOREACH(peer, &peers, entry) {
+    if (memcmp(*delme, peer, sizeof(struct candidate)) == 0) {
+      sae_debug(
+          SAE_DEBUG_PROTOCOL_MSG,
+          "deleting peer at " MACSTR " in state %s\n",
+          MAC2STR(peer->peer_mac),
+          state_to_string(peer->state));
+      if ((peer->state == SAE_COMMITTED) || (peer->state == SAE_CONFIRMED)) {
+        curr_open--;
+        if (curr_open < 0) {
+          /*
+           * one of those "should not happen" kinds of things
+           */
+          sae_debug(
+              SAE_DEBUG_ERR,
+              "***ERROR*** we have %d currently open sessions\n",
+              curr_open);
         }
+      }
+      cb->evl->rem_timeout(peer->t0); /* no harm if not set */
+      peer->t0 = 0;
+      cb->evl->rem_timeout(peer->t1); /*      ditto         */
+      peer->t1 = 0;
+      cb->evl->rem_timeout(peer->t2); /*      ditto         */
+      peer->t2 = 0;
+      cb->evl->rem_timeout(peer->rekey_ping_timer);
+      peer->rekey_ping_timer = 0;
+      TAILQ_REMOVE(&peers, peer, entry);
+      /*
+       * PWE, the private value, the PMK and KCK are all secret so
+       * take some special care when deleting them.
+       */
+      EC_POINT_clear_free(peer->pwe);
+      BN_clear_free(peer->private_val);
+      memset(peer->pmk, 0, SHA256_DIGEST_LENGTH);
+      memset(peer->kck, 0, SHA256_DIGEST_LENGTH);
+      BN_free(peer->peer_scalar);
+      EC_POINT_free(peer->peer_element);
+      BN_free(peer->my_scalar);
+      EC_POINT_free(peer->my_element);
+      aid_free(peer->association_id);
+      free(*delme);
+      *delme = NULL;
+      return;
     }
-    sae_debug(SAE_DEBUG_ERR, "failed to delete peer :-( \n");
+  }
+  sae_debug(SAE_DEBUG_ERR, "failed to delete peer :-( \n");
 }
 
 /*
  * a callback-able version of delete peer
  */
-static void
-destroy_peer (void *data)
-{
-    struct candidate *peer = (struct candidate *)data;
+static void destroy_peer(void *data) {
+  struct candidate *peer = (struct candidate *)data;
 
-    delete_peer(&peer);
+  delete_peer(&peer);
 }
 
-static int
-on_blacklist (unsigned char *mac)
-{
-    struct candidate *peer;
+static int on_blacklist(unsigned char *mac) {
+  struct candidate *peer;
 
-    TAILQ_FOREACH(peer, &blacklist, entry) {
-        if (memcmp(peer->peer_mac, mac, ETH_ALEN) == 0) {
-            return 1;
+  TAILQ_FOREACH(peer, &blacklist, entry) {
+    if (memcmp(peer->peer_mac, mac, ETH_ALEN) == 0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+struct candidate *find_peer(unsigned char *mac, int accept) {
+  struct candidate *peer, *found = NULL;
+
+  TAILQ_FOREACH(peer, &peers, entry) {
+    if (memcmp(peer->peer_mac, mac, ETH_ALEN) == 0) {
+      /*
+       * if "accept" then we're only looking for peers in "accepted" state
+       */
+      if (accept) {
+        if (peer->state == SAE_ACCEPTED) {
+          return peer;
         }
-    }
-    return 0;
-}
-
-struct candidate *
-find_peer (unsigned char *mac, int accept)
-{
-    struct candidate *peer, *found = NULL;
-
-    TAILQ_FOREACH(peer, &peers, entry) {
-        if (memcmp(peer->peer_mac, mac, ETH_ALEN) == 0) {
-            /*
-             * if "accept" then we're only looking for peers in "accepted" state
-             */
-            if (accept) {
-                if (peer->state == SAE_ACCEPTED) {
-                    return peer;
-                }
-                continue;
-            }
-            /*
-             * otherwise we'll take any peer but, if there are 2, give preference
-             * to the one not in "accepted" state
-             */
-            if (found == NULL) {
-                found = peer;
-            } else {
-                if ((found->state == SAE_ACCEPTED) &&
-                    (peer->state != SAE_ACCEPTED)) {
-                    found = peer;
-                }
-            }
+        continue;
+      }
+      /*
+       * otherwise we'll take any peer but, if there are 2, give preference
+       * to the one not in "accepted" state
+       */
+      if (found == NULL) {
+        found = peer;
+      } else {
+        if ((found->state == SAE_ACCEPTED) && (peer->state != SAE_ACCEPTED)) {
+          found = peer;
         }
+      }
     }
-    return found;
+  }
+  return found;
 }
 
-static int
-check_dup (struct candidate *peer, int check_me, struct ieee80211_mgmt_frame *frame, int len)
-{
-    unsigned char *ptr;
-    int itemsize, ret;
-    BIGNUM *scalar;
+static int check_dup(
+    struct candidate *peer,
+    int check_me,
+    struct ieee80211_mgmt_frame *frame,
+    int len) {
+  unsigned char *ptr;
+  int itemsize, ret;
+  BIGNUM *scalar;
 
-    if ((scalar = BN_new()) == NULL) {
-        /*
-         * this seems kind of serious so return that it is a dupe so we don't
-         * do anymore processing of this frame
-         */
-        return 0;
-    }
-    ptr = frame->authenticate.u.var8 + sizeof(unsigned short);
-    if (peer->got_token) {
-        /*
-         * we know how big the token is because we generated it in the first place!
-         */
-        ptr += SHA256_DIGEST_LENGTH;
-    }
-    itemsize = BN_num_bytes(peer->grp_def->order);
-    BN_bin2bn(ptr, itemsize, scalar);
-    if (check_me) {
-        ret = BN_cmp(peer->my_scalar, scalar);
-    } else {
-        ret = BN_cmp(peer->peer_scalar, scalar);
-    }
-    BN_free(scalar);
-    return ret;
-}
-
-static int
-check_confirm (struct candidate *peer, struct ieee80211_mgmt_frame *frame)
-{
-    unsigned short sent_confirm;
-
-    sent_confirm = ieee_order(*(frame->authenticate.u.var16));
-    if ((sent_confirm > peer->rc) && (sent_confirm != COUNTER_INFINITY)) {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-
-static int
-process_confirm (struct candidate *peer, struct ieee80211_mgmt_frame *frame, int len)
-{
-    unsigned char tmp[128];
-    enum result r = NO_ERR;
-    BIGNUM *x = NULL;
-    BIGNUM *y = NULL;
-    EC_POINT *psum = NULL;
-    HMAC_CTX *ctx;
-    int offset;
-    ctx = HMAC_CTX_new();
-    if (ctx == NULL) {
-        r = ERR_FATAL;
-        goto out;
-    }
-
-    if (len != (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) + sizeof(unsigned short) + SHA256_DIGEST_LENGTH)) {
-        sae_debug(SAE_DEBUG_ERR, "bad size of confirm message (%d)\n", len);
-        r = ERR_NOT_FATAL;
-        goto out;
-    }
-    if (((x = BN_new()) == NULL) ||
-        ((y = BN_new()) == NULL) ||
-        ((psum = EC_POINT_new(peer->grp_def->group)) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to construct confirm!\n");
-        r = ERR_FATAL;
-        goto out;
-    }
-
-    CN_Init(ctx, peer->kck, SHA256_DIGEST_LENGTH);     /* the key */
-
-    peer->rc = ieee_order(*(frame->authenticate.u.var16));
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "processing confirm (%d)\n", peer->rc);
+  if ((scalar = BN_new()) == NULL) {
     /*
-     * compute the confirm verifier using the over-the-air format of send_conf
+     * this seems kind of serious so return that it is a dupe so we don't
+     * do anymore processing of this frame
      */
-    CN_Update(ctx, frame->authenticate.u.var8, sizeof(unsigned short));
+    return 0;
+  }
+  ptr = frame->authenticate.u.var8 + sizeof(unsigned short);
+  if (peer->got_token) {
+    /*
+     * we know how big the token is because we generated it in the first place!
+     */
+    ptr += SHA256_DIGEST_LENGTH;
+  }
+  itemsize = BN_num_bytes(peer->grp_def->order);
+  BN_bin2bn(ptr, itemsize, scalar);
+  if (check_me) {
+    ret = BN_cmp(peer->my_scalar, scalar);
+  } else {
+    ret = BN_cmp(peer->peer_scalar, scalar);
+  }
+  BN_free(scalar);
+  return ret;
+}
 
-        /* peer's scalar */
-    offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->peer_scalar);
-    memset(tmp, 0, offset);
-    BN_bn2bin(peer->peer_scalar, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
+static int check_confirm(
+    struct candidate *peer,
+    struct ieee80211_mgmt_frame *frame) {
+  unsigned short sent_confirm;
 
-    if (!EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, peer->peer_element, x, y, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get x,y of peer's element\n");
-        r = ERR_NOT_FATAL;
-        goto out;
-    }
+  sent_confirm = ieee_order(*(frame->authenticate.u.var16));
+  if ((sent_confirm > peer->rc) && (sent_confirm != COUNTER_INFINITY)) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
 
-    /* Rarely x can be way too big, e.g. 1348 bytes. Corrupted packet? */
-    if (BN_num_bytes(peer->grp_def->prime) < BN_num_bytes(x) || BN_num_bytes(peer->grp_def->prime) < BN_num_bytes(y)) {
-        sae_debug(SAE_DEBUG_ERR, "coords are too big, x = %d bytes, y = %d bytes\n", BN_num_bytes(x), BN_num_bytes(y));
-        r = ERR_NOT_FATAL;
-        goto out;
-    }
+static int process_confirm(
+    struct candidate *peer,
+    struct ieee80211_mgmt_frame *frame,
+    int len) {
+  unsigned char tmp[128];
+  enum result r = NO_ERR;
+  BIGNUM *x = NULL;
+  BIGNUM *y = NULL;
+  EC_POINT *psum = NULL;
+  HMAC_CTX *ctx;
+  int offset;
+  ctx = HMAC_CTX_new();
+  if (ctx == NULL) {
+    r = ERR_FATAL;
+    goto out;
+  }
 
-        /* peer's element */
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
-    memset(tmp, 0, offset);
-    BN_bn2bin(x, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
-    memset(tmp, 0, offset);
-    BN_bn2bin(y, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  if (len != (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
+              sizeof(unsigned short) + SHA256_DIGEST_LENGTH)) {
+    sae_debug(SAE_DEBUG_ERR, "bad size of confirm message (%d)\n", len);
+    r = ERR_NOT_FATAL;
+    goto out;
+  }
+  if (((x = BN_new()) == NULL) || ((y = BN_new()) == NULL) ||
+      ((psum = EC_POINT_new(peer->grp_def->group)) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to construct confirm!\n");
+    r = ERR_FATAL;
+    goto out;
+  }
 
-        /* my scalar */
-    offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->my_scalar);
-    memset(tmp, 0, offset);
-    BN_bn2bin(peer->my_scalar, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
+  CN_Init(ctx, peer->kck, SHA256_DIGEST_LENGTH); /* the key */
 
-    if (!EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, peer->my_element, x, y, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get x,y of my element\n");
-        r = ERR_NOT_FATAL;
-        goto out;
-    }
-        /* my element */
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
-    memset(tmp, 0, offset);
-    BN_bn2bin(x, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
-    memset(tmp, 0, offset);
-    BN_bn2bin(y, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  peer->rc = ieee_order(*(frame->authenticate.u.var16));
+  sae_debug(SAE_DEBUG_PROTOCOL_MSG, "processing confirm (%d)\n", peer->rc);
+  /*
+   * compute the confirm verifier using the over-the-air format of send_conf
+   */
+  CN_Update(ctx, frame->authenticate.u.var8, sizeof(unsigned short));
 
-    CN_Final(ctx, tmp);
-    HMAC_CTX_free(ctx);
-    ctx = NULL;
+  /* peer's scalar */
+  offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->peer_scalar);
+  memset(tmp, 0, offset);
+  BN_bn2bin(peer->peer_scalar, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
 
-    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-        print_buffer("peer's confirm",
-                    frame->authenticate.u.var8,
-                    SHA256_DIGEST_LENGTH + sizeof(unsigned short));
-    }
+  if (!EC_POINT_get_affine_coordinates_GFp(
+          peer->grp_def->group, peer->peer_element, x, y, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get x,y of peer's element\n");
+    r = ERR_NOT_FATAL;
+    goto out;
+  }
 
-    if (memcmp(tmp, (frame->authenticate.u.var8 + sizeof(unsigned short)), SHA256_DIGEST_LENGTH)) {
-        sae_debug(SAE_DEBUG_ERR, "confirm did not verify!\n");
-        r = ERR_BLACKLIST;
-        goto out;
-    }
+  /* Rarely x can be way too big, e.g. 1348 bytes. Corrupted packet? */
+  if (BN_num_bytes(peer->grp_def->prime) < BN_num_bytes(x) ||
+      BN_num_bytes(peer->grp_def->prime) < BN_num_bytes(y)) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "coords are too big, x = %d bytes, y = %d bytes\n",
+        BN_num_bytes(x),
+        BN_num_bytes(y));
+    r = ERR_NOT_FATAL;
+    goto out;
+  }
 
-    r = NO_ERR;
+  /* peer's element */
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
+  memset(tmp, 0, offset);
+  BN_bn2bin(x, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
+  memset(tmp, 0, offset);
+  BN_bn2bin(y, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+
+  /* my scalar */
+  offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->my_scalar);
+  memset(tmp, 0, offset);
+  BN_bn2bin(peer->my_scalar, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
+
+  if (!EC_POINT_get_affine_coordinates_GFp(
+          peer->grp_def->group, peer->my_element, x, y, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get x,y of my element\n");
+    r = ERR_NOT_FATAL;
+    goto out;
+  }
+  /* my element */
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
+  memset(tmp, 0, offset);
+  BN_bn2bin(x, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
+  memset(tmp, 0, offset);
+  BN_bn2bin(y, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+
+  CN_Final(ctx, tmp);
+  HMAC_CTX_free(ctx);
+  ctx = NULL;
+
+  if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+    print_buffer(
+        "peer's confirm",
+        frame->authenticate.u.var8,
+        SHA256_DIGEST_LENGTH + sizeof(unsigned short));
+  }
+
+  if (memcmp(
+          tmp,
+          (frame->authenticate.u.var8 + sizeof(unsigned short)),
+          SHA256_DIGEST_LENGTH)) {
+    sae_debug(SAE_DEBUG_ERR, "confirm did not verify!\n");
+    r = ERR_BLACKLIST;
+    goto out;
+  }
+
+  r = NO_ERR;
 
 out:
-    HMAC_CTX_free(ctx);
+  HMAC_CTX_free(ctx);
 
-    BN_free(x);
-    BN_free(y);
-    EC_POINT_free(psum);
+  BN_free(x);
+  BN_free(y);
+  EC_POINT_free(psum);
 
-    return r;
+  return r;
 }
 
-static int
-confirm_to_peer (struct candidate *peer)
-{
-    char buf[2048];
-    unsigned char tmp[128];
-    struct ieee80211_mgmt_frame *frame;
-    size_t len = 0;
-    BIGNUM *x, *y;
-    HMAC_CTX *ctx;
-    unsigned short send_conf;
-    int offset;
-    int ret = 0;
-    ctx = HMAC_CTX_new();
-    if (ctx == NULL) {
-        return -1;
-    }
+static int confirm_to_peer(struct candidate *peer) {
+  char buf[2048];
+  unsigned char tmp[128];
+  struct ieee80211_mgmt_frame *frame;
+  size_t len = 0;
+  BIGNUM *x, *y;
+  HMAC_CTX *ctx;
+  unsigned short send_conf;
+  int offset;
+  int ret = 0;
+  ctx = HMAC_CTX_new();
+  if (ctx == NULL) {
+    return -1;
+  }
 
-    if (((x = BN_new()) == NULL) ||
-        ((y = BN_new()) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to construct confirm!\n");
-        return -1;
-    }
+  if (((x = BN_new()) == NULL) || ((y = BN_new()) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to construct confirm!\n");
+    return -1;
+  }
 
-    memset(buf, 0, sizeof(buf));
-    frame = (struct ieee80211_mgmt_frame *)buf;
+  memset(buf, 0, sizeof(buf));
+  frame = (struct ieee80211_mgmt_frame *)buf;
 
-    frame->frame_control = ieee_order((IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
-    memcpy(frame->sa, peer->my_mac, ETH_ALEN);
-    memcpy(frame->da, peer->peer_mac, ETH_ALEN);
-    memcpy(frame->bssid, peer->peer_mac, ETH_ALEN);
+  frame->frame_control = ieee_order(
+      (IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
+  memcpy(frame->sa, peer->my_mac, ETH_ALEN);
+  memcpy(frame->da, peer->peer_mac, ETH_ALEN);
+  memcpy(frame->bssid, peer->peer_mac, ETH_ALEN);
 
-    frame->authenticate.alg = ieee_order(SAE_AUTH_ALG);
-    frame->authenticate.auth_seq = ieee_order(SAE_AUTH_CONFIRM);
-    len = IEEE802_11_HDR_LEN + sizeof(frame->authenticate);
+  frame->authenticate.alg = ieee_order(SAE_AUTH_ALG);
+  frame->authenticate.auth_seq = ieee_order(SAE_AUTH_CONFIRM);
+  len = IEEE802_11_HDR_LEN + sizeof(frame->authenticate);
 
-    if (peer->sc != COUNTER_INFINITY) {
-        peer->sc++;
-    }
-    send_conf = ieee_order(peer->sc);
-    memcpy(frame->authenticate.u.var8, (unsigned char *)&send_conf, sizeof(unsigned short));
-    len += sizeof(unsigned short);
+  if (peer->sc != COUNTER_INFINITY) {
+    peer->sc++;
+  }
+  send_conf = ieee_order(peer->sc);
+  memcpy(
+      frame->authenticate.u.var8,
+      (unsigned char *)&send_conf,
+      sizeof(unsigned short));
+  len += sizeof(unsigned short);
 
+  CN_Init(ctx, peer->kck, SHA256_DIGEST_LENGTH); /* the key */
 
-    CN_Init(ctx, peer->kck, SHA256_DIGEST_LENGTH);     /* the key */
+  /* send_conf is in over-the-air format now */
+  CN_Update(ctx, (unsigned char *)&send_conf, sizeof(unsigned short));
 
-    /* send_conf is in over-the-air format now */
-    CN_Update(ctx, (unsigned char *)&send_conf, sizeof(unsigned short));
+  /* my scalar */
+  offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->my_scalar);
+  memset(tmp, 0, offset);
+  BN_bn2bin(peer->my_scalar, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
 
-        /* my scalar */
-    offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->my_scalar);
-    memset(tmp, 0, offset);
-    BN_bn2bin(peer->my_scalar, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
+  if (!EC_POINT_get_affine_coordinates_GFp(
+          peer->grp_def->group, peer->my_element, x, y, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get x,y of my element\n");
+    ret = -1;
+    goto fail;
+  }
+  /* my element */
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
+  memset(tmp, 0, offset);
+  BN_bn2bin(x, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
+  memset(tmp, 0, offset);
+  BN_bn2bin(y, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
 
-    if (!EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, peer->my_element, x, y, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get x,y of my element\n");
-        ret = -1;
-        goto fail;
-    }
-        /* my element */
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
-    memset(tmp, 0, offset);
-    BN_bn2bin(x, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
-    memset(tmp, 0, offset);
-    BN_bn2bin(y, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  /* peer's scalar */
+  offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->peer_scalar);
+  memset(tmp, 0, offset);
+  BN_bn2bin(peer->peer_scalar, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
 
-        /* peer's scalar */
-    offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->peer_scalar);
-    memset(tmp, 0, offset);
-    BN_bn2bin(peer->peer_scalar, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->order));
+  if (!EC_POINT_get_affine_coordinates_GFp(
+          peer->grp_def->group, peer->peer_element, x, y, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get x,y of peer's element\n");
+    ret = -1;
+    goto fail;
+  }
+  /* peer's element */
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
+  memset(tmp, 0, offset);
+  BN_bn2bin(x, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
+  memset(tmp, 0, offset);
+  BN_bn2bin(y, tmp + offset);
+  CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
 
-    if (!EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, peer->peer_element, x, y, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get x,y of peer's element\n");
-        ret = -1;
-        goto fail;
-    }
-        /* peer's element */
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
-    memset(tmp, 0, offset);
-    BN_bn2bin(x, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
-    memset(tmp, 0, offset);
-    BN_bn2bin(y, tmp + offset);
-    CN_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  CN_Final(ctx, (frame->authenticate.u.var8 + sizeof(unsigned short)));
 
-    CN_Final(ctx, (frame->authenticate.u.var8 + sizeof(unsigned short)));
+  if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+    print_buffer(
+        "local confirm",
+        frame->authenticate.u.var8,
+        SHA256_DIGEST_LENGTH + sizeof(unsigned short));
+  }
 
-    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-        print_buffer("local confirm",
-                    frame->authenticate.u.var8,
-                    SHA256_DIGEST_LENGTH + sizeof(unsigned short));
-    }
+  len += SHA256_DIGEST_LENGTH;
 
-    len += SHA256_DIGEST_LENGTH;
-
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, MACSTR " in %s, sending %s (sc=%d), len %zu\n",
-              MAC2STR(peer->peer_mac),
-              state_to_string(peer->state),
-              seq_to_string(ieee_order(frame->authenticate.auth_seq)),
-              peer->sc, len);
-    if (cb->meshd_write_mgmt(buf, len, peer->cookie) != len) {
-        sae_debug(SAE_DEBUG_ERR, "can't send an authentication frame to " MACSTR "\n",
-                MAC2STR(peer->peer_mac));
-        ret = -1;
-        goto fail;
-    }
+  sae_debug(
+      SAE_DEBUG_PROTOCOL_MSG,
+      MACSTR " in %s, sending %s (sc=%d), len %zu\n",
+      MAC2STR(peer->peer_mac),
+      state_to_string(peer->state),
+      seq_to_string(ieee_order(frame->authenticate.auth_seq)),
+      peer->sc,
+      len);
+  if (cb->meshd_write_mgmt(buf, len, peer->cookie) != len) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "can't send an authentication frame to " MACSTR "\n",
+        MAC2STR(peer->peer_mac));
+    ret = -1;
+    goto fail;
+  }
 
 fail:
 
+  BN_free(x);
+  BN_free(y);
+  HMAC_CTX_free(ctx);
+
+  return ret;
+}
+
+static int process_commit(
+    struct candidate *peer,
+    struct ieee80211_mgmt_frame *frame,
+    int len) {
+  BIGNUM *x = NULL, *y = NULL, *k = NULL, *nsum;
+  int offset, itemsize, ret = 0;
+  EC_POINT *K = NULL;
+  unsigned char *ptr, *tmp, keyseed[SHA256_DIGEST_LENGTH],
+      kckpmk[(SHA256_DIGEST_LENGTH * 2) * 8];
+  HMAC_CTX *ctx;
+  ctx = HMAC_CTX_new();
+  if (ctx == NULL) {
+    return -1;
+  }
+
+  /*
+   * check whether the frame is big enough (might be proprietary IEs or cruft
+   * appended)
+   */
+  if (len < (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
+             (2 * BN_num_bytes(peer->grp_def->prime)) +
+             BN_num_bytes(peer->grp_def->order))) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "invalid size for commit message (%d < %d+%zu+(2*%d)+%d = %zu))\n",
+        len,
+        IEEE802_11_HDR_LEN,
+        sizeof(frame->authenticate),
+        BN_num_bytes(peer->grp_def->prime),
+        BN_num_bytes(peer->grp_def->order),
+        (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
+         (2 * BN_num_bytes(peer->grp_def->prime)) +
+         BN_num_bytes(peer->grp_def->order)));
+    goto fail;
+  }
+  if (((x = BN_new()) == NULL) || ((y = BN_new()) == NULL) ||
+      ((k = BN_new()) == NULL) ||
+      ((K = EC_POINT_new(peer->grp_def->group)) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to create x,y bignums\n");
+    goto fail;
+  }
+  ptr = frame->authenticate.u.var8;
+  /*
+   * first thing in a commit is the finite cyclic group, skip the group
+   */
+  ptr += sizeof(unsigned short);
+
+  if (peer->got_token) {
+    /*
+     * if we got a token then skip over it. We know the size because we
+     * created it in the first place!
+     */
+    ptr += SHA256_DIGEST_LENGTH;
+  }
+
+  /*
+   * first get the peer's scalar
+   */
+  itemsize = BN_num_bytes(peer->grp_def->order);
+  BN_bin2bn(ptr, itemsize, peer->peer_scalar);
+  ptr += itemsize;
+  /*
+   * then get x and y and turn them into the peer's element
+   */
+  itemsize = BN_num_bytes(peer->grp_def->prime);
+  BN_bin2bn(ptr, itemsize, x);
+  ptr += itemsize;
+  BN_bin2bn(ptr, itemsize, y);
+
+  if (!EC_POINT_set_affine_coordinates_GFp(
+          peer->grp_def->group, peer->peer_element, x, y, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to obtain peer's password element!\n");
+    goto fail;
+  }
+
+  /*
+   * validate the scalar...
+   */
+  if ((BN_cmp(peer->peer_scalar, BN_value_one()) < 1) ||
+      (BN_cmp(peer->peer_scalar, peer->grp_def->order) > 0)) {
+    sae_debug(SAE_DEBUG_ERR, "peer's scalar is invalid!\n");
+    goto fail;
+  }
+  /*
+   * ...and the element
+   */
+  if (!EC_POINT_is_on_curve(peer->grp_def->group, peer->peer_element, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "peer's element is invalid!\n");
+    goto fail;
+  }
+
+  if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+    printf("peer's commit:\n");
+    pp_a_bignum("peer's scalar", peer->peer_scalar);
+    printf("peer's element:\n");
+    pp_a_bignum("x", x);
+    pp_a_bignum("y", y);
+  }
+
+  /*
+   * now compute: scalar * PWE...
+   */
+  if (!EC_POINT_mul(
+          peer->grp_def->group, K, NULL, peer->pwe, peer->peer_scalar, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to multiply peer's scalar and PWE!\n");
+    goto fail;
+  }
+
+  /*
+   * ... + element
+   */
+  if (!EC_POINT_add(peer->grp_def->group, K, K, peer->peer_element, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to add element to running point!\n");
+    goto fail;
+  }
+  /*
+   * ... * private val = our private_val * peer's private_val * pwe
+   */
+  if (!EC_POINT_mul(
+          peer->grp_def->group, K, NULL, K, peer->private_val, bnctx)) {
+    sae_debug(
+        SAE_DEBUG_ERR, "unable to multiple intermediate by private value!\n");
+    goto fail;
+  }
+
+  if (!EC_POINT_get_affine_coordinates_GFp(
+          peer->grp_def->group, K, k, NULL, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get secret key!\n");
+    goto fail;
+  }
+
+  /*
+   * compute the KCK and PMK
+   */
+  if ((tmp = (unsigned char *)malloc(BN_num_bytes(peer->grp_def->prime))) ==
+      NULL) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "unable to malloc %d bytes for secret!\n",
+        BN_num_bytes(k));
+    goto fail;
+  }
+  /*
+   * first extract the entropy from k into keyseed...
+   */
+  offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(k);
+  memset(tmp, 0, offset);
+  BN_bn2bin(k, tmp + offset);
+  H_Init(ctx, allzero, SHA256_DIGEST_LENGTH);
+  H_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
+  H_Final(ctx, keyseed);
+  free(tmp);
+
+  /*
+   * ...then expand it to create KCK | PMK
+   */
+  if (((tmp = (unsigned char *)malloc(BN_num_bytes(peer->grp_def->order))) ==
+       NULL) ||
+      ((nsum = BN_new()) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to create buf/bignum to sum scalars!\n");
+    goto fail;
+  }
+  BN_add(nsum, peer->my_scalar, peer->peer_scalar);
+  BN_mod(nsum, nsum, peer->grp_def->order, bnctx);
+  offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(nsum);
+  memset(tmp, 0, offset);
+  BN_bn2bin(nsum, tmp + offset);
+
+  memcpy(peer->pmkid, tmp, 16);
+
+  prf(keyseed,
+      SHA256_DIGEST_LENGTH,
+      (unsigned char *)"SAE KCK and PMK",
+      strlen("SAE KCK and PMK"),
+      tmp,
+      BN_num_bytes(peer->grp_def->order),
+      kckpmk,
+      ((SHA256_DIGEST_LENGTH * 2) * 8));
+  free(tmp);
+  BN_free(nsum);
+
+  memcpy(peer->kck, kckpmk, SHA256_DIGEST_LENGTH);
+  memcpy(peer->pmk, kckpmk + SHA256_DIGEST_LENGTH, SHA256_DIGEST_LENGTH);
+
+  if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+    pp_a_bignum("k", k);
+    print_buffer("keyseed", keyseed, SHA256_DIGEST_LENGTH);
+    print_buffer("KCK", peer->kck, SHA256_DIGEST_LENGTH);
+    print_buffer("PMK", peer->pmk, SHA256_DIGEST_LENGTH);
+  }
+  if (0) {
+  fail:
+    ret = -1;
+  }
+  BN_free(x);
+  BN_free(y);
+  BN_free(k);
+  EC_POINT_free(K);
+  HMAC_CTX_free(ctx);
+
+  return ret;
+}
+
+static int
+commit_to_peer(struct candidate *peer, unsigned char *token, int token_len) {
+  char buf[2048];
+  struct ieee80211_mgmt_frame *frame;
+  int offset1, offset2;
+  size_t len = 0;
+  BIGNUM *x, *y, *mask;
+  unsigned short grp_num;
+  unsigned char *ptr;
+
+  memset(buf, 0, sizeof(buf));
+  frame = (struct ieee80211_mgmt_frame *)buf;
+
+  /*
+   * fill in authentication frame header...
+   */
+  frame->frame_control = ieee_order(
+      (IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
+  memcpy(frame->sa, peer->my_mac, ETH_ALEN);
+  memcpy(frame->da, peer->peer_mac, ETH_ALEN);
+  memcpy(frame->bssid, peer->peer_mac, ETH_ALEN);
+
+  frame->authenticate.alg = ieee_order(SAE_AUTH_ALG);
+  frame->authenticate.auth_seq = ieee_order(SAE_AUTH_COMMIT);
+  len = IEEE802_11_HDR_LEN + sizeof(frame->authenticate);
+  ptr = frame->authenticate.u.var8;
+
+  /*
+   * first, indicate what group we're committing with
+   */
+  grp_num = ieee_order(peer->grp_def->group_num);
+  memcpy(ptr, &grp_num, sizeof(unsigned short));
+  ptr += sizeof(unsigned short);
+  len += sizeof(unsigned short);
+
+  /*
+   * if we've been asked to include a token then include a token
+   */
+  if (token_len && (token != NULL)) {
+    memcpy(ptr, token, token_len);
+    ptr += token_len;
+    len += token_len;
+  }
+
+  if (peer->private_val == NULL) {
+    if (((mask = BN_new()) == NULL) ||
+        ((peer->private_val = BN_new()) == NULL)) {
+      sae_debug(SAE_DEBUG_ERR, "unable to commit to peer!\n");
+      return -1;
+    }
+    /*
+     * generate private values
+     */
+    BN_rand_range(peer->private_val, peer->grp_def->order);
+    BN_rand_range(mask, peer->grp_def->order);
+    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+      pp_a_bignum("local private value", peer->private_val);
+      pp_a_bignum("local mask value", mask);
+    }
+    /*
+     * generate scalar = (priv + mask) mod order
+     */
+    BN_add(peer->my_scalar, peer->private_val, mask);
+    BN_mod(peer->my_scalar, peer->my_scalar, peer->grp_def->order, bnctx);
+    /*
+     * generate element = -(mask*pwe)
+     */
+    if (!EC_POINT_mul(
+            peer->grp_def->group,
+            peer->my_element,
+            NULL,
+            peer->pwe,
+            mask,
+            bnctx)) {
+      sae_debug(SAE_DEBUG_ERR, "unable to compute A!\n");
+      BN_free(mask);
+      return -1;
+    }
+    if (!EC_POINT_invert(peer->grp_def->group, peer->my_element, bnctx)) {
+      sae_debug(SAE_DEBUG_ERR, "unable to invert A!\n");
+      BN_free(mask);
+      return -1;
+    }
+    BN_free(mask);
+  }
+  if (((x = BN_new()) == NULL) || ((y = BN_new()) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to create x,y bignums\n");
+    return -1;
+  }
+  if (!EC_POINT_get_affine_coordinates_GFp(
+          peer->grp_def->group, peer->my_element, x, y, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get secret key!\n");
     BN_free(x);
     BN_free(y);
-    HMAC_CTX_free(ctx);
+    return -1;
+  }
+  if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+    printf("local commit:\n");
+    pp_a_bignum("my scalar", peer->my_scalar);
+    printf("my element:\n");
+    pp_a_bignum("x", x);
+    pp_a_bignum("y", y);
+  }
+  /*
+   * fill in the commit, first in the commit message is the scalar
+   */
+  offset1 = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->my_scalar);
+  BN_bn2bin(peer->my_scalar, ptr + offset1);
+  ptr += BN_num_bytes(peer->grp_def->order);
+  len += BN_num_bytes(peer->grp_def->order);
 
-    return ret;
+  /*
+   * ...next is the element, x then y
+   */
+  if (!EC_POINT_get_affine_coordinates_GFp(
+          peer->grp_def->group, peer->my_element, x, y, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to determine u!\n");
+    exit(1);
+  }
+  offset1 = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
+  BN_bn2bin(x, ptr + offset1);
+  ptr += BN_num_bytes(peer->grp_def->prime);
+
+  offset2 = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
+  BN_bn2bin(y, ptr + offset2);
+  ptr += BN_num_bytes(peer->grp_def->prime);
+
+  len += (2 * BN_num_bytes(peer->grp_def->prime));
+
+  sae_debug(
+      SAE_DEBUG_PROTOCOL_MSG,
+      "peer " MACSTR " in %s, sending %s (%s token), len %zu, group %d\n",
+      MAC2STR(peer->peer_mac),
+      state_to_string(peer->state),
+      seq_to_string(ieee_order(frame->authenticate.auth_seq)),
+      (token_len ? "with" : "no"),
+      len,
+      peer->grp_def->group_num);
+  BN_free(x);
+  BN_free(y);
+  if (cb->meshd_write_mgmt(buf, len, peer->cookie) != len) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "can't send an authentication frame to " MACSTR "\n",
+        MAC2STR(peer->peer_mac));
+    return -1;
+  }
+
+  return 0;
 }
 
-static int
-process_commit (struct candidate *peer, struct ieee80211_mgmt_frame *frame, int len)
-{
-    BIGNUM *x = NULL, *y = NULL, *k = NULL, *nsum;
-    int offset, itemsize, ret = 0;
-    EC_POINT *K = NULL;
-    unsigned char *ptr, *tmp, keyseed[SHA256_DIGEST_LENGTH], kckpmk[(SHA256_DIGEST_LENGTH * 2) * 8];
-    HMAC_CTX *ctx;
-    ctx = HMAC_CTX_new();
-    if (ctx == NULL) {
-        return -1;
-    }
+static int request_token(
+    struct ieee80211_mgmt_frame *req,
+    unsigned char *me,
+    void *cookie) {
+  char buf[2048];
+  struct ieee80211_mgmt_frame *frame;
+  HMAC_CTX *ctx;
+  size_t len = 0;
+  ctx = HMAC_CTX_new();
+  if (ctx == NULL) {
+    return -1;
+  }
 
-    /*
-     * check whether the frame is big enough (might be proprietary IEs or cruft appended)
-     */
-    if (len < (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
-                (2 * BN_num_bytes(peer->grp_def->prime)) + BN_num_bytes(peer->grp_def->order))) {
-        sae_debug(SAE_DEBUG_ERR, "invalid size for commit message (%d < %d+%zu+(2*%d)+%d = %zu))\n", len,
-                  IEEE802_11_HDR_LEN, sizeof(frame->authenticate), BN_num_bytes(peer->grp_def->prime),
-                  BN_num_bytes(peer->grp_def->order),
-                  (IEEE802_11_HDR_LEN+sizeof(frame->authenticate)+
-                   (2*BN_num_bytes(peer->grp_def->prime)) + BN_num_bytes(peer->grp_def->order)));
-        goto fail;
-    }
-    if (((x = BN_new()) == NULL) ||
-        ((y = BN_new()) == NULL) ||
-        ((k = BN_new()) == NULL) ||
-        ((K = EC_POINT_new(peer->grp_def->group)) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to create x,y bignums\n");
-        goto fail;
-    }
-    ptr = frame->authenticate.u.var8;
-    /*
-     * first thing in a commit is the finite cyclic group, skip the group
-     */
-    ptr += sizeof(unsigned short);
+  memset(buf, 0, sizeof(buf));
+  frame = (struct ieee80211_mgmt_frame *)buf;
 
-    if (peer->got_token) {
-        /*
-         * if we got a token then skip over it. We know the size because we
-         * created it in the first place!
-         */
-        ptr += SHA256_DIGEST_LENGTH;
-    }
+  frame->frame_control = ieee_order(
+      (IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
+  memcpy(frame->sa, me, ETH_ALEN);
+  memcpy(frame->da, req->sa, ETH_ALEN);
+  memcpy(frame->bssid, req->sa, ETH_ALEN);
 
-    /*
-     * first get the peer's scalar
-     */
-    itemsize = BN_num_bytes(peer->grp_def->order);
-    BN_bin2bn(ptr, itemsize, peer->peer_scalar);
-    ptr += itemsize;
-    /*
-     * then get x and y and turn them into the peer's element
-     */
-    itemsize = BN_num_bytes(peer->grp_def->prime);
-    BN_bin2bn(ptr, itemsize, x);
-    ptr += itemsize;
-    BN_bin2bn(ptr, itemsize, y);
+  frame->authenticate.alg = req->authenticate.alg;
+  frame->authenticate.auth_seq = ieee_order(SAE_AUTH_COMMIT);
+  frame->authenticate.status =
+      ieee_order(WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED);
+  len = IEEE802_11_HDR_LEN + sizeof(frame->authenticate);
 
-    if (!EC_POINT_set_affine_coordinates_GFp(peer->grp_def->group, peer->peer_element, x, y, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to obtain peer's password element!\n");
-        goto fail;
-    }
+  H_Init(ctx, (unsigned char *)&token_generator, sizeof(unsigned long));
+  H_Update(ctx, req->sa, ETH_ALEN);
+  H_Update(ctx, me, ETH_ALEN);
+  H_Final(ctx, frame->authenticate.u.var8);
+  HMAC_CTX_free(ctx);
+  ctx = NULL;
+  len += SHA256_DIGEST_LENGTH;
 
-    /*
-     * validate the scalar...
-     */
-    if ((BN_cmp(peer->peer_scalar, BN_value_one()) < 1) ||
-        (BN_cmp(peer->peer_scalar, peer->grp_def->order) > 0)) {
-        sae_debug(SAE_DEBUG_ERR, "peer's scalar is invalid!\n");
-        goto fail;
-    }
-    /*
-     * ...and the element
-     */
-    if (!EC_POINT_is_on_curve(peer->grp_def->group, peer->peer_element, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "peer's element is invalid!\n");
-        goto fail;
-    }
-
-    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-        printf("peer's commit:\n");
-        pp_a_bignum("peer's scalar", peer->peer_scalar);
-        printf("peer's element:\n");
-        pp_a_bignum("x", x);
-        pp_a_bignum("y", y);
-    }
-
-    /*
-     * now compute: scalar * PWE...
-     */
-    if (!EC_POINT_mul(peer->grp_def->group, K, NULL, peer->pwe, peer->peer_scalar, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to multiply peer's scalar and PWE!\n");
-        goto fail;
-    }
-
-    /*
-     * ... + element
-     */
-    if (!EC_POINT_add(peer->grp_def->group, K, K, peer->peer_element, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to add element to running point!\n");
-        goto fail;
-    }
-    /*
-     * ... * private val = our private_val * peer's private_val * pwe
-     */
-    if (!EC_POINT_mul(peer->grp_def->group, K, NULL, K, peer->private_val, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to multiple intermediate by private value!\n");
-        goto fail;
-    }
-
-    if (!EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, K, k, NULL, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get secret key!\n");
-        goto fail;
-    }
-
-    /*
-     * compute the KCK and PMK
-     */
-    if ((tmp = (unsigned char *)malloc(BN_num_bytes(peer->grp_def->prime))) == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "unable to malloc %d bytes for secret!\n",
-                  BN_num_bytes(k));
-        goto fail;
-    }
-    /*
-     * first extract the entropy from k into keyseed...
-     */
-    offset = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(k);
-    memset(tmp, 0, offset);
-    BN_bn2bin(k, tmp + offset);
-    H_Init(ctx, allzero, SHA256_DIGEST_LENGTH);
-    H_Update(ctx, tmp, BN_num_bytes(peer->grp_def->prime));
-    H_Final(ctx, keyseed);
-    free(tmp);
-
-    /*
-     * ...then expand it to create KCK | PMK
-     */
-    if (((tmp = (unsigned char *)malloc(BN_num_bytes(peer->grp_def->order))) == NULL) ||
-        ((nsum = BN_new()) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to create buf/bignum to sum scalars!\n");
-        goto fail;
-    }
-    BN_add(nsum, peer->my_scalar, peer->peer_scalar);
-    BN_mod(nsum, nsum, peer->grp_def->order, bnctx);
-    offset = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(nsum);
-    memset(tmp, 0, offset);
-    BN_bn2bin(nsum, tmp + offset);
-
-    memcpy(peer->pmkid, tmp, 16);
-
-    prf(keyseed, SHA256_DIGEST_LENGTH,
-        (unsigned char *)"SAE KCK and PMK", strlen("SAE KCK and PMK"),
-        tmp, BN_num_bytes(peer->grp_def->order),
-        kckpmk, ((SHA256_DIGEST_LENGTH * 2) * 8));
-    free(tmp);
-    BN_free(nsum);
-
-    memcpy(peer->kck, kckpmk, SHA256_DIGEST_LENGTH);
-    memcpy(peer->pmk, kckpmk+SHA256_DIGEST_LENGTH, SHA256_DIGEST_LENGTH);
-
-    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-        pp_a_bignum("k", k);
-        print_buffer("keyseed", keyseed, SHA256_DIGEST_LENGTH);
-        print_buffer("KCK", peer->kck, SHA256_DIGEST_LENGTH);
-        print_buffer("PMK", peer->pmk, SHA256_DIGEST_LENGTH);
-    }
-    if (0) {
-fail:
-        ret = -1;
-    }
-    BN_free(x);
-    BN_free(y);
-    BN_free(k);
-    EC_POINT_free(K);
-    HMAC_CTX_free(ctx);
-
-    return ret;
+  sae_debug(
+      SAE_DEBUG_PROTOCOL_MSG,
+      "sending a token request to " MACSTR "\n",
+      MAC2STR(req->sa));
+  if (cb->meshd_write_mgmt(buf, len, cookie) != len) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "can't send a rejection frame to " MACSTR "\n",
+        MAC2STR(req->sa));
+    return -1;
+  }
+  return len;
 }
 
-static int
-commit_to_peer (struct candidate *peer, unsigned char *token, int token_len)
-{
-    char buf[2048];
-    struct ieee80211_mgmt_frame *frame;
-    int offset1, offset2;
-    size_t len = 0;
-    BIGNUM *x, *y, *mask;
-    unsigned short grp_num;
-    unsigned char *ptr;
+static int reject_to_peer(
+    struct candidate *peer,
+    struct ieee80211_mgmt_frame *frame) {
+  char buf[2048];
+  struct ieee80211_mgmt_frame *rej;
+  size_t len = 0;
 
-    memset(buf, 0, sizeof(buf));
-    frame = (struct ieee80211_mgmt_frame *)buf;
+  memset(buf, 0, sizeof(buf));
+  rej = (struct ieee80211_mgmt_frame *)buf;
 
-    /*
-     * fill in authentication frame header...
-     */
-    frame->frame_control = ieee_order((IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
-    memcpy(frame->sa, peer->my_mac, ETH_ALEN);
-    memcpy(frame->da, peer->peer_mac, ETH_ALEN);
-    memcpy(frame->bssid, peer->peer_mac, ETH_ALEN);
+  rej->frame_control = ieee_order(
+      (IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
+  memcpy(rej->sa, peer->my_mac, ETH_ALEN);
+  memcpy(rej->da, peer->peer_mac, ETH_ALEN);
+  memcpy(rej->bssid, peer->peer_mac, ETH_ALEN);
 
-    frame->authenticate.alg = ieee_order(SAE_AUTH_ALG);
-    frame->authenticate.auth_seq = ieee_order(SAE_AUTH_COMMIT);
-    len = IEEE802_11_HDR_LEN + sizeof(frame->authenticate);
-    ptr = frame->authenticate.u.var8;
+  rej->authenticate.alg =
+      frame->authenticate.alg; /* no need for order conversion */
+  rej->authenticate.auth_seq = ieee_order(SAE_AUTH_COMMIT);
+  rej->authenticate.status = ieee_order(WLAN_STATUS_NOT_SUPPORTED_GROUP);
+  len = IEEE802_11_HDR_LEN + sizeof(rej->authenticate);
 
-    /*
-     * first, indicate what group we're committing with
-     */
-    grp_num = ieee_order(peer->grp_def->group_num);
-    memcpy(ptr, &grp_num, sizeof(unsigned short));
-    ptr += sizeof(unsigned short);
-    len += sizeof(unsigned short);
+  /*
+   * indicate what we're rejecting
+   */
+  memcpy(
+      rej->authenticate.u.var8,
+      frame->authenticate.u.var8,
+      sizeof(unsigned long));
+  len += sizeof(unsigned long);
 
-    /*
-     * if we've been asked to include a token then include a token
-     */
-    if (token_len && (token != NULL)) {
-        memcpy(ptr, token, token_len);
-        ptr += token_len;
-        len += token_len;
-    }
+  sae_debug(
+      SAE_DEBUG_PROTOCOL_MSG,
+      "sending REJECTION to " MACSTR "\n",
+      MAC2STR(peer->peer_mac));
+  if (cb->meshd_write_mgmt(buf, len, peer->cookie) != len) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "can't send an authentication frame to " MACSTR "\n",
+        MAC2STR(peer->peer_mac));
+    return -1;
+  }
 
-    if (peer->private_val == NULL) {
-        if (((mask = BN_new()) == NULL) ||
-            ((peer->private_val = BN_new()) == NULL)) {
-            sae_debug(SAE_DEBUG_ERR, "unable to commit to peer!\n");
-            return -1;
-        }
-        /*
-         * generate private values
-         */
-        BN_rand_range(peer->private_val, peer->grp_def->order);
-        BN_rand_range(mask, peer->grp_def->order);
-        if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-            pp_a_bignum("local private value", peer->private_val);
-            pp_a_bignum("local mask value", mask);
-        }
-        /*
-         * generate scalar = (priv + mask) mod order
-         */
-        BN_add(peer->my_scalar, peer->private_val, mask);
-        BN_mod(peer->my_scalar, peer->my_scalar, peer->grp_def->order, bnctx);
-        /*
-         * generate element = -(mask*pwe)
-         */
-        if (!EC_POINT_mul(peer->grp_def->group, peer->my_element, NULL, peer->pwe, mask, bnctx)) {
-            sae_debug(SAE_DEBUG_ERR, "unable to compute A!\n");
-            BN_free(mask);
-            return -1;
-        }
-        if (!EC_POINT_invert(peer->grp_def->group, peer->my_element, bnctx)) {
-            sae_debug(SAE_DEBUG_ERR, "unable to invert A!\n");
-            BN_free(mask);
-            return -1;
-        }
-        BN_free(mask);
-    }
-    if (((x = BN_new()) == NULL) ||
-        ((y = BN_new()) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to create x,y bignums\n");
-        return -1;
-    }
-    if (!EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, peer->my_element, x, y, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get secret key!\n");
-        BN_free(x);
-        BN_free(y);
-        return -1;
-    }
-    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-        printf("local commit:\n");
-        pp_a_bignum("my scalar", peer->my_scalar);
-        printf("my element:\n");
-        pp_a_bignum("x", x);
-        pp_a_bignum("y", y);
-    }
-    /*
-     * fill in the commit, first in the commit message is the scalar
-     */
-    offset1 = BN_num_bytes(peer->grp_def->order) - BN_num_bytes(peer->my_scalar);
-    BN_bn2bin(peer->my_scalar, ptr + offset1);
-    ptr += BN_num_bytes(peer->grp_def->order);
-    len += BN_num_bytes(peer->grp_def->order);
-
-    /*
-     * ...next is the element, x then y
-     */
-    if (!EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, peer->my_element, x, y, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to determine u!\n");
-        exit(1);
-    }
-    offset1 = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(x);
-    BN_bn2bin(x, ptr + offset1);
-    ptr += BN_num_bytes(peer->grp_def->prime);
-
-    offset2 = BN_num_bytes(peer->grp_def->prime) - BN_num_bytes(y);
-    BN_bn2bin(y, ptr + offset2);
-    ptr += BN_num_bytes(peer->grp_def->prime);
-
-    len += (2 * BN_num_bytes(peer->grp_def->prime));
-
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "peer " MACSTR " in %s, sending %s (%s token), len %zu, group %d\n",
-              MAC2STR(peer->peer_mac),
-              state_to_string(peer->state),
-              seq_to_string(ieee_order(frame->authenticate.auth_seq)),
-              (token_len ? "with" : "no"), len,
-              peer->grp_def->group_num);
-    BN_free(x);
-    BN_free(y);
-    if (cb->meshd_write_mgmt(buf, len, peer->cookie) != len) {
-        sae_debug(SAE_DEBUG_ERR, "can't send an authentication frame to " MACSTR "\n",
-                  MAC2STR(peer->peer_mac));
-        return -1;
-    }
-
-    return 0;
+  return 0;
 }
-
-static int
-request_token (struct ieee80211_mgmt_frame *req, unsigned char *me, void *cookie)
-{
-    char buf[2048];
-    struct ieee80211_mgmt_frame *frame;
-    HMAC_CTX *ctx;
-    size_t len = 0;
-    ctx = HMAC_CTX_new();
-    if (ctx == NULL) {
-        return -1;
-    }
-
-    memset(buf, 0, sizeof(buf));
-    frame = (struct ieee80211_mgmt_frame *)buf;
-
-    frame->frame_control = ieee_order((IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
-    memcpy(frame->sa, me, ETH_ALEN);
-    memcpy(frame->da, req->sa, ETH_ALEN);
-    memcpy(frame->bssid, req->sa, ETH_ALEN);
-
-    frame->authenticate.alg = req->authenticate.alg;
-    frame->authenticate.auth_seq = ieee_order(SAE_AUTH_COMMIT);
-    frame->authenticate.status = ieee_order(WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED);
-    len = IEEE802_11_HDR_LEN + sizeof(frame->authenticate);
-
-    H_Init(ctx, (unsigned char *)&token_generator, sizeof(unsigned long));
-    H_Update(ctx, req->sa, ETH_ALEN);
-    H_Update(ctx, me, ETH_ALEN);
-    H_Final(ctx, frame->authenticate.u.var8);
-    HMAC_CTX_free(ctx);
-    ctx = NULL;
-    len += SHA256_DIGEST_LENGTH;
-
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "sending a token request to " MACSTR "\n", MAC2STR(req->sa));
-    if (cb->meshd_write_mgmt(buf, len, cookie) != len) {
-        sae_debug(SAE_DEBUG_ERR, "can't send a rejection frame to " MACSTR "\n",
-                MAC2STR(req->sa));
-        return -1;
-    }
-    return len;
-}
-
-static int
-reject_to_peer (struct candidate *peer, struct ieee80211_mgmt_frame *frame)
-{
-    char buf[2048];
-    struct ieee80211_mgmt_frame *rej;
-    size_t len = 0;
-
-    memset(buf, 0, sizeof(buf));
-    rej = (struct ieee80211_mgmt_frame *)buf;
-
-    rej->frame_control = ieee_order((IEEE802_11_FC_TYPE_MGMT << 2 | IEEE802_11_FC_STYPE_AUTH << 4));
-    memcpy(rej->sa, peer->my_mac, ETH_ALEN);
-    memcpy(rej->da, peer->peer_mac, ETH_ALEN);
-    memcpy(rej->bssid, peer->peer_mac, ETH_ALEN);
-
-    rej->authenticate.alg = frame->authenticate.alg;    /* no need for order conversion */
-    rej->authenticate.auth_seq = ieee_order(SAE_AUTH_COMMIT);
-    rej->authenticate.status = ieee_order(WLAN_STATUS_NOT_SUPPORTED_GROUP);
-    len = IEEE802_11_HDR_LEN + sizeof(rej->authenticate);
-
-    /*
-     * indicate what we're rejecting
-     */
-    memcpy(rej->authenticate.u.var8, frame->authenticate.u.var8, sizeof(unsigned long));
-    len += sizeof(unsigned long);
-
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "sending REJECTION to " MACSTR "\n", MAC2STR(peer->peer_mac));
-    if (cb->meshd_write_mgmt(buf, len, peer->cookie) != len) {
-        sae_debug(SAE_DEBUG_ERR, "can't send an authentication frame to " MACSTR "\n",
-                MAC2STR(peer->peer_mac));
-        return -1;
-    }
-
-    return 0;
-}
-
 
 /*
  * calculate the legendre symbol (a/p)
  */
-static int
-legendre (BIGNUM *a, BIGNUM *p, BIGNUM *exp, BN_CTX *bnctx)
-{
-    BIGNUM *tmp = NULL;
-    int symbol = -1;
+static int legendre(BIGNUM *a, BIGNUM *p, BIGNUM *exp, BN_CTX *bnctx) {
+  BIGNUM *tmp = NULL;
+  int symbol = -1;
 
-    if ((tmp = BN_new()) != NULL) {
-        BN_mod_exp(tmp, a, exp, p, bnctx);
-        if (BN_is_word(tmp, 1))
-                symbol = 1;
-        else if (BN_is_zero(tmp))
-                symbol = 0;
-        else
-                symbol = -1;
+  if ((tmp = BN_new()) != NULL) {
+    BN_mod_exp(tmp, a, exp, p, bnctx);
+    if (BN_is_word(tmp, 1))
+      symbol = 1;
+    else if (BN_is_zero(tmp))
+      symbol = 0;
+    else
+      symbol = -1;
 
-        BN_free(tmp);
-    }
-    return symbol;
+    BN_free(tmp);
+  }
+  return symbol;
 }
 
 /*
  * assign_group_tp_peer()
  *      The group has been selected, assign it to the peer and create PWE.
  */
-static int
-assign_group_to_peer (struct candidate *peer, GD *grp)
-{
-    HMAC_CTX *ctx;
-    BIGNUM *x_candidate = NULL, *x = NULL, *rnd = NULL, *qr = NULL, *qnr = NULL;
-    BIGNUM *pm1 = NULL, *pm1d2 = NULL, *tmp1 = NULL, *tmp2 = NULL, *a = NULL, *b = NULL;
-    unsigned char pwe_digest[SHA256_DIGEST_LENGTH], addrs[ETH_ALEN * 2], ctr;
-    unsigned char *prfbuf = NULL, *primebuf = NULL;
-    int primebitlen, is_odd, check, found = 0;
+static int assign_group_to_peer(struct candidate *peer, GD *grp) {
+  HMAC_CTX *ctx;
+  BIGNUM *x_candidate = NULL, *x = NULL, *rnd = NULL, *qr = NULL, *qnr = NULL;
+  BIGNUM *pm1 = NULL, *pm1d2 = NULL, *tmp1 = NULL, *tmp2 = NULL, *a = NULL,
+         *b = NULL;
+  unsigned char pwe_digest[SHA256_DIGEST_LENGTH], addrs[ETH_ALEN * 2], ctr;
+  unsigned char *prfbuf = NULL, *primebuf = NULL;
+  int primebitlen, is_odd, check, found = 0;
+
+  /*
+   * allow for replacement of group....
+   */
+  EC_POINT_free(peer->pwe);
+  peer->pwe = NULL;
+  EC_POINT_free(peer->peer_element);
+  peer->peer_element = NULL;
+  EC_POINT_free(peer->my_element);
+  peer->my_element = NULL;
+  BN_free(peer->private_val);
+  peer->private_val = NULL;
+
+  if (((rnd = BN_new()) == NULL) || ((pm1d2 = BN_new()) == NULL) ||
+      ((pm1 = BN_new()) == NULL) || ((tmp1 = BN_new()) == NULL) ||
+      ((tmp2 = BN_new()) == NULL) || ((a = BN_new()) == NULL) ||
+      ((b = BN_new()) == NULL) || ((qr = BN_new()) == NULL) ||
+      ((qnr = BN_new()) == NULL) || ((x_candidate = BN_new()) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "can't create bignum for candidate!\n");
+    goto fail;
+  }
+  peer->grp_def = grp;
+  peer->pwe = EC_POINT_new(grp->group);
+  peer->peer_element = EC_POINT_new(grp->group);
+  peer->my_element = EC_POINT_new(grp->group);
+
+  if ((prfbuf = (unsigned char *)malloc(BN_num_bytes(grp->prime))) == NULL) {
+    sae_debug(SAE_DEBUG_ERR, "unable to malloc space for prf buffer!\n");
+    BN_free(rnd);
+    BN_free(x_candidate);
+    goto fail;
+  }
+  if ((primebuf = (unsigned char *)malloc(BN_num_bytes(grp->prime))) == NULL) {
+    sae_debug(SAE_DEBUG_ERR, "unable to malloc space for prime!\n");
+    free(prfbuf);
+    BN_free(rnd);
+    BN_free(x_candidate);
+    goto fail;
+  }
+  BN_bn2bin(grp->prime, primebuf);
+  primebitlen = BN_num_bits(grp->prime);
+
+  if (!EC_GROUP_get_curve_GFp(grp->group, NULL, a, b, NULL)) {
+    free(prfbuf);
+  }
+
+  BN_sub(pm1, grp->prime, BN_value_one());
+  BN_copy(tmp1, BN_value_one());
+  BN_add(tmp1, tmp1, BN_value_one());
+  BN_div(pm1d2, tmp2, pm1, tmp1, bnctx); /* (p-1)/2 */
+
+  /*
+   * generate a random quadratic residue modulo p and a random
+   * quadratic non-residue modulo p.
+   */
+  do {
+    BN_rand_range(qr, pm1);
+  } while (legendre(qr, grp->prime, pm1d2, bnctx) != 1);
+  do {
+    BN_rand_range(qnr, pm1);
+  } while (legendre(qnr, grp->prime, pm1d2, bnctx) != -1);
+  memset(prfbuf, 0, BN_num_bytes(grp->prime));
+
+  sae_debug(
+      SAE_DEBUG_CRYPTO,
+      "computing PWE on %d bit curve number %d\n",
+      primebitlen,
+      grp->group_num);
+  ctr = 0;
+  while (ctr < 40) {
+    ctr++;
+    /*
+     * compute counter-mode password value and stretch to prime
+     */
+    if (memcmp(peer->peer_mac, peer->my_mac, ETH_ALEN) > 0) {
+      memcpy(addrs, peer->peer_mac, ETH_ALEN);
+      memcpy(addrs + ETH_ALEN, peer->my_mac, ETH_ALEN);
+    } else {
+      memcpy(addrs, peer->my_mac, ETH_ALEN);
+      memcpy(addrs + ETH_ALEN, peer->peer_mac, ETH_ALEN);
+    }
+    ctx = HMAC_CTX_new();
+    if (ctx == NULL)
+      goto fail;
+    H_Init(ctx, addrs, (ETH_ALEN * 2));
+    H_Update(ctx, (unsigned char *)grp->password, strlen(grp->password));
+    H_Update(ctx, &ctr, sizeof(ctr));
+    H_Final(ctx, pwe_digest);
+    HMAC_CTX_free(ctx);
+    ctx = NULL;
+
+    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+      if (memcmp(peer->peer_mac, peer->my_mac, ETH_ALEN) > 0) {
+        printf(
+            "H(" MACSTR " | " MACSTR ", %s | %d)\n",
+            MAC2STR(peer->peer_mac),
+            MAC2STR(peer->my_mac),
+            grp->password,
+            ctr);
+      } else {
+        printf(
+            "H(" MACSTR " | " MACSTR ", %s | %d)\n",
+            MAC2STR(peer->my_mac),
+            MAC2STR(peer->peer_mac),
+            grp->password,
+            ctr);
+      }
+      dump_buffer(pwe_digest, SHA256_DIGEST_LENGTH);
+    }
+
+    BN_bin2bn(pwe_digest, SHA256_DIGEST_LENGTH, rnd);
+    prf(pwe_digest,
+        SHA256_DIGEST_LENGTH,
+        (unsigned char *)"SAE Hunting and Pecking",
+        strlen("SAE Hunting and Pecking"),
+        primebuf,
+        BN_num_bytes(grp->prime),
+        prfbuf,
+        primebitlen);
+    BN_bin2bn(prfbuf, BN_num_bytes(grp->prime), x_candidate);
+    /*
+     * prf() returns a string of bits 0..primebitlen, but BN_bin2bn will
+     * treat that string of bits as a big-endian number. If the primebitlen
+     * is not an even multiple of 8 we masked off the excess bits-- those
+     * _after_ primebitlen-- in prf() so now interpreting this as a
+     * big-endian number is wrong. We have to shift right the amount we
+     * masked off.
+     */
+    if (primebitlen % 8) {
+      BN_rshift(x_candidate, x_candidate, (8 - (primebitlen % 8)));
+    }
 
     /*
-     * allow for replacement of group....
+     * if this candidate value is greater than the prime then try again
      */
+    if (BN_ucmp(x_candidate, grp->prime) >= 0) {
+      continue;
+    }
+
+    if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
+      memset(prfbuf, 0, BN_num_bytes(grp->prime));
+      BN_bn2bin(
+          x_candidate,
+          prfbuf + (BN_num_bytes(grp->prime) - BN_num_bytes(x_candidate)));
+      print_buffer("candidate x value", prfbuf, BN_num_bytes(grp->prime));
+    }
+
+    /*
+     * compute y^2 using the equation of the curve
+     *
+     *      y^2 = x^3 + ax + b
+     */
+    BN_mod_sqr(tmp1, x_candidate, grp->prime, bnctx);
+    BN_mod_mul(tmp2, tmp1, x_candidate, grp->prime, bnctx);
+    BN_mod_mul(tmp1, a, x_candidate, grp->prime, bnctx);
+    BN_mod_add_quick(tmp2, tmp2, tmp1, grp->prime);
+    BN_mod_add_quick(tmp2, tmp2, b, grp->prime);
+
+    /*
+     * mask tmp2 so doing legendre won't leak timing info
+     *
+     * tmp1 is a random number between 1 and p-1
+     */
+    BN_rand_range(tmp1, pm1);
+
+    BN_mod_mul(tmp2, tmp2, tmp1, grp->prime, bnctx);
+    BN_mod_mul(tmp2, tmp2, tmp1, grp->prime, bnctx);
+    /*
+     * now tmp2 (y^2) is masked, all values between 1 and p-1
+     * are equally probable. Multiplying by r^2 does not change
+     * whether or not tmp2 is a quadratic residue, just masks it.
+     *
+     * flip a coin, multiply by the random quadratic residue or the
+     * random quadratic nonresidue and record heads or tails
+     */
+    if (BN_is_odd(tmp1)) {
+      BN_mod_mul(tmp2, tmp2, qr, grp->prime, bnctx);
+      check = 1;
+    } else {
+      BN_mod_mul(tmp2, tmp2, qnr, grp->prime, bnctx);
+      check = -1;
+    }
+
+    /*
+     * now it's safe to do legendre, if check is 1 then it's
+     * a straightforward test (multiplying by qr does not
+     * change result), if check is -1 then its the opposite test
+     * (multiplying a qr by qnr would make a qnr)
+     */
+    if (legendre(tmp2, grp->prime, pm1d2, bnctx) == check) {
+      if (found == 1) {
+        continue;
+      }
+      /*
+       * need to unambiguously identify the solution, if there is one...
+       */
+      if (BN_is_odd(rnd)) {
+        is_odd = 1;
+      } else {
+        is_odd = 0;
+      }
+      if ((x = BN_dup(x_candidate)) == NULL) {
+        goto fail;
+      }
+      sae_debug(
+          SAE_DEBUG_CRYPTO,
+          "it took %d tries to find PWE: %d\n",
+          ctr,
+          grp->group_num);
+      found = 1;
+    }
+  }
+  /*
+   * 2^-40 is about one in a trillion so we should always find a point.
+   * When we do, we know x^3 + ax + b is a quadratic residue so we can
+   * assign a point using x and our discriminator (is_odd)
+   */
+  if ((found == 0) || (!EC_POINT_set_compressed_coordinates_GFp(
+                          grp->group, peer->pwe, x, is_odd, bnctx))) {
     EC_POINT_free(peer->pwe);
     peer->pwe = NULL;
-    EC_POINT_free(peer->peer_element);
-    peer->peer_element = NULL;
-    EC_POINT_free(peer->my_element);
-    peer->my_element = NULL;
-    BN_free(peer->private_val);
-    peer->private_val = NULL;
+  }
 
-    if (((rnd = BN_new()) == NULL) ||
-        ((pm1d2 = BN_new()) == NULL) ||
-        ((pm1 = BN_new()) == NULL) ||
-        ((tmp1 = BN_new()) == NULL) ||
-        ((tmp2 = BN_new()) == NULL) ||
-        ((a = BN_new()) == NULL) ||
-        ((b = BN_new()) == NULL) ||
-        ((qr = BN_new()) == NULL) ||
-        ((qnr = BN_new()) == NULL) ||
-        ((x_candidate = BN_new()) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "can't create bignum for candidate!\n");
-        goto fail;
+  if (found && peer->pwe && (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB)) {
+    BIGNUM *px = NULL, *py = NULL;
+    if (((px = BN_new()) != NULL) && ((py = BN_new()) != NULL)) {
+      if (EC_POINT_get_affine_coordinates_GFp(
+              peer->grp_def->group, peer->pwe, px, py, bnctx)) {
+        printf("PWE (x,y):\n");
+        memset(prfbuf, 0, BN_num_bytes(grp->prime));
+        BN_bn2bin(px, prfbuf + (BN_num_bytes(grp->prime) - BN_num_bytes(px)));
+        print_buffer("x", prfbuf, BN_num_bytes(grp->prime));
+        memset(prfbuf, 0, BN_num_bytes(grp->prime));
+        BN_bn2bin(py, prfbuf + (BN_num_bytes(grp->prime) - BN_num_bytes(py)));
+        print_buffer("y", prfbuf, BN_num_bytes(grp->prime));
+      }
+      BN_free(px);
+      BN_free(py);
     }
-    peer->grp_def = grp;
-    peer->pwe = EC_POINT_new(grp->group);
-    peer->peer_element = EC_POINT_new(grp->group);
-    peer->my_element = EC_POINT_new(grp->group);
-
-    if ((prfbuf = (unsigned char *)malloc(BN_num_bytes(grp->prime))) == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "unable to malloc space for prf buffer!\n");
-        BN_free(rnd);
-        BN_free(x_candidate);
-	goto fail;
-    }
-    if ((primebuf = (unsigned char *)malloc(BN_num_bytes(grp->prime))) == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "unable to malloc space for prime!\n");
-        free(prfbuf);
-        BN_free(rnd);
-        BN_free(x_candidate);
-	goto fail;
-    }
-    BN_bn2bin(grp->prime, primebuf);
-    primebitlen = BN_num_bits(grp->prime);
-
-    if (!EC_GROUP_get_curve_GFp(grp->group, NULL, a, b, NULL)) {
-        free(prfbuf);
-    }
-
-    BN_sub(pm1, grp->prime, BN_value_one());
-    BN_copy(tmp1, BN_value_one());
-    BN_add(tmp1, tmp1, BN_value_one());
-    BN_div(pm1d2, tmp2, pm1, tmp1, bnctx);      /* (p-1)/2 */
-
-    /*
-     * generate a random quadratic residue modulo p and a random
-     * quadratic non-residue modulo p.
-     */
-    do {
-        BN_rand_range(qr, pm1);
-    } while (legendre(qr, grp->prime, pm1d2, bnctx) != 1);
-    do {
-        BN_rand_range(qnr, pm1);
-    } while (legendre(qnr, grp->prime, pm1d2, bnctx) != -1);
-    memset(prfbuf, 0, BN_num_bytes(grp->prime));
-
-    sae_debug(SAE_DEBUG_CRYPTO, "computing PWE on %d bit curve number %d\n", primebitlen, grp->group_num);
-    ctr = 0;
-    while (ctr < 40) {
-        ctr++;
-        /*
-         * compute counter-mode password value and stretch to prime
-         */
-        if (memcmp(peer->peer_mac, peer->my_mac, ETH_ALEN) > 0) {
-            memcpy(addrs, peer->peer_mac, ETH_ALEN);
-            memcpy(addrs+ETH_ALEN, peer->my_mac, ETH_ALEN);
-        } else {
-            memcpy(addrs, peer->my_mac, ETH_ALEN);
-            memcpy(addrs+ETH_ALEN, peer->peer_mac, ETH_ALEN);
-        }
-        ctx = HMAC_CTX_new();
-        if (ctx == NULL)
-            goto fail;
-        H_Init(ctx, addrs, (ETH_ALEN * 2));
-        H_Update(ctx, (unsigned char *) grp->password, strlen(grp->password));
-        H_Update(ctx, &ctr, sizeof(ctr));
-        H_Final(ctx, pwe_digest);
-        HMAC_CTX_free(ctx);
-        ctx = NULL;
-
-        if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-            if (memcmp(peer->peer_mac, peer->my_mac, ETH_ALEN) > 0) {
-                printf("H(" MACSTR " | " MACSTR ", %s | %d)\n",
-                       MAC2STR(peer->peer_mac), MAC2STR(peer->my_mac), grp->password, ctr);
-            } else {
-                printf("H(" MACSTR " | " MACSTR ", %s | %d)\n",
-                       MAC2STR(peer->my_mac), MAC2STR(peer->peer_mac), grp->password, ctr);
-            }
-            dump_buffer(pwe_digest, SHA256_DIGEST_LENGTH);
-        }
-
-        BN_bin2bn(pwe_digest, SHA256_DIGEST_LENGTH, rnd);
-        prf(pwe_digest, SHA256_DIGEST_LENGTH,
-            (unsigned char *)"SAE Hunting and Pecking", strlen("SAE Hunting and Pecking"),
-            primebuf, BN_num_bytes(grp->prime),
-            prfbuf, primebitlen);
-        BN_bin2bn(prfbuf, BN_num_bytes(grp->prime), x_candidate);
-        /*
-         * prf() returns a string of bits 0..primebitlen, but BN_bin2bn will
-         * treat that string of bits as a big-endian number. If the primebitlen
-         * is not an even multiple of 8 we masked off the excess bits-- those
-         * _after_ primebitlen-- in prf() so now interpreting this as a
-         * big-endian number is wrong. We have to shift right the amount we
-         * masked off.
-         */
-        if (primebitlen % 8) {
-            BN_rshift(x_candidate, x_candidate, (8 - (primebitlen % 8)));
-        }
-
-        /*
-         * if this candidate value is greater than the prime then try again
-         */
-        if (BN_ucmp(x_candidate, grp->prime) >= 0) {
-            continue;
-        }
-
-        if (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB) {
-            memset(prfbuf, 0, BN_num_bytes(grp->prime));
-            BN_bn2bin(x_candidate, prfbuf + (BN_num_bytes(grp->prime) - BN_num_bytes(x_candidate)));
-            print_buffer("candidate x value", prfbuf, BN_num_bytes(grp->prime));
-        }
-
-        /*
-         * compute y^2 using the equation of the curve
-         *
-         *      y^2 = x^3 + ax + b
-         */
-        BN_mod_sqr(tmp1, x_candidate, grp->prime, bnctx);
-        BN_mod_mul(tmp2, tmp1, x_candidate, grp->prime, bnctx);
-        BN_mod_mul(tmp1, a, x_candidate, grp->prime, bnctx);
-        BN_mod_add_quick(tmp2, tmp2, tmp1, grp->prime);
-        BN_mod_add_quick(tmp2, tmp2, b, grp->prime);
-
-        /*
-         * mask tmp2 so doing legendre won't leak timing info
-         *
-         * tmp1 is a random number between 1 and p-1
-         */
-        BN_rand_range(tmp1, pm1);
-
-        BN_mod_mul(tmp2, tmp2, tmp1, grp->prime, bnctx);
-        BN_mod_mul(tmp2, tmp2, tmp1, grp->prime, bnctx);
-        /*
-         * now tmp2 (y^2) is masked, all values between 1 and p-1
-         * are equally probable. Multiplying by r^2 does not change
-         * whether or not tmp2 is a quadratic residue, just masks it.
-         *
-         * flip a coin, multiply by the random quadratic residue or the
-         * random quadratic nonresidue and record heads or tails
-         */
-        if (BN_is_odd(tmp1)) {
-            BN_mod_mul(tmp2, tmp2, qr, grp->prime, bnctx);
-            check = 1;
-        } else {
-            BN_mod_mul(tmp2, tmp2, qnr, grp->prime, bnctx);
-            check = -1;
-        }
-
-        /*
-         * now it's safe to do legendre, if check is 1 then it's
-         * a straightforward test (multiplying by qr does not
-         * change result), if check is -1 then its the opposite test
-         * (multiplying a qr by qnr would make a qnr)
-         */
-        if (legendre(tmp2, grp->prime, pm1d2, bnctx) == check) {
-            if (found == 1) {
-                continue;
-            }
-            /*
-             * need to unambiguously identify the solution, if there is one...
-             */
-            if (BN_is_odd(rnd)) {
-                is_odd = 1;
-            } else {
-                is_odd = 0;
-            }
-            if ((x = BN_dup(x_candidate)) == NULL) {
-                goto fail;
-            }
-            sae_debug(SAE_DEBUG_CRYPTO, "it took %d tries to find PWE: %d\n", ctr, grp->group_num);
-            found = 1;
-        }
-    }
-    /*
-     * 2^-40 is about one in a trillion so we should always find a point.
-     * When we do, we know x^3 + ax + b is a quadratic residue so we can
-     * assign a point using x and our discriminator (is_odd)
-     */
-    if ((found == 0) ||
-        (!EC_POINT_set_compressed_coordinates_GFp(grp->group, peer->pwe, x, is_odd, bnctx))) {
-        EC_POINT_free(peer->pwe);
-        peer->pwe = NULL;
-    }
-
-    if (found && peer->pwe && (sae_debug_mask & SAE_DEBUG_CRYPTO_VERB)) {
-        BIGNUM *px = NULL, *py = NULL;
-        if (((px = BN_new()) != NULL) &&
-            ((py = BN_new()) != NULL)) {
-            if (EC_POINT_get_affine_coordinates_GFp(peer->grp_def->group, peer->pwe, px, py, bnctx)) {
-                printf("PWE (x,y):\n");
-                memset(prfbuf, 0, BN_num_bytes(grp->prime));
-                BN_bn2bin(px, prfbuf + (BN_num_bytes(grp->prime) - BN_num_bytes(px)));
-                print_buffer("x", prfbuf, BN_num_bytes(grp->prime));
-                memset(prfbuf, 0, BN_num_bytes(grp->prime));
-                BN_bn2bin(py, prfbuf + (BN_num_bytes(grp->prime) - BN_num_bytes(py)));
-                print_buffer("y", prfbuf, BN_num_bytes(grp->prime));
-            }
-            BN_free(px);
-            BN_free(py);
-        }
-    }
+  }
 
 fail:
-    if (prfbuf != NULL) {
-        free(prfbuf);
-    }
-    if (primebuf != NULL) {
-        free(primebuf);
-    }
-    if (found) {
-        BN_free(x);
-    }
+  if (prfbuf != NULL) {
+    free(prfbuf);
+  }
+  if (primebuf != NULL) {
+    free(primebuf);
+  }
+  if (found) {
+    BN_free(x);
+  }
 
-    BN_free(x_candidate);
-    BN_free(rnd);
-    BN_free(pm1d2);
-    BN_free(pm1);
-    BN_free(tmp1);
-    BN_free(tmp2);
-    BN_free(a);
-    BN_free(b);
-    BN_free(qr);
-    BN_free(qnr);
+  BN_free(x_candidate);
+  BN_free(rnd);
+  BN_free(pm1d2);
+  BN_free(pm1);
+  BN_free(tmp1);
+  BN_free(tmp2);
+  BN_free(a);
+  BN_free(b);
+  BN_free(qr);
+  BN_free(qnr);
 
-    if (peer->pwe == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "unable to find random point on curve for group %d, something's fishy!\n",
-                  grp->group_num);
-        return -1;
-    }
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "assigning group %d to peer, the size of the prime is %d\n",
-              peer->grp_def->group_num, BN_num_bytes(peer->grp_def->prime));
+  if (peer->pwe == NULL) {
+    sae_debug(
+        SAE_DEBUG_ERR,
+        "unable to find random point on curve for group %d, something's "
+        "fishy!\n",
+        grp->group_num);
+    return -1;
+  }
+  sae_debug(
+      SAE_DEBUG_PROTOCOL_MSG,
+      "assigning group %d to peer, the size of the prime is %d\n",
+      peer->grp_def->group_num,
+      BN_num_bytes(peer->grp_def->prime));
 
-    return 0;
+  return 0;
 }
 
-static void
-retransmit_peer (void *data)
-{
-    struct candidate *peer;
+static void retransmit_peer(void *data) {
+  struct candidate *peer;
 
-    peer = (struct candidate *)data;
-    sae_debug(SAE_DEBUG_STATE_MACHINE, "timer %llu fired! retrans = %d, incrementing\n", peer->t0, peer->sync);
-    if (peer->sync > giveup_threshold) {
-        sae_debug(SAE_DEBUG_STATE_MACHINE, "peer not listening!\n");
-        if (peer->state == SAE_COMMITTED) {
-            /*
-             * if the peer never responded then put it on the blacklist for a while
-             */
-            sae_debug(SAE_DEBUG_STATE_MACHINE, MACSTR " never responded, adding to blacklist\n", MAC2STR(peer->peer_mac));
-            blacklist_peer(peer);
-        }
-        cb->fin(WLAN_STATUS_AUTHENTICATION_TIMEOUT, peer->peer_mac, NULL, 0, peer->cookie);
-        delete_peer(&peer);
-        return;
+  peer = (struct candidate *)data;
+  sae_debug(
+      SAE_DEBUG_STATE_MACHINE,
+      "timer %llu fired! retrans = %d, incrementing\n",
+      peer->t0,
+      peer->sync);
+  if (peer->sync > giveup_threshold) {
+    sae_debug(SAE_DEBUG_STATE_MACHINE, "peer not listening!\n");
+    if (peer->state == SAE_COMMITTED) {
+      /*
+       * if the peer never responded then put it on the blacklist for a while
+       */
+      sae_debug(
+          SAE_DEBUG_STATE_MACHINE,
+          MACSTR " never responded, adding to blacklist\n",
+          MAC2STR(peer->peer_mac));
+      blacklist_peer(peer);
     }
-    peer->sync++;
-    switch (peer->state) {
-        case SAE_COMMITTED:
-            commit_to_peer(peer, NULL, 0);
-            peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-            break;
-        case SAE_CONFIRMED:
-            confirm_to_peer(peer);
-            peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-            break;
-        default:
-            sae_debug(SAE_DEBUG_STATE_MACHINE, "timer fired and not committed or confirmed!\n");
-            break;
-    }
+    cb->fin(
+        WLAN_STATUS_AUTHENTICATION_TIMEOUT,
+        peer->peer_mac,
+        NULL,
+        0,
+        peer->cookie);
+    delete_peer(&peer);
+    return;
+  }
+  peer->sync++;
+  switch (peer->state) {
+    case SAE_COMMITTED:
+      commit_to_peer(peer, NULL, 0);
+      peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+      break;
+    case SAE_CONFIRMED:
+      confirm_to_peer(peer);
+      peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+      break;
+    default:
+      sae_debug(
+          SAE_DEBUG_STATE_MACHINE,
+          "timer fired and not committed or confirmed!\n");
+      break;
+  }
 }
 
-struct candidate *
-create_candidate (unsigned char *her_mac, unsigned char *my_mac, unsigned short got_token, void *cookie)
-{
-    struct candidate *peer;
+struct candidate *create_candidate(
+    unsigned char *her_mac,
+    unsigned char *my_mac,
+    unsigned short got_token,
+    void *cookie) {
+  struct candidate *peer;
 
-    if ((peer = (struct candidate *)malloc(sizeof(struct candidate))) == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "can't malloc space for candidate!\n");
-        return NULL;
-    }
-    memset(peer, 0, sizeof(*peer));
-    memcpy(peer->my_mac, my_mac, ETH_ALEN);
-    memcpy(peer->peer_mac, her_mac, ETH_ALEN);
-    if (((peer->peer_scalar = BN_new()) == NULL) ||
-        ((peer->my_scalar = BN_new()) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "can't create peer data structures!\n");
-        free(peer);
-        return NULL;
-    }
-    peer->got_token = got_token;
-    peer->failed_auth = peer->beacons = peer->state = peer->sync = peer->sc = peer->rc = 0;
-    peer->private_val = NULL;
-    peer->pwe = peer->peer_element = peer->my_element = NULL;
-    TAILQ_INSERT_TAIL(&peers, peer, entry);
-    peer->state = SAE_NOTHING;
-    peer->cookie = cookie;
-    peer->association_id = aid_alloc();
-    curr_open++;
+  if ((peer = (struct candidate *)malloc(sizeof(struct candidate))) == NULL) {
+    sae_debug(SAE_DEBUG_ERR, "can't malloc space for candidate!\n");
+    return NULL;
+  }
+  memset(peer, 0, sizeof(*peer));
+  memcpy(peer->my_mac, my_mac, ETH_ALEN);
+  memcpy(peer->peer_mac, her_mac, ETH_ALEN);
+  if (((peer->peer_scalar = BN_new()) == NULL) ||
+      ((peer->my_scalar = BN_new()) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "can't create peer data structures!\n");
+    free(peer);
+    return NULL;
+  }
+  peer->got_token = got_token;
+  peer->failed_auth = peer->beacons = peer->state = peer->sync = peer->sc =
+      peer->rc = 0;
+  peer->private_val = NULL;
+  peer->pwe = peer->peer_element = peer->my_element = NULL;
+  TAILQ_INSERT_TAIL(&peers, peer, entry);
+  peer->state = SAE_NOTHING;
+  peer->cookie = cookie;
+  peer->association_id = aid_alloc();
+  curr_open++;
 
-    cb->peer_created(her_mac);
+  cb->peer_created(her_mac);
 
-    return peer;
+  return peer;
 }
 
 // This is used to verify that the invariants for candidate peers are preserved,
 // namely that there are no more than two candidates for a peer and if there are
 // two candidates then one is accepted and one is not.
-static int
-validate_peers (unsigned char *mac)
-{
-    const int MaxPeers = 10;
-    struct candidate *peer;
-    struct candidate *candidates[MaxPeers];
-    int i, count = 0;
+static int validate_peers(unsigned char *mac) {
+  const int MaxPeers = 10;
+  struct candidate *peer;
+  struct candidate *candidates[MaxPeers];
+  int i, count = 0;
 
-    TAILQ_FOREACH(peer, &peers, entry) {
-        if (memcmp(peer->peer_mac, mac, ETH_ALEN) == 0)
-            if (count < MaxPeers)               // pointless to report problems with candidates after MaxPeers
-                candidates[count++] = peer;
-    }
+  TAILQ_FOREACH(peer, &peers, entry) {
+    if (memcmp(peer->peer_mac, mac, ETH_ALEN) == 0)
+      if (count < MaxPeers) // pointless to report problems with candidates
+                            // after MaxPeers
+        candidates[count++] = peer;
+  }
 
-    if (count > 2) {
-        sae_debug(SAE_DEBUG_STATE_MACHINE, "found %d candidates for peer " MACSTR "!!!\n", count, MAC2STR(mac));
-        for (i = 0; i < count; ++i)
-            peer = candidates[i];
-    } else if (count == 2) {
-        if ((candidates[0]->state == SAE_ACCEPTED && candidates[1]->state == SAE_ACCEPTED) ||
-            (candidates[0]->state != SAE_ACCEPTED && candidates[1]->state != SAE_ACCEPTED))
-            sae_debug(SAE_DEBUG_STATE_MACHINE, "peer " MACSTR " should have one and only one accepted candidate!!!\n", MAC2STR(mac));
-    }
+  if (count > 2) {
+    sae_debug(
+        SAE_DEBUG_STATE_MACHINE,
+        "found %d candidates for peer " MACSTR "!!!\n",
+        count,
+        MAC2STR(mac));
+    for (i = 0; i < count; ++i)
+      peer = candidates[i];
+  } else if (count == 2) {
+    if ((candidates[0]->state == SAE_ACCEPTED &&
+         candidates[1]->state == SAE_ACCEPTED) ||
+        (candidates[0]->state != SAE_ACCEPTED &&
+         candidates[1]->state != SAE_ACCEPTED))
+      sae_debug(
+          SAE_DEBUG_STATE_MACHINE,
+          "peer " MACSTR
+          " should have one and only one accepted candidate!!!\n",
+          MAC2STR(mac));
+  }
 
-    return count;
+  return count;
 }
 
-static bool
-reauth_in_progress (struct candidate *peer)
-{
-    if (peer->state == SAE_COMMITTED || peer->state == SAE_CONFIRMED)
-        return true;
+static bool reauth_in_progress(struct candidate *peer) {
+  if (peer->state == SAE_COMMITTED || peer->state == SAE_CONFIRMED)
+    return true;
 
-    else if (peer->link_state == PLINK_OPN_SNT ||
-        peer->link_state == PLINK_OPN_RCVD ||
-        peer->link_state == PLINK_CNF_RCVD)
-        return true;
+  else if (
+      peer->link_state == PLINK_OPN_SNT || peer->link_state == PLINK_OPN_RCVD ||
+      peer->link_state == PLINK_CNF_RCVD)
+    return true;
 
-    return false;
+  return false;
 }
 
-void
-do_reauth (struct candidate *peer)
-{
-    struct candidate *newpeer;
-    int count = validate_peers(peer->peer_mac);
+void do_reauth(struct candidate *peer) {
+  struct candidate *newpeer;
+  int count = validate_peers(peer->peer_mac);
 
-    if (!reauth_in_progress(peer) && count == 1) {
-        if ((newpeer = create_candidate(peer->peer_mac, peer->my_mac, 0, peer->cookie)) != NULL) {
-            if (assign_group_to_peer(newpeer, gd) < 0) {
-                delete_peer(&newpeer);
+  if (!reauth_in_progress(peer) && count == 1) {
+    if ((newpeer = create_candidate(
+             peer->peer_mac, peer->my_mac, 0, peer->cookie)) != NULL) {
+      if (assign_group_to_peer(newpeer, gd) < 0) {
+        delete_peer(&newpeer);
+      } else {
+        commit_to_peer(newpeer, NULL, 0);
+        newpeer->t0 =
+            cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, newpeer);
+        newpeer->state = SAE_COMMITTED;
+      }
+    }
+    /*
+     * make a hard deletion of this guy in case the reauth fails and we
+     * don't end up deleting this instance
+     */
+    peer->t2 = cb->evl->add_timeout(SRV_SEC(5), destroy_peer, peer);
+
+  } else {
+    if (peer->t1)
+      cb->evl->rem_timeout(peer->t1);
+    peer->t1 = cb->evl->add_timeout_with_jitter(
+        SRV_SEC(pmk_expiry), reauth, peer, SRV_SEC(REAUTH_JITTER));
+  }
+}
+
+static void reauth(void *data) {
+  struct candidate *peer = (struct candidate *)data;
+  do_reauth(peer);
+}
+
+static enum result process_authentication_frame(
+    struct candidate *peer,
+    struct ieee80211_mgmt_frame *frame,
+    int len) {
+  unsigned short grp;
+  unsigned short seq = ieee_order(frame->authenticate.auth_seq);
+  unsigned short status = ieee_order(frame->authenticate.status);
+  GD *group_def;
+  struct candidate *delme;
+  enum result ret;
+
+  sae_debug(
+      SAE_DEBUG_PROTOCOL_MSG,
+      "recv'd %s from " MACSTR " while in %s\n",
+      seq_to_string(seq),
+      MAC2STR(frame->sa),
+      state_to_string(peer->state));
+
+  cb->evl->rem_timeout(peer->t0);
+  peer->t0 = 0;
+  /*
+   * implement the state machine for SAE
+   */
+  switch (peer->state) {
+    case SAE_NOTHING:
+      switch (seq) {
+        case SAE_AUTH_COMMIT:
+          /*
+           * if the status is anything other than 0 then throw this away
+           * since as far as we're concerned this is unsolicited and there's
+           * no error we committed.
+           */
+          if (status != 0) {
+            return ERR_FATAL;
+          }
+          /*
+           * grab the group from the frame...
+           */
+          grp = ieee_order(*((frame->authenticate.u.var16)));
+          /*
+           * ...and see if it's supported
+           */
+          group_def = gd;
+          while (group_def) {
+            if (grp == group_def->group_num) {
+              if (assign_group_to_peer(peer, group_def) < 0) {
+                return ERR_FATAL;
+              }
+              break;
+            }
+            group_def = group_def->next;
+          }
+          if (group_def == NULL) {
+            /*
+             * send a rejection to the peer and a "del" event to the parent
+             */
+            sae_debug(
+                SAE_DEBUG_STATE_MACHINE,
+                "group %d not supported, reject.\n",
+                grp);
+            reject_to_peer(peer, frame);
+            return ERR_FATAL;
+          }
+          sae_debug(
+              SAE_DEBUG_STATE_MACHINE,
+              "COMMIT received for unknown peer " MACSTR
+              ", committing and confirming\n",
+              MAC2STR(peer->peer_mac));
+          peer->sc = peer->rc = 0;
+          commit_to_peer(peer, NULL, 0);
+          if (process_commit(peer, frame, len) < 0) {
+            return ERR_FATAL;
+          }
+          /*
+           * send both a commit and a confirm and transition into confirmed
+           */
+          confirm_to_peer(peer);
+          peer->sync = 0;
+          peer->t0 =
+              cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+          peer->state = SAE_CONFIRMED;
+          break;
+        case SAE_AUTH_CONFIRM:
+          return ERR_FATAL;
+        default:
+          sae_debug(
+              SAE_DEBUG_ERR,
+              "unknown SAE frame (%d) from " MACSTR "\n",
+              seq,
+              MAC2STR(peer->peer_mac));
+          return ERR_NOT_FATAL;
+      }
+      break;
+    case SAE_COMMITTED:
+      switch (seq) {
+        case SAE_AUTH_COMMIT:
+          /*
+           * if it's an anti-clogging token request, send another
+           * commit with the token.
+           *
+           * Increment the sync counter, the spec doesn't say so but this
+           * guards against bad implementations.
+           */
+          if (status == WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED) {
+            sae_debug(
+                SAE_DEBUG_STATE_MACHINE,
+                "received a token request, add a token, length %zu, and resend "
+                "commit\n",
+                (len - (IEEE802_11_HDR_LEN + sizeof(frame->authenticate))));
+            commit_to_peer(
+                peer,
+                frame->authenticate.u.var8,
+                (len - (IEEE802_11_HDR_LEN + sizeof(frame->authenticate))));
+            peer->sync = 0;
+            peer->t0 =
+                cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+            break;
+          }
+          /*
+           * grab the group from the frame, we need it later
+           */
+          grp = ieee_order(*((frame->authenticate.u.var16)));
+          if (status == WLAN_STATUS_NOT_SUPPORTED_GROUP) {
+            /*
+             * if it's a rejection check whether it's what we sent.
+             * If so try another configured group.
+             */
+            if (grp == peer->grp_def->group_num) {
+              /*
+               * if there's no more configured groups to offer then just declare
+               * failure,
+               * blacklist the client since we cannot currently communicate.
+               */
+              if (peer->grp_def->next == NULL) {
+                return ERR_BLACKLIST;
+              }
+              /*
+               * otherwise assign the next group and send another commit
+               */
+              group_def = peer->grp_def->next;
+              sae_debug(
+                  SAE_DEBUG_STATE_MACHINE,
+                  "peer rejected %d, try group %d instead...\n",
+                  peer->grp_def->group_num,
+                  group_def->group_num);
+              assign_group_to_peer(peer, group_def);
+              commit_to_peer(peer, NULL, 0);
+              peer->sync = 0;
             } else {
-                commit_to_peer(newpeer, NULL, 0);
-                newpeer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, newpeer);
-                newpeer->state = SAE_COMMITTED;
+              sae_debug(
+                  SAE_DEBUG_STATE_MACHINE,
+                  "peer is rejecting something (%d) not offered, must be old, "
+                  "ignore...\n",
+                  grp);
             }
-        }
-        /*
-         * make a hard deletion of this guy in case the reauth fails and we
-         * don't end up deleting this instance
-         */
-        peer->t2 = cb->evl->add_timeout(SRV_SEC(5), destroy_peer, peer);
-
-    } else {
-        if (peer->t1)
-            cb->evl->rem_timeout(peer->t1);
-        peer->t1 = cb->evl->add_timeout_with_jitter(SRV_SEC(pmk_expiry), reauth, peer, SRV_SEC(REAUTH_JITTER));
-    }
-}
-
-static void
-reauth (void *data)
-{
-    struct candidate *peer = (struct candidate *)data;
-    do_reauth(peer);
-}
-
-static enum result
-process_authentication_frame (struct candidate *peer, struct ieee80211_mgmt_frame *frame, int len)
-{
-    unsigned short grp;
-    unsigned short seq = ieee_order(frame->authenticate.auth_seq);
-    unsigned short status = ieee_order(frame->authenticate.status);
-    GD *group_def;
-    struct candidate *delme;
-    enum result ret;
-
-    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "recv'd %s from " MACSTR " while in %s\n",
-              seq_to_string(seq), MAC2STR(frame->sa),
-              state_to_string(peer->state));
-
-    cb->evl->rem_timeout(peer->t0);
-    peer->t0 = 0;
-    /*
-     * implement the state machine for SAE
-     */
-    switch (peer->state) {
-        case SAE_NOTHING:
-            switch (seq) {
-                case SAE_AUTH_COMMIT:
-                    /*
-                     * if the status is anything other than 0 then throw this away
-                     * since as far as we're concerned this is unsolicited and there's
-                     * no error we committed.
-                     */
-                    if (status != 0) {
-                        return ERR_FATAL;
-                    }
-                    /*
-                     * grab the group from the frame...
-                     */
-                    grp = ieee_order(*((frame->authenticate.u.var16)));
-                    /*
-                     * ...and see if it's supported
-                     */
-                    group_def = gd;
-                    while (group_def) {
-                        if (grp == group_def->group_num) {
-                            if (assign_group_to_peer(peer, group_def) < 0) {
-                                return ERR_FATAL;
-                            }
-                            break;
-                        }
-                        group_def = group_def->next;
-                    }
-                    if (group_def == NULL) {
-                        /*
-                         * send a rejection to the peer and a "del" event to the parent
-                         */
-                        sae_debug(SAE_DEBUG_STATE_MACHINE, "group %d not supported, reject.\n", grp);
-                        reject_to_peer(peer, frame);
-                        return ERR_FATAL;
-                    }
-                    sae_debug(SAE_DEBUG_STATE_MACHINE, "COMMIT received for unknown peer " MACSTR ", committing and confirming\n",
-                    MAC2STR(peer->peer_mac));
-                    peer->sc = peer->rc = 0;
-                    commit_to_peer(peer, NULL, 0);
-                    if (process_commit(peer, frame, len) < 0) {
-                        return ERR_FATAL;
-                    }
-                    /*
-                     * send both a commit and a confirm and transition into confirmed
-                     */
-                    confirm_to_peer(peer);
-                    peer->sync = 0;
-                    peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                    peer->state = SAE_CONFIRMED;
-                    break;
-                case SAE_AUTH_CONFIRM:
-                    return ERR_FATAL;
-                default:
-                    sae_debug(SAE_DEBUG_ERR, "unknown SAE frame (%d) from " MACSTR "\n",
-                           seq, MAC2STR(peer->peer_mac));
-                    return ERR_NOT_FATAL;
-            }
+            peer->t0 =
+                cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
             break;
-        case SAE_COMMITTED:
-            switch (seq) {
-                case SAE_AUTH_COMMIT:
-                    /*
-                     * if it's an anti-clogging token request, send another
-                     * commit with the token.
-                     *
-                     * Increment the sync counter, the spec doesn't say so but this
-                     * guards against bad implementations.
-                     */
-                    if (status == WLAN_STATUS_ANTI_CLOGGING_TOKEN_NEEDED) {
-                        sae_debug(SAE_DEBUG_STATE_MACHINE,
-                                  "received a token request, add a token, length %zu, and resend commit\n",
-                                  (len - (IEEE802_11_HDR_LEN + sizeof(frame->authenticate))));
-                        commit_to_peer(peer, frame->authenticate.u.var8,
-                                       (len - (IEEE802_11_HDR_LEN + sizeof(frame->authenticate))));
-                        peer->sync = 0;
-                        peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                        break;
-                    }
-                    /*
-                     * grab the group from the frame, we need it later
-                     */
-                    grp = ieee_order(*((frame->authenticate.u.var16)));
-                    if (status == WLAN_STATUS_NOT_SUPPORTED_GROUP) {
-                        /*
-                         * if it's a rejection check whether it's what we sent.
-                         * If so try another configured group.
-                         */
-                        if (grp == peer->grp_def->group_num) {
-                            /*
-                             * if there's no more configured groups to offer then just declare failure,
-                             * blacklist the client since we cannot currently communicate.
-                             */
-                            if (peer->grp_def->next == NULL) {
-                                return ERR_BLACKLIST;
-                            }
-                            /*
-                             * otherwise assign the next group and send another commit
-                             */
-                            group_def = peer->grp_def->next;
-                            sae_debug(SAE_DEBUG_STATE_MACHINE, "peer rejected %d, try group %d instead...\n",
-                                      peer->grp_def->group_num, group_def->group_num);
-                            assign_group_to_peer(peer, group_def);
-                            commit_to_peer(peer, NULL, 0);
-                            peer->sync = 0;
-                        } else {
-                            sae_debug(SAE_DEBUG_STATE_MACHINE,
-                                      "peer is rejecting something (%d) not offered, must be old, ignore...\n", grp);
-                        }
-                        peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                        break;
-                    }
-                    /*
-                     * silently drop any other failure
-                     */
-                    if (status != 0) {
-                        peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                        break;
-                    }
-                    /*
-                     * if the group offered is not the same as what we offered
-                     * that means the commit messages crossed in the ether. Check
-                     * whether this is something we can support and if so tie break.
-                     */
-                    if (grp != peer->grp_def->group_num) {
-                        group_def = gd;
-                        while (group_def) {
-                            if (grp == group_def->group_num) {
-                                break;
-                            }
-                            group_def = group_def->next;
-                        }
-                        /*
-                         * nope, not supported, send rejection
-                         */
-                        if (group_def == NULL) {
-                            if (peer->sync > giveup_threshold) {
-                                return ERR_FATAL;
-                            }
-                            sae_debug(SAE_DEBUG_STATE_MACHINE, "group %d not supported, send rejection\n", grp);
-                            peer->sync++;
-                            reject_to_peer(peer, frame);
-                            peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                            break;
-                        }
-                        /*
-                         * OK, this is not what we offered but it's aceptable...
-                         */
-                        if (memcmp(peer->my_mac, peer->peer_mac, ETH_ALEN) > 0) {
-                            sae_debug(SAE_DEBUG_STATE_MACHINE,
-                                      "offered group %d, got %d in return, numerically greater, maintain.\n",
-                                      peer->grp_def->group_num, grp);
-
-                            /*
-                             * the numerically greater MAC address retransmits
-                             */
-                            commit_to_peer(peer, NULL, 0);
-                            peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                            break;
-                        } else {
-                            sae_debug(SAE_DEBUG_STATE_MACHINE,
-                                      "offered group %d, got %d in return, numerically lesser, submit.\n",
-                                      peer->grp_def->group_num, grp);
-                            /*
-                             * the numerically lesser converts, send a commit with
-                             * this group and then just proceed with the acceptable
-                             * commit
-                             */
-                            peer->sync = 0;
-                            assign_group_to_peer(peer, group_def);
-                            commit_to_peer(peer, NULL, 0);
-                            if (process_commit(peer, frame, len) < 0) {
-                                return ERR_FATAL;
-                            }
-                        }
-                    } else {
-                        /*
-                         * else it's the group we offered, check for a reflection attack,
-                         * and if not then process the frame
-                         */
-                        if (check_dup(peer, 1, frame, len) == 0) {
-                            return NO_ERR;      /* silently discard */
-                        }
-                        if (process_commit(peer, frame, len) < 0) {
-                            return ERR_FATAL;
-                        }
-                    }
-                    confirm_to_peer(peer);
-                    peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                    peer->state = SAE_CONFIRMED;
-                    break;
-                case SAE_AUTH_CONFIRM:
-                    sae_debug(SAE_DEBUG_STATE_MACHINE, "got CONFIRM before COMMIT, try again\n");
-                    if (peer->sync > giveup_threshold) {
-                        return ERR_FATAL;
-                    }
-                    peer->sync++;
-                    commit_to_peer(peer, NULL, 0);
-                    peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                    break;
-                default:
-                    sae_debug(SAE_DEBUG_ERR, "unknown SAE frame (%d) from " MACSTR "\n",
-                              seq, MAC2STR(peer->peer_mac));
-                    return ERR_NOT_FATAL;
-            }
+          }
+          /*
+           * silently drop any other failure
+           */
+          if (status != 0) {
+            peer->t0 =
+                cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
             break;
-        case SAE_CONFIRMED:
-            if (status != 0) {
-                /*
-                 * silently discard, but since we cancelled the timer above, reset it
-                 */
-                peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+          }
+          /*
+           * if the group offered is not the same as what we offered
+           * that means the commit messages crossed in the ether. Check
+           * whether this is something we can support and if so tie break.
+           */
+          if (grp != peer->grp_def->group_num) {
+            group_def = gd;
+            while (group_def) {
+              if (grp == group_def->group_num) {
                 break;
+              }
+              group_def = group_def->next;
             }
-            switch (seq) {
-                case SAE_AUTH_COMMIT:
-                    if (peer->sync > giveup_threshold) {
-                        return ERR_FATAL;
-                    }
-                    grp = ieee_order(*(frame->authenticate.u.var16));
-                    if (grp == peer->grp_def->group_num) {
-                        sae_debug(SAE_DEBUG_STATE_MACHINE, "got COMMIT again, try to resync\n");
-                        peer->sync++;
-                        commit_to_peer(peer, NULL, 0);
-                        confirm_to_peer(peer);
-                    }
-                    peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                    break;
-                case SAE_AUTH_CONFIRM:
-                    ret = process_confirm(peer, frame, len);
-                    switch (ret) {
-                        case ERR_FATAL:
-                        case ERR_BLACKLIST:
-                            sae_debug(SAE_DEBUG_STATE_MACHINE, "Delete event received from protocol instance for " MACSTR "\n",
-                                      MAC2STR(peer->peer_mac));
-                            return ret;
-                        case ERR_NOT_FATAL:                   /* this is not in 11s draft */
-                            peer->sync++;
-                            confirm_to_peer(peer);
-                            return NO_ERR;
-                        case NO_ERR:
-                            break;
-                    }
-                    curr_open--;
-                    peer->sc = COUNTER_INFINITY;
-                    if ((delme = find_peer(peer->peer_mac, 1)) != NULL) {
-                        sae_debug(SAE_DEBUG_STATE_MACHINE,
-                                  "peer " MACSTR " in %s has just ACCEPTED, found another in %s, deleting\n",
-                                  MAC2STR(peer->peer_mac),
-                                  state_to_string(peer->state), state_to_string(delme->state));
-                        delete_peer(&delme);
-                    }
-                    /*
-                     * print out the PMK if we have debugging on for that
-                     */
-                    if (peer->state != SAE_ACCEPTED) {
-                        if (sae_debug_mask & SAE_DEBUG_CRYPTO) {
-                            print_buffer("PMK", peer->pmk, SHA256_DIGEST_LENGTH);
-                        }
-                        cb->fin(WLAN_STATUS_SUCCESSFUL, peer->peer_mac, peer->pmk, SHA256_DIGEST_LENGTH, peer->cookie);
-                    }
-                    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "setting reauth timer for %lu seconds\n", pmk_expiry);
-                    if (peer->t1)
-                        cb->evl->rem_timeout(peer->t1);
-                    peer->t1 = cb->evl->add_timeout_with_jitter(SRV_SEC(pmk_expiry), reauth, peer, SRV_SEC(REAUTH_JITTER));
-                    peer->state = SAE_ACCEPTED;
-                    break;
-                default:
-                    sae_debug(SAE_DEBUG_ERR, "unknown SAE frame (%d) from " MACSTR "\n",
-                              seq, MAC2STR(peer->peer_mac));
-                    return ERR_NOT_FATAL;
+            /*
+             * nope, not supported, send rejection
+             */
+            if (group_def == NULL) {
+              if (peer->sync > giveup_threshold) {
+                return ERR_FATAL;
+              }
+              sae_debug(
+                  SAE_DEBUG_STATE_MACHINE,
+                  "group %d not supported, send rejection\n",
+                  grp);
+              peer->sync++;
+              reject_to_peer(peer, frame);
+              peer->t0 =
+                  cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+              break;
             }
-            break;
-        case SAE_ACCEPTED:
-            switch (seq) {
-                case SAE_AUTH_COMMIT:
-                    /*
-                     * something stinks in state machine land...
-                     */
-                    sae_debug(SAE_DEBUG_STATE_MACHINE, "got a COMMIT from " MACSTR " when already ACCEPTED, deleting to start over\n",
-                              MAC2STR(peer->peer_mac));
-                    return ERR_FATAL;
-                    break;
-                case SAE_AUTH_CONFIRM:
-                    if (peer->sync > giveup_threshold) {
-                        sae_debug(SAE_DEBUG_STATE_MACHINE, "too many syncronization errors on " MACSTR ", deleting\n",
-                                  MAC2STR(peer->peer_mac));
-                        return ERR_FATAL;
-                    }
-                    /*
-                     * must've lost our confirm, check if it's old or invalid,
-                     * if neither send confirm again....
-                     */
-                    if (check_confirm(peer, frame) &&
-                        (process_confirm(peer, frame, len) >= 0)) {
-                        sae_debug(SAE_DEBUG_STATE_MACHINE, "peer " MACSTR " resending CONFIRM...\n",
-                        MAC2STR(peer->peer_mac));
-                        peer->sync++;
-                        confirm_to_peer(peer);
-                    }
-                    break;
-                default:
-                    sae_debug(SAE_DEBUG_ERR, "unknown SAE frame (%d) from " MACSTR "\n",
-                              seq, MAC2STR(peer->peer_mac));
-                    return ERR_NOT_FATAL;
+            /*
+             * OK, this is not what we offered but it's aceptable...
+             */
+            if (memcmp(peer->my_mac, peer->peer_mac, ETH_ALEN) > 0) {
+              sae_debug(
+                  SAE_DEBUG_STATE_MACHINE,
+                  "offered group %d, got %d in return, numerically greater, "
+                  "maintain.\n",
+                  peer->grp_def->group_num,
+                  grp);
+
+              /*
+               * the numerically greater MAC address retransmits
+               */
+              commit_to_peer(peer, NULL, 0);
+              peer->t0 =
+                  cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+              break;
+            } else {
+              sae_debug(
+                  SAE_DEBUG_STATE_MACHINE,
+                  "offered group %d, got %d in return, numerically lesser, "
+                  "submit.\n",
+                  peer->grp_def->group_num,
+                  grp);
+              /*
+               * the numerically lesser converts, send a commit with
+               * this group and then just proceed with the acceptable
+               * commit
+               */
+              peer->sync = 0;
+              assign_group_to_peer(peer, group_def);
+              commit_to_peer(peer, NULL, 0);
+              if (process_commit(peer, frame, len) < 0) {
+                return ERR_FATAL;
+              }
             }
-            break;
-    }
-    sae_debug(SAE_DEBUG_STATE_MACHINE, "state of " MACSTR " is now (%d) %s\n\n",
-              MAC2STR(peer->peer_mac), peer->state, state_to_string(peer->state));
-    return NO_ERR;
+          } else {
+            /*
+             * else it's the group we offered, check for a reflection attack,
+             * and if not then process the frame
+             */
+            if (check_dup(peer, 1, frame, len) == 0) {
+              return NO_ERR; /* silently discard */
+            }
+            if (process_commit(peer, frame, len) < 0) {
+              return ERR_FATAL;
+            }
+          }
+          confirm_to_peer(peer);
+          peer->t0 =
+              cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+          peer->state = SAE_CONFIRMED;
+          break;
+        case SAE_AUTH_CONFIRM:
+          sae_debug(
+              SAE_DEBUG_STATE_MACHINE,
+              "got CONFIRM before COMMIT, try again\n");
+          if (peer->sync > giveup_threshold) {
+            return ERR_FATAL;
+          }
+          peer->sync++;
+          commit_to_peer(peer, NULL, 0);
+          peer->t0 =
+              cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+          break;
+        default:
+          sae_debug(
+              SAE_DEBUG_ERR,
+              "unknown SAE frame (%d) from " MACSTR "\n",
+              seq,
+              MAC2STR(peer->peer_mac));
+          return ERR_NOT_FATAL;
+      }
+      break;
+    case SAE_CONFIRMED:
+      if (status != 0) {
+        /*
+         * silently discard, but since we cancelled the timer above, reset it
+         */
+        peer->t0 =
+            cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+        break;
+      }
+      switch (seq) {
+        case SAE_AUTH_COMMIT:
+          if (peer->sync > giveup_threshold) {
+            return ERR_FATAL;
+          }
+          grp = ieee_order(*(frame->authenticate.u.var16));
+          if (grp == peer->grp_def->group_num) {
+            sae_debug(
+                SAE_DEBUG_STATE_MACHINE, "got COMMIT again, try to resync\n");
+            peer->sync++;
+            commit_to_peer(peer, NULL, 0);
+            confirm_to_peer(peer);
+          }
+          peer->t0 =
+              cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+          break;
+        case SAE_AUTH_CONFIRM:
+          ret = process_confirm(peer, frame, len);
+          switch (ret) {
+            case ERR_FATAL:
+            case ERR_BLACKLIST:
+              sae_debug(
+                  SAE_DEBUG_STATE_MACHINE,
+                  "Delete event received from protocol instance for " MACSTR
+                  "\n",
+                  MAC2STR(peer->peer_mac));
+              return ret;
+            case ERR_NOT_FATAL: /* this is not in 11s draft */
+              peer->sync++;
+              confirm_to_peer(peer);
+              return NO_ERR;
+            case NO_ERR:
+              break;
+          }
+          curr_open--;
+          peer->sc = COUNTER_INFINITY;
+          if ((delme = find_peer(peer->peer_mac, 1)) != NULL) {
+            sae_debug(
+                SAE_DEBUG_STATE_MACHINE,
+                "peer " MACSTR
+                " in %s has just ACCEPTED, found another in %s, deleting\n",
+                MAC2STR(peer->peer_mac),
+                state_to_string(peer->state),
+                state_to_string(delme->state));
+            delete_peer(&delme);
+          }
+          /*
+           * print out the PMK if we have debugging on for that
+           */
+          if (peer->state != SAE_ACCEPTED) {
+            if (sae_debug_mask & SAE_DEBUG_CRYPTO) {
+              print_buffer("PMK", peer->pmk, SHA256_DIGEST_LENGTH);
+            }
+            cb->fin(
+                WLAN_STATUS_SUCCESSFUL,
+                peer->peer_mac,
+                peer->pmk,
+                SHA256_DIGEST_LENGTH,
+                peer->cookie);
+          }
+          sae_debug(
+              SAE_DEBUG_PROTOCOL_MSG,
+              "setting reauth timer for %lu seconds\n",
+              pmk_expiry);
+          if (peer->t1)
+            cb->evl->rem_timeout(peer->t1);
+          peer->t1 = cb->evl->add_timeout_with_jitter(
+              SRV_SEC(pmk_expiry), reauth, peer, SRV_SEC(REAUTH_JITTER));
+          peer->state = SAE_ACCEPTED;
+          break;
+        default:
+          sae_debug(
+              SAE_DEBUG_ERR,
+              "unknown SAE frame (%d) from " MACSTR "\n",
+              seq,
+              MAC2STR(peer->peer_mac));
+          return ERR_NOT_FATAL;
+      }
+      break;
+    case SAE_ACCEPTED:
+      switch (seq) {
+        case SAE_AUTH_COMMIT:
+          /*
+           * something stinks in state machine land...
+           */
+          sae_debug(
+              SAE_DEBUG_STATE_MACHINE,
+              "got a COMMIT from " MACSTR
+              " when already ACCEPTED, deleting to start over\n",
+              MAC2STR(peer->peer_mac));
+          return ERR_FATAL;
+          break;
+        case SAE_AUTH_CONFIRM:
+          if (peer->sync > giveup_threshold) {
+            sae_debug(
+                SAE_DEBUG_STATE_MACHINE,
+                "too many syncronization errors on " MACSTR ", deleting\n",
+                MAC2STR(peer->peer_mac));
+            return ERR_FATAL;
+          }
+          /*
+           * must've lost our confirm, check if it's old or invalid,
+           * if neither send confirm again....
+           */
+          if (check_confirm(peer, frame) &&
+              (process_confirm(peer, frame, len) >= 0)) {
+            sae_debug(
+                SAE_DEBUG_STATE_MACHINE,
+                "peer " MACSTR " resending CONFIRM...\n",
+                MAC2STR(peer->peer_mac));
+            peer->sync++;
+            confirm_to_peer(peer);
+          }
+          break;
+        default:
+          sae_debug(
+              SAE_DEBUG_ERR,
+              "unknown SAE frame (%d) from " MACSTR "\n",
+              seq,
+              MAC2STR(peer->peer_mac));
+          return ERR_NOT_FATAL;
+      }
+      break;
+  }
+  sae_debug(
+      SAE_DEBUG_STATE_MACHINE,
+      "state of " MACSTR " is now (%d) %s\n\n",
+      MAC2STR(peer->peer_mac),
+      peer->state,
+      state_to_string(peer->state));
+  return NO_ERR;
 }
 
 static int
-have_token (struct ieee80211_mgmt_frame *frame, int len, unsigned char *me)
-{
-    unsigned short seq = ieee_order(frame->authenticate.auth_seq);
-    unsigned short alg;
-    unsigned char token[SHA256_DIGEST_LENGTH];
-    HMAC_CTX *ctx;
-    GD *group_def;
-    ctx = HMAC_CTX_new();
-    if (ctx == NULL) {
-        fprintf(stderr, "Failed to allocate HMAC context\n");
-        return -1;
-    }
+have_token(struct ieee80211_mgmt_frame *frame, int len, unsigned char *me) {
+  unsigned short seq = ieee_order(frame->authenticate.auth_seq);
+  unsigned short alg;
+  unsigned char token[SHA256_DIGEST_LENGTH];
+  HMAC_CTX *ctx;
+  GD *group_def;
+  ctx = HMAC_CTX_new();
+  if (ctx == NULL) {
+    fprintf(stderr, "Failed to allocate HMAC context\n");
+    return -1;
+  }
 
-    /*
-     * if it's not a commit then by definition there's no token: bad
-     */
-    if (seq != SAE_AUTH_COMMIT) {
-        sae_debug(SAE_DEBUG_PROTOCOL_MSG, "checking for token but not a commit!\n");
-        return -1;
-    }
+  /*
+   * if it's not a commit then by definition there's no token: bad
+   */
+  if (seq != SAE_AUTH_COMMIT) {
+    sae_debug(SAE_DEBUG_PROTOCOL_MSG, "checking for token but not a commit!\n");
+    return -1;
+  }
 
-    /*
-     * it's a commmit so the first thing is the finite cyclic group
-     */
-    alg = ieee_order(*(frame->authenticate.u.var16));
+  /*
+   * it's a commmit so the first thing is the finite cyclic group
+   */
+  alg = ieee_order(*(frame->authenticate.u.var16));
 
-    group_def = gd;
-    while (group_def) {
-        if (alg == group_def->group_num) {
-            break;
-        }
-        group_def = group_def->next;
+  group_def = gd;
+  while (group_def) {
+    if (alg == group_def->group_num) {
+      break;
     }
-    if (group_def == NULL) {
-        /*
-         * if the group isn't supported then there's no way we can truely
-         * evaluate this frame, just check whether our token is there. If the
-         * group isn't supported then at least we'll tell the peer of that fact
-         * later and maybe we can come to some resolution after a few more exchanges.
-         */
-        if (len < (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) + sizeof(unsigned short) + SHA256_DIGEST_LENGTH)) {
-            sae_debug(SAE_DEBUG_PROTOCOL_MSG, "checking for token but there can't be one, too short!\n");
-            /*
-             * no token, ask for one
-             */
-            return 1;
-        }
-        H_Init(ctx, (unsigned char *)&token_generator, sizeof(unsigned long));
-        H_Update(ctx, frame->sa, ETH_ALEN);
-        H_Update(ctx, me, ETH_ALEN);
-        H_Final(ctx, token);
-        HMAC_CTX_free(ctx);
-        ctx = NULL;
-        if (memcmp(token, (frame->authenticate.u.var8 + sizeof(unsigned short)), SHA256_DIGEST_LENGTH)) {
-            /*
-             * there's something there but it's not a token, so ask for one.
-             *
-             * should we maybe return -1 to silently drop this frame? Hmmm...
-             */
-             return 1;
-        }
-    } else {
-        /*
-         * The length should be the size of an authenticate frame (minus all the optional
-         * fields and IEs) plus the size of the finite cyclic group field (unsigned short)
-         * plus the size of the tokens we generate (SHA256_DIGEST_LEN) plus the size of
-         * the order of the selected group plus twice the size of the prime of the selected
-         * group (x-coordinate and y-coordinate, each the length of the prime).
-         *
-         * NB: if/when FFC groups are supported it won't be plus twice the prime, it'll just be
-         * plus the length of the prime (an FFC element is not complex like an ECC element is).
-         */
-        if (len != (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) + sizeof(unsigned short) +
-                    SHA256_DIGEST_LENGTH + BN_num_bytes(group_def->order) +
-                    (2 * BN_num_bytes(group_def->prime)))) {
-            sae_debug(SAE_DEBUG_PROTOCOL_MSG,
-                      "checking for token in offer of group %d but length is wrong: %d vs. %zu\n",
-                      group_def->group_num, len,
-                      (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) + sizeof(unsigned short) +
-                       SHA256_DIGEST_LENGTH + BN_num_bytes(group_def->order) +
-                       (2 * BN_num_bytes(group_def->prime))));
-            return 1;
-        }
-        H_Init(ctx, (unsigned char *)&token_generator, sizeof(unsigned long));
-        H_Update(ctx, frame->sa, ETH_ALEN);
-        H_Update(ctx, me, ETH_ALEN);
-        H_Final(ctx, token);
-        HMAC_CTX_free(ctx);
-        ctx = NULL;
-        if (memcmp(token, (frame->authenticate.u.var8 + sizeof(unsigned short)), SHA256_DIGEST_LENGTH)) {
-            /*
-             * bad token
-             */
-             return -1;
-        }
-    }
+    group_def = group_def->next;
+  }
+  if (group_def == NULL) {
     /*
-     * found a token and it's good
+     * if the group isn't supported then there's no way we can truely
+     * evaluate this frame, just check whether our token is there. If the
+     * group isn't supported then at least we'll tell the peer of that fact
+     * later and maybe we can come to some resolution after a few more
+     * exchanges.
      */
-    return 0;
+    if (len < (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
+               sizeof(unsigned short) + SHA256_DIGEST_LENGTH)) {
+      sae_debug(
+          SAE_DEBUG_PROTOCOL_MSG,
+          "checking for token but there can't be one, too short!\n");
+      /*
+       * no token, ask for one
+       */
+      return 1;
+    }
+    H_Init(ctx, (unsigned char *)&token_generator, sizeof(unsigned long));
+    H_Update(ctx, frame->sa, ETH_ALEN);
+    H_Update(ctx, me, ETH_ALEN);
+    H_Final(ctx, token);
+    HMAC_CTX_free(ctx);
+    ctx = NULL;
+    if (memcmp(
+            token,
+            (frame->authenticate.u.var8 + sizeof(unsigned short)),
+            SHA256_DIGEST_LENGTH)) {
+      /*
+       * there's something there but it's not a token, so ask for one.
+       *
+       * should we maybe return -1 to silently drop this frame? Hmmm...
+       */
+      return 1;
+    }
+  } else {
+    /*
+     * The length should be the size of an authenticate frame (minus all the
+     * optional
+     * fields and IEs) plus the size of the finite cyclic group field (unsigned
+     * short)
+     * plus the size of the tokens we generate (SHA256_DIGEST_LEN) plus the size
+     * of
+     * the order of the selected group plus twice the size of the prime of the
+     * selected
+     * group (x-coordinate and y-coordinate, each the length of the prime).
+     *
+     * NB: if/when FFC groups are supported it won't be plus twice the prime,
+     * it'll just be
+     * plus the length of the prime (an FFC element is not complex like an ECC
+     * element is).
+     */
+    if (len != (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
+                sizeof(unsigned short) + SHA256_DIGEST_LENGTH +
+                BN_num_bytes(group_def->order) +
+                (2 * BN_num_bytes(group_def->prime)))) {
+      sae_debug(
+          SAE_DEBUG_PROTOCOL_MSG,
+          "checking for token in offer of group %d but length is wrong: %d vs. "
+          "%zu\n",
+          group_def->group_num,
+          len,
+          (IEEE802_11_HDR_LEN + sizeof(frame->authenticate) +
+           sizeof(unsigned short) + SHA256_DIGEST_LENGTH +
+           BN_num_bytes(group_def->order) +
+           (2 * BN_num_bytes(group_def->prime))));
+      return 1;
+    }
+    H_Init(ctx, (unsigned char *)&token_generator, sizeof(unsigned long));
+    H_Update(ctx, frame->sa, ETH_ALEN);
+    H_Update(ctx, me, ETH_ALEN);
+    H_Final(ctx, token);
+    HMAC_CTX_free(ctx);
+    ctx = NULL;
+    if (memcmp(
+            token,
+            (frame->authenticate.u.var8 + sizeof(unsigned short)),
+            SHA256_DIGEST_LENGTH)) {
+      /*
+       * bad token
+       */
+      return -1;
+    }
+  }
+  /*
+   * found a token and it's good
+   */
+  return 0;
 }
 
 /*
  * the "parent process" gets management frames as input and dispatches to
  * "protocol instances".
  */
-int
-process_mgmt_frame (struct ieee80211_mgmt_frame *frame, int len, unsigned char *me, void *cookie, bool skip_sae)
-{
-    unsigned short frame_control, type, auth_alg;
-    int need_token;
-    struct candidate *peer;
-    enum result ret = ERR_FATAL;
+int process_mgmt_frame(
+    struct ieee80211_mgmt_frame *frame,
+    int len,
+    unsigned char *me,
+    void *cookie,
+    bool skip_sae) {
+  unsigned short frame_control, type, auth_alg;
+  int need_token;
+  struct candidate *peer;
+  enum result ret = ERR_FATAL;
 
-    if (bnctx == NULL) {
-        /*
-         * sae_initialize() has not been called yet!
-         */
-        fprintf(stderr, "sae_initialize() must be called first!\n");
-        return -1;
-    }
-    frame_control = ieee_order(frame->frame_control);
-    type = IEEE802_11_FC_GET_TYPE(frame_control);
-    if (type != IEEE802_11_FC_TYPE_MGMT) {
-        /*
-         * we should only get management frames
-         */
-        return -1;
-    }
+  if (bnctx == NULL) {
     /*
-     * process the management frame
+     * sae_initialize() has not been called yet!
      */
-    switch (IEEE802_11_FC_GET_STYPE(frame_control)) {
+    fprintf(stderr, "sae_initialize() must be called first!\n");
+    return -1;
+  }
+  frame_control = ieee_order(frame->frame_control);
+  type = IEEE802_11_FC_GET_TYPE(frame_control);
+  if (type != IEEE802_11_FC_TYPE_MGMT) {
+    /*
+     * we should only get management frames
+     */
+    return -1;
+  }
+  /*
+   * process the management frame
+   */
+  switch (IEEE802_11_FC_GET_STYPE(frame_control)) {
+    /*
+     * a beacon sort of like an "Initiate" event
+     */
+    case IEEE802_11_FC_STYPE_BEACON:
+      /*
+       * ignore blacklisted peers
+       */
+      if (on_blacklist(frame->sa)) {
+        break;
+      }
+      if ((peer = find_peer(frame->sa, 0)) != NULL) {
         /*
-         * a beacon sort of like an "Initiate" event
+         * we're already dealing with this guy, ignore his beacons now
          */
-        case IEEE802_11_FC_STYPE_BEACON:
+        peer->beacons++;
+      } else if (skip_sae) {
+        sae_debug(
+            SAE_DEBUG_PROTOCOL_MSG,
+            "received a beacon from " MACSTR "\n",
+            MAC2STR(frame->sa));
+        sae_debug(SAE_DEBUG_STATE_MACHINE, "Initiate event\n");
+        if ((peer = create_candidate(frame->sa, me, 0, cookie)) == NULL) {
+          return -1;
+        }
+        peer->cookie = cookie;
+        cb->fin(
+            WLAN_STATUS_SUCCESSFUL,
+            peer->peer_mac,
+            peer->pmk,
+            SHA256_DIGEST_LENGTH,
+            peer->cookie);
+      } else {
+        /*
+         * This is actually not part of the parent state machine but handling
+         * it here makes the rest of the protocol instance state machine nicer.
+         *
+         * a new mesh point! auth_req transitions from state "NOTHING" to
+         * "COMMITTED"
+         */
+        sae_debug(
+            SAE_DEBUG_PROTOCOL_MSG,
+            "received a beacon from " MACSTR "\n",
+            MAC2STR(frame->sa));
+        sae_debug(SAE_DEBUG_STATE_MACHINE, "Initiate event\n");
+        if ((peer = create_candidate(frame->sa, me, 0, cookie)) == NULL) {
+          return -1;
+        }
+        peer->cookie = cookie;
+        /*
+         * assign the first group in the list as the one to try
+         */
+        if (assign_group_to_peer(peer, gd) < 0) {
+          cb->fin(
+              WLAN_STATUS_UNSPECIFIED_FAILURE,
+              peer->peer_mac,
+              NULL,
+              0,
+              peer->cookie);
+          delete_peer(&peer);
+        } else {
+          commit_to_peer(peer, NULL, 0);
+          peer->t0 =
+              cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
+          peer->state = SAE_COMMITTED;
+          sae_debug(
+              SAE_DEBUG_STATE_MACHINE,
+              "state of " MACSTR " is now (%d) %s\n\n",
+              MAC2STR(peer->peer_mac),
+              peer->state,
+              state_to_string(peer->state));
+        }
+        break;
+      }
+      break;
+    case IEEE802_11_FC_STYPE_AUTH:
+      auth_alg = ieee_order(frame->authenticate.alg);
+      if (auth_alg != SAE_AUTH_ALG) {
+        sae_debug(
+            SAE_DEBUG_PROTOCOL_MSG,
+            "let kernel handle authenticate (%d) frame from " MACSTR
+            " to " MACSTR "\n",
+            auth_alg,
+            MAC2STR(frame->sa),
+            MAC2STR(frame->da));
+        break;
+      }
+      peer = find_peer(frame->sa, 0);
+      switch (ieee_order(frame->authenticate.auth_seq)) {
+        case SAE_AUTH_COMMIT:
+          if ((peer != NULL) && (peer->state != SAE_ACCEPTED)) {
+            ret = process_authentication_frame(peer, frame, len);
+          } else {
             /*
-             * ignore blacklisted peers
+             * check if this is the same scalar that was sent when we
+             * accepted.
              */
-            if (on_blacklist(frame->sa)) {
-                break;
+            if ((peer != NULL) && (peer->state == SAE_ACCEPTED)) {
+              if (check_dup(peer, 0, frame, len) == 0) {
+                return 0;
+              }
             }
-            if ((peer = find_peer(frame->sa, 0)) != NULL) {
+            /*
+             * if we are currently in a token-demanding state then check for a
+             * token
+             */
+            if (!(curr_open < open_threshold)) {
+              need_token = have_token(frame, len, me);
+              if (need_token < 0) {
                 /*
-                 * we're already dealing with this guy, ignore his beacons now
+                 * silently drop nonsense frames
                  */
-                peer->beacons++;
-            } else if (skip_sae) {
-                sae_debug(SAE_DEBUG_PROTOCOL_MSG, "received a beacon from " MACSTR "\n", MAC2STR(frame->sa));
-                sae_debug(SAE_DEBUG_STATE_MACHINE, "Initiate event\n");
-                if ((peer = create_candidate(frame->sa, me, 0, cookie)) == NULL) {
-                    return -1;
-                }
-                peer->cookie = cookie;
-                cb->fin(WLAN_STATUS_SUCCESSFUL, peer->peer_mac, peer->pmk, SHA256_DIGEST_LENGTH, peer->cookie);
-            } else {
+                return 0;
+              } else if (need_token > 0) {
                 /*
-                 * This is actually not part of the parent state machine but handling
-                 * it here makes the rest of the protocol instance state machine nicer.
-                 *
-                 * a new mesh point! auth_req transitions from state "NOTHING" to "COMMITTED"
+                 * request a token if the frame should have one but didn't
                  */
-                sae_debug(SAE_DEBUG_PROTOCOL_MSG, "received a beacon from " MACSTR "\n", MAC2STR(frame->sa));
-                sae_debug(SAE_DEBUG_STATE_MACHINE, "Initiate event\n");
-                if ((peer = create_candidate(frame->sa, me, 0, cookie)) == NULL) {
-                    return -1;
-                }
-                peer->cookie = cookie;
-                /*
-                 * assign the first group in the list as the one to try
-                 */
-                if (assign_group_to_peer(peer, gd) < 0) {
-                    cb->fin(WLAN_STATUS_UNSPECIFIED_FAILURE, peer->peer_mac, NULL, 0, peer->cookie);
-                    delete_peer(&peer);
-                } else {
-                    commit_to_peer(peer, NULL, 0);
-                    peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
-                    peer->state = SAE_COMMITTED;
-                    sae_debug(SAE_DEBUG_STATE_MACHINE, "state of " MACSTR " is now (%d) %s\n\n",
-                              MAC2STR(peer->peer_mac), peer->state, state_to_string(peer->state));
-                }
-                break;
+                sae_debug(
+                    SAE_DEBUG_STATE_MACHINE,
+                    "token needed for COMMIT (%d open), requesting one\n",
+                    curr_open);
+                request_token(frame, me, cookie);
+                return 0;
+              } else {
+                sae_debug(SAE_DEBUG_STATE_MACHINE, "correct token received\n");
+              }
             }
-            break;
-        case IEEE802_11_FC_STYPE_AUTH:
-            auth_alg = ieee_order(frame->authenticate.alg);
-            if (auth_alg != SAE_AUTH_ALG) {
-                sae_debug(SAE_DEBUG_PROTOCOL_MSG,
-                          "let kernel handle authenticate (%d) frame from " MACSTR " to " MACSTR "\n",
-                          auth_alg, MAC2STR(frame->sa), MAC2STR(frame->da));
-                break;
+            /*
+             * if we got here that means we're not demanding tokens or we are
+             * and the token was correct. In either case we create a protocol
+             * instance.
+             */
+            if ((peer = create_candidate(
+                     frame->sa, me, (curr_open >= open_threshold), cookie)) ==
+                NULL) {
+              sae_debug(
+                  SAE_DEBUG_ERR,
+                  "can't malloc space for candidate from " MACSTR "\n",
+                  MAC2STR(frame->sa));
+              return -1;
             }
-            peer = find_peer(frame->sa, 0);
-            switch (ieee_order(frame->authenticate.auth_seq)) {
-                case SAE_AUTH_COMMIT:
-                    if ((peer != NULL) && (peer->state != SAE_ACCEPTED)) {
-                        ret = process_authentication_frame(peer, frame, len);
-                    } else {
-                        /*
-                         * check if this is the same scalar that was sent when we
-                         * accepted.
-                         */
-                        if ((peer != NULL) && (peer->state == SAE_ACCEPTED)) {
-                            if (check_dup(peer, 0, frame, len) == 0) {
-                                return 0;
-                            }
-                        }
-                        /*
-                         * if we are currently in a token-demanding state then check for a token
-                         */
-                        if (!(curr_open < open_threshold)) {
-                            need_token = have_token(frame, len, me);
-                            if (need_token < 0) {
-                                /*
-                                 * silently drop nonsense frames
-                                 */
-                                return 0;
-                            } else if (need_token > 0) {
-                                /*
-                                 * request a token if the frame should have one but didn't
-                                 */
-                                sae_debug(SAE_DEBUG_STATE_MACHINE, "token needed for COMMIT (%d open), requesting one\n",
-                                          curr_open);
-                                request_token(frame, me, cookie);
-                                return 0;
-                            } else {
-                                sae_debug(SAE_DEBUG_STATE_MACHINE, "correct token received\n");
-                            }
-                        }
-                        /*
-                         * if we got here that means we're not demanding tokens or we are
-                         * and the token was correct. In either case we create a protocol instance.
-                         */
-                        if ((peer = create_candidate(frame->sa, me, (curr_open >= open_threshold), cookie)) == NULL) {
-                            sae_debug(SAE_DEBUG_ERR, "can't malloc space for candidate from " MACSTR "\n",
-                                      MAC2STR(frame->sa));
-                            return -1;
-                        }
-                        ret = process_authentication_frame(peer, frame, len);
-                    }
-                    break;
-                case SAE_AUTH_CONFIRM:
-                    if (peer == NULL) {
-                        /*
-                         * no peer instance, no way to handle this frame!
-                         */
-                        return 0;
-                    }
-                    /*
-                     * since we searched above with "0" the peer we've handled the case
-                     * of two peers in the db with one in ACCEPTED state already.
-                     */
-                    ret = process_authentication_frame(peer, frame, len);
-                    break;
-            }
-            switch (ret) {
-                case ERR_BLACKLIST:
-                    /*
-                     * a "del" event
-                     */
-                    blacklist_peer(peer);
-                    cb->fin(WLAN_STATUS_UNSPECIFIED_FAILURE, peer->peer_mac, NULL, 0, peer->cookie);
-                    /* no break / fall-through intentional */
-                case ERR_FATAL:
-                    /*
-                     * a "fail" event, it could be argued that fin() should be done
-                     * here but there are a certain class of failures-- group rejection
-                     * for instance-- that don't really need fin() notification because
-                     * the protocol might recover and successfully finish later.
-                     */
-                    delete_peer(&peer);
-                    return 0;
-                case ERR_NOT_FATAL:
-                    /*
-                     * This isn't in the 11s draft but when there is some internal error from
-                     * an API call it's not really a protocol error. These things can (should?)
-                     * be handled with a "fail" event but let's try and be a little more accomodating.
-                     *
-                     * if we get a non-fatal error return to NOTHING but don't delete yet, this way we
-                     * won't try to authenticate her again when we see a beacon but will respond to an
-                     * initiation from her later.
-                     */
-                    peer->failed_auth++;
-                    peer->sync = peer->sc = peer->rc = 0;
-                    peer->state = SAE_NOTHING;
-                    break;
-                case NO_ERR:
-                    break;
-            }
-            if (peer->sync > giveup_threshold) {
-                /*
-                 * if the state machines are so out-of-whack just declare failure
-                 */
-                sae_debug(SAE_DEBUG_STATE_MACHINE,
-                          "too many state machine syncronization errors, adding " MACSTR " to blacklist\n",
-                          MAC2STR(peer->peer_mac));
-                blacklist_peer(peer);
-                cb->fin(WLAN_STATUS_REQUEST_DECLINED, peer->peer_mac, NULL, 0, peer->cookie);
-                delete_peer(&peer);
-            }
-            break;
-        case IEEE802_11_FC_STYPE_ACTION:
-            return process_ampe_frame(frame, len, me, cookie);
-        default:
-            return -1;
-    }
+            ret = process_authentication_frame(peer, frame, len);
+          }
+          break;
+        case SAE_AUTH_CONFIRM:
+          if (peer == NULL) {
+            /*
+             * no peer instance, no way to handle this frame!
+             */
+            return 0;
+          }
+          /*
+           * since we searched above with "0" the peer we've handled the case
+           * of two peers in the db with one in ACCEPTED state already.
+           */
+          ret = process_authentication_frame(peer, frame, len);
+          break;
+      }
+      switch (ret) {
+        case ERR_BLACKLIST:
+          /*
+           * a "del" event
+           */
+          blacklist_peer(peer);
+          cb->fin(
+              WLAN_STATUS_UNSPECIFIED_FAILURE,
+              peer->peer_mac,
+              NULL,
+              0,
+              peer->cookie);
+        /* no break / fall-through intentional */
+        case ERR_FATAL:
+          /*
+           * a "fail" event, it could be argued that fin() should be done
+           * here but there are a certain class of failures-- group rejection
+           * for instance-- that don't really need fin() notification because
+           * the protocol might recover and successfully finish later.
+           */
+          delete_peer(&peer);
+          return 0;
+        case ERR_NOT_FATAL:
+          /*
+           * This isn't in the 11s draft but when there is some internal error
+           * from
+           * an API call it's not really a protocol error. These things can
+           * (should?)
+           * be handled with a "fail" event but let's try and be a little more
+           * accomodating.
+           *
+           * if we get a non-fatal error return to NOTHING but don't delete yet,
+           * this way we
+           * won't try to authenticate her again when we see a beacon but will
+           * respond to an
+           * initiation from her later.
+           */
+          peer->failed_auth++;
+          peer->sync = peer->sc = peer->rc = 0;
+          peer->state = SAE_NOTHING;
+          break;
+        case NO_ERR:
+          break;
+      }
+      if (peer->sync > giveup_threshold) {
+        /*
+         * if the state machines are so out-of-whack just declare failure
+         */
+        sae_debug(
+            SAE_DEBUG_STATE_MACHINE,
+            "too many state machine syncronization errors, adding " MACSTR
+            " to blacklist\n",
+            MAC2STR(peer->peer_mac));
+        blacklist_peer(peer);
+        cb->fin(
+            WLAN_STATUS_REQUEST_DECLINED,
+            peer->peer_mac,
+            NULL,
+            0,
+            peer->cookie);
+        delete_peer(&peer);
+      }
+      break;
+    case IEEE802_11_FC_STYPE_ACTION:
+      return process_ampe_frame(frame, len, me, cookie);
+    default:
+      return -1;
+  }
 
-    return 0;
+  return 0;
 }
 
 static int
-compute_group_definition (GD *grp, char *password, unsigned short num)
-{
-    BIGNUM *cofactor = NULL;
-    int nid, ret = 0;
+compute_group_definition(GD *grp, char *password, unsigned short num) {
+  BIGNUM *cofactor = NULL;
+  int nid, ret = 0;
 
-    switch (num) {        /* from IANA registry for IKE D-H groups */
-        case 19:
-            nid = NID_X9_62_prime256v1;
-            break;
-        case 20:
-            nid = NID_secp384r1;
-            break;
-        case 21:
-            nid = NID_secp521r1;
-            break;
-        case 25:
-            nid = NID_X9_62_prime192v1;
-            break;
-        case 26:
-            nid = NID_secp224r1;
-            break;
-        default:
-            sae_debug(SAE_DEBUG_ERR, "unsupported group %d\n", num);
-            return -1;
-    }
-    if ((grp->group = EC_GROUP_new_by_curve_name(nid)) == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "unable to create EC_GROUP!\n");
-        return -1;
-    }
-    cofactor = NULL; grp->order = NULL; grp->prime = NULL;
+  switch (num) { /* from IANA registry for IKE D-H groups */
+    case 19:
+      nid = NID_X9_62_prime256v1;
+      break;
+    case 20:
+      nid = NID_secp384r1;
+      break;
+    case 21:
+      nid = NID_secp521r1;
+      break;
+    case 25:
+      nid = NID_X9_62_prime192v1;
+      break;
+    case 26:
+      nid = NID_secp224r1;
+      break;
+    default:
+      sae_debug(SAE_DEBUG_ERR, "unsupported group %d\n", num);
+      return -1;
+  }
+  if ((grp->group = EC_GROUP_new_by_curve_name(nid)) == NULL) {
+    sae_debug(SAE_DEBUG_ERR, "unable to create EC_GROUP!\n");
+    return -1;
+  }
+  cofactor = NULL;
+  grp->order = NULL;
+  grp->prime = NULL;
 
-    if (((cofactor = BN_new()) == NULL) ||
-        ((grp->order = BN_new()) == NULL) ||
-        ((grp->prime = BN_new()) == NULL)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to create bignums!\n");
-        goto fail;
-    }
-    if (!EC_GROUP_get_curve_GFp(grp->group, grp->prime, NULL, NULL, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get prime for GFp curve!\n");
-        goto fail;
-    }
-    if (!EC_GROUP_get_order(grp->group, grp->order, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get order for curve!\n");
-        goto fail;
-    }
-    if (!EC_GROUP_get_cofactor(grp->group, cofactor, bnctx)) {
-        sae_debug(SAE_DEBUG_ERR, "unable to get cofactor for curve!\n");
-        goto fail;
-    }
-    if (BN_cmp(cofactor, BN_value_one())) {
-        /*
-         * no curves with a co-factor > 1 are allowed. Technically they will work
-         * but the special handling of them to deal with a small sub-group attack
-         * when compared to how many of them are in this IANA registry (as of writing
-         * this that number is zero) makes it better to just not support them.
-         */
-        sae_debug(SAE_DEBUG_ERR, "attempting to use a curve with a co-factor > 1!\n");
-        goto fail;
-    }
-    grp->group_num = num;
-    strncpy(grp->password, password, sizeof(grp->password));
-
-    if (0) {
-fail:
-        BN_free(grp->order);
-        BN_free(grp->prime);
-        ret = -1;
-    }
-    BN_free(cofactor);
-
-    return ret;
-}
-
-int
-sae_parse_config (char *confdir, struct sae_config* config)
-{
-    int i;
-    FILE *fp;
-    char buf[80], *ptr;
-    int ret;
-
-    if (config == NULL)
-        return -1;
-
-    memset(config, 0, sizeof(*config));
-    snprintf(conffile, sizeof(conffile), "%s/sae.conf", confdir);
-    if ((fp = fopen(conffile, "r")) == NULL) {
-        sae_debug(SAE_DEBUG_ERR, "cannot open configuration file, %s!\n", conffile);
-        return -1;
-    }
-    while (!feof(fp)) {
-        if (fgets(buf, sizeof(buf), fp) == 0) {
-            continue;
-        }
-        if ((ret = parse_buffer(buf, &ptr)) < 0) {
-            break;
-        }
-        if (ret == 0) {
-            continue;
-        }
-        if (strncmp(buf, "group", strlen("group")) == 0) {
-            i = 0;
-            do {
-                config->group[i++] = atoi(ptr);
-                ptr = strstr(ptr, " ");
-                if (ptr == NULL)
-                    break;
-                if (*ptr != '\n')
-                    ptr++;
-            } while (*ptr != '\n');
-            config->num_groups = i;
-        } else if (strncmp(buf, "password", strlen("password")) == 0) {
-            strcpy(config->pwd, ptr);
-        } else if (strncmp(buf, "debug", strlen("debug")) == 0) {
-            config->debug = atoi(ptr);
-        } else if (strncmp(buf, "retrans", strlen("retrans")) == 0) {
-            config->retrans = atoi(ptr);
-        } else if (strncmp(buf, "lifetime", strlen("lifetime")) == 0) {
-            config->pmk_expiry = atoi(ptr);
-        } else if (strncmp(buf, "thresh", strlen("thresh")) == 0) {
-            config->open_threshold = atoi(ptr);
-        } else if (strncmp(buf, "blacklist", strlen("blacklist")) == 0) {
-            config->blacklist_timeout = atoi(ptr);
-        } else if (strncmp(buf, "giveup", strlen("giveup")) == 0) {
-            config->giveup_threshold = atoi(ptr);
-        }
-    }
-    fclose(fp);
-    return 0;
-}
-
-void
-sae_dump_db (int unused)
-{
-    struct candidate *peer;
-
-    fprintf(stderr, "SAE:\n");
-    TAILQ_FOREACH(peer, &peers, entry) {
-        fprintf(stderr, "\t" MACSTR " in state %s\n", MAC2STR(peer->peer_mac), state_to_string(peer->state));
-    }
-}
-
-static bool check_callbacks(struct sae_cb *callbacks)
-{
-    bool valid = callbacks != NULL;
-    valid = valid && callbacks->meshd_write_mgmt != NULL;
-    valid = valid && callbacks->peer_created != NULL;
-    valid = valid && callbacks->fin != NULL;
-    return valid;
-}
-
-int
-sae_initialize (char *ourssid, struct sae_config *config, struct sae_cb *callbacks)
-{
-    GD *curr, *prev = NULL;
-    int i;
-
-    if (!check_callbacks(callbacks))
-        return -1;
-
-    cb = callbacks;
-
-    /* TODO: detect duplicate calls.  validate config. */
-
-    EVP_add_digest(EVP_sha256());
-    if ((out = BIO_new(BIO_s_file())) == NULL) {
-        fprintf(stderr, "SAE: unable to create file BIO!\n");
-        return -1;
-    }
-    BIO_set_fp(out, stderr, BIO_NOCLOSE);
-
+  if (((cofactor = BN_new()) == NULL) || ((grp->order = BN_new()) == NULL) ||
+      ((grp->prime = BN_new()) == NULL)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to create bignums!\n");
+    goto fail;
+  }
+  if (!EC_GROUP_get_curve_GFp(grp->group, grp->prime, NULL, NULL, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get prime for GFp curve!\n");
+    goto fail;
+  }
+  if (!EC_GROUP_get_order(grp->group, grp->order, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get order for curve!\n");
+    goto fail;
+  }
+  if (!EC_GROUP_get_cofactor(grp->group, cofactor, bnctx)) {
+    sae_debug(SAE_DEBUG_ERR, "unable to get cofactor for curve!\n");
+    goto fail;
+  }
+  if (BN_cmp(cofactor, BN_value_one())) {
     /*
-     * initialize globals
+     * no curves with a co-factor > 1 are allowed. Technically they will work
+     * but the special handling of them to deal with a small sub-group attack
+     * when compared to how many of them are in this IANA registry (as of
+     * writing
+     * this that number is zero) makes it better to just not support them.
      */
-    memset(allzero, 0, SHA256_DIGEST_LENGTH);
-    TAILQ_INIT(&peers);
-    TAILQ_INIT(&blacklist);
-    i = RAND_bytes((unsigned char *)&token_generator, sizeof(unsigned long));
-    if (i == 0) {
-        fprintf(stderr, "failed to generate random token!\n");
-        return -1;
+    sae_debug(
+        SAE_DEBUG_ERR, "attempting to use a curve with a co-factor > 1!\n");
+    goto fail;
+  }
+  grp->group_num = num;
+  strncpy(grp->password, password, sizeof(grp->password));
+
+  if (0) {
+  fail:
+    BN_free(grp->order);
+    BN_free(grp->prime);
+    ret = -1;
+  }
+  BN_free(cofactor);
+
+  return ret;
+}
+
+int sae_parse_config(char *confdir, struct sae_config *config) {
+  int i;
+  FILE *fp;
+  char buf[80], *ptr;
+  int ret;
+
+  if (config == NULL)
+    return -1;
+
+  memset(config, 0, sizeof(*config));
+  snprintf(conffile, sizeof(conffile), "%s/sae.conf", confdir);
+  if ((fp = fopen(conffile, "r")) == NULL) {
+    sae_debug(SAE_DEBUG_ERR, "cannot open configuration file, %s!\n", conffile);
+    return -1;
+  }
+  while (!feof(fp)) {
+    if (fgets(buf, sizeof(buf), fp) == 0) {
+      continue;
     }
-    if ((bnctx = BN_CTX_new()) == NULL) {
-        fprintf(stderr, "cannot create bignum context!\n");
-        return -1;
+    if ((ret = parse_buffer(buf, &ptr)) < 0) {
+      break;
     }
-    /*
-     * set defaults and read in config
-     */
-    sae_debug_mask = config->debug;
-    curr_open = 0;
-    open_threshold = config->open_threshold ? config->open_threshold : 5;
-    blacklist_timeout = config->blacklist_timeout ? config->blacklist_timeout
-        : 30;
-    giveup_threshold = config->giveup_threshold ? config->giveup_threshold :
-        5;
-    retrans = config->retrans ? config->retrans : 3;
-    pmk_expiry = config->pmk_expiry ? config->pmk_expiry : 86400; /* one day */
-    /*
-     * create groups from configuration data
-     */
-    for (i=0; i<config->num_groups; i++) {
-        if ((curr = (GD *)malloc(sizeof(GD))) == NULL) {
-            sae_debug(SAE_DEBUG_ERR, "cannot malloc group definition!\n");
-            return -1;
-        }
-        if (compute_group_definition(curr, config->pwd, config->group[i])) {
-            free(curr);
-            continue;
-        }
-        if (prev)
-            prev->next = curr;
-        else
-            gd = curr;
-        prev = curr;
-        curr->next = NULL;
-        sae_debug(SAE_DEBUG_STATE_MACHINE, "group %d is configured, prime is %d"
-                " bytes\n", curr->group_num, BN_num_bytes(curr->prime));
+    if (ret == 0) {
+      continue;
     }
-    return 1;
+    if (strncmp(buf, "group", strlen("group")) == 0) {
+      i = 0;
+      do {
+        config->group[i++] = atoi(ptr);
+        ptr = strstr(ptr, " ");
+        if (ptr == NULL)
+          break;
+        if (*ptr != '\n')
+          ptr++;
+      } while (*ptr != '\n');
+      config->num_groups = i;
+    } else if (strncmp(buf, "password", strlen("password")) == 0) {
+      strcpy(config->pwd, ptr);
+    } else if (strncmp(buf, "debug", strlen("debug")) == 0) {
+      config->debug = atoi(ptr);
+    } else if (strncmp(buf, "retrans", strlen("retrans")) == 0) {
+      config->retrans = atoi(ptr);
+    } else if (strncmp(buf, "lifetime", strlen("lifetime")) == 0) {
+      config->pmk_expiry = atoi(ptr);
+    } else if (strncmp(buf, "thresh", strlen("thresh")) == 0) {
+      config->open_threshold = atoi(ptr);
+    } else if (strncmp(buf, "blacklist", strlen("blacklist")) == 0) {
+      config->blacklist_timeout = atoi(ptr);
+    } else if (strncmp(buf, "giveup", strlen("giveup")) == 0) {
+      config->giveup_threshold = atoi(ptr);
+    }
+  }
+  fclose(fp);
+  return 0;
+}
+
+void sae_dump_db(int unused) {
+  struct candidate *peer;
+
+  fprintf(stderr, "SAE:\n");
+  TAILQ_FOREACH(peer, &peers, entry) {
+    fprintf(
+        stderr,
+        "\t" MACSTR " in state %s\n",
+        MAC2STR(peer->peer_mac),
+        state_to_string(peer->state));
+  }
+}
+
+static bool check_callbacks(struct sae_cb *callbacks) {
+  bool valid = callbacks != NULL;
+  valid = valid && callbacks->meshd_write_mgmt != NULL;
+  valid = valid && callbacks->peer_created != NULL;
+  valid = valid && callbacks->fin != NULL;
+  return valid;
+}
+
+int sae_initialize(
+    char *ourssid,
+    struct sae_config *config,
+    struct sae_cb *callbacks) {
+  GD *curr, *prev = NULL;
+  int i;
+
+  if (!check_callbacks(callbacks))
+    return -1;
+
+  cb = callbacks;
+
+  /* TODO: detect duplicate calls.  validate config. */
+
+  EVP_add_digest(EVP_sha256());
+  if ((out = BIO_new(BIO_s_file())) == NULL) {
+    fprintf(stderr, "SAE: unable to create file BIO!\n");
+    return -1;
+  }
+  BIO_set_fp(out, stderr, BIO_NOCLOSE);
+
+  /*
+   * initialize globals
+   */
+  memset(allzero, 0, SHA256_DIGEST_LENGTH);
+  TAILQ_INIT(&peers);
+  TAILQ_INIT(&blacklist);
+  i = RAND_bytes((unsigned char *)&token_generator, sizeof(unsigned long));
+  if (i == 0) {
+    fprintf(stderr, "failed to generate random token!\n");
+    return -1;
+  }
+  if ((bnctx = BN_CTX_new()) == NULL) {
+    fprintf(stderr, "cannot create bignum context!\n");
+    return -1;
+  }
+  /*
+   * set defaults and read in config
+   */
+  sae_debug_mask = config->debug;
+  curr_open = 0;
+  open_threshold = config->open_threshold ? config->open_threshold : 5;
+  blacklist_timeout =
+      config->blacklist_timeout ? config->blacklist_timeout : 30;
+  giveup_threshold = config->giveup_threshold ? config->giveup_threshold : 5;
+  retrans = config->retrans ? config->retrans : 3;
+  pmk_expiry = config->pmk_expiry ? config->pmk_expiry : 86400; /* one day */
+  /*
+   * create groups from configuration data
+   */
+  for (i = 0; i < config->num_groups; i++) {
+    if ((curr = (GD *)malloc(sizeof(GD))) == NULL) {
+      sae_debug(SAE_DEBUG_ERR, "cannot malloc group definition!\n");
+      return -1;
+    }
+    if (compute_group_definition(curr, config->pwd, config->group[i])) {
+      free(curr);
+      continue;
+    }
+    if (prev)
+      prev->next = curr;
+    else
+      gd = curr;
+    prev = curr;
+    curr->next = NULL;
+    sae_debug(
+        SAE_DEBUG_STATE_MACHINE,
+        "group %d is configured, prime is %d"
+        " bytes\n",
+        curr->group_num,
+        BN_num_bytes(curr->prime));
+  }
+  return 1;
 }

--- a/sae.h
+++ b/sae.h
@@ -43,43 +43,64 @@
 #include "ieee802_11.h"
 #include "peers.h"
 
-#define    SAE_MAX_EC_GROUPS    10
-#define    SAE_MAX_PASSWORD_LEN 80
+#define SAE_MAX_EC_GROUPS 10
+#define SAE_MAX_PASSWORD_LEN 80
 
 struct sae_config {
-    int group[SAE_MAX_EC_GROUPS];
-    int num_groups;
-    char pwd[SAE_MAX_PASSWORD_LEN];
-    int debug;
-    int retrans;
-    int pmk_expiry;
-    int open_threshold;
-    int blacklist_timeout;
-    int giveup_threshold;
+  int group[SAE_MAX_EC_GROUPS];
+  int num_groups;
+  char pwd[SAE_MAX_PASSWORD_LEN];
+  int debug;
+  int retrans;
+  int pmk_expiry;
+  int open_threshold;
+  int blacklist_timeout;
+  int giveup_threshold;
 };
 
 struct sae_cb {
-    int (*meshd_write_mgmt)(char *frame, int framelen, void *cookie);
-    void (*peer_created)(unsigned char *peer_mac);
-    void (*fin)(unsigned short reason, unsigned char *peer_mac,
-                unsigned char *key, int keylen, void *cookie);
-    struct evl_ops *evl;
+  int (*meshd_write_mgmt)(char *frame, int framelen, void *cookie);
+  void (*peer_created)(unsigned char *peer_mac);
+  void (*fin)(
+      unsigned short reason,
+      unsigned char *peer_mac,
+      unsigned char *key,
+      int keylen,
+      void *cookie);
+  struct evl_ops *evl;
 };
 
 /* You may choose not to call sae_parse_config and
  * populate sae_config in some other way before
  * invoking sae_initialize() */
-int sae_parse_config(char* confdir, struct sae_config *config);
-int sae_initialize(char *ssid, struct sae_config *config, struct sae_cb *callbacks);
-int process_mgmt_frame(struct ieee80211_mgmt_frame *frame, int len,
-                       unsigned char *local_mac_addr, void *cookie, bool skip_sae);
-struct candidate *create_candidate(unsigned char *her_mac, unsigned char *my_mac, unsigned short got_token, void *cookie);
+int sae_parse_config(char *confdir, struct sae_config *config);
+int sae_initialize(
+    char *ssid,
+    struct sae_config *config,
+    struct sae_cb *callbacks);
+int process_mgmt_frame(
+    struct ieee80211_mgmt_frame *frame,
+    int len,
+    unsigned char *local_mac_addr,
+    void *cookie,
+    bool skip_sae);
+struct candidate *create_candidate(
+    unsigned char *her_mac,
+    unsigned char *my_mac,
+    unsigned short got_token,
+    void *cookie);
 void sae_read_config(int signal);
-void sae_dump_db (int signal);
-int prf (unsigned char *key, int keylen, unsigned char *label, int labellen,
-     unsigned char *context, int contextlen,
-     unsigned char *result, int resultbitlen);
+void sae_dump_db(int signal);
+int prf(
+    unsigned char *key,
+    int keylen,
+    unsigned char *label,
+    int labellen,
+    unsigned char *context,
+    int contextlen,
+    unsigned char *result,
+    int resultbitlen);
 
 void do_reauth(struct candidate *peer);
 
-#endif  /* _SAE_H_ */
+#endif /* _SAE_H_ */


### PR DESCRIPTION
The current coding style is a terrible mess of differently-spaced
indent levels and hard tabs.  Nowadays we have tools that do an
okay job of keeping everything aligned, and this is not a battle
worth caring about so add a .clang-format file and reformat
everything accordingly.

Style is mostly facebook style except pointers are aligned with
the variable as is common in C.  I flipped a coin on 2-vs-4
space indents and it came up as 2, so you're welcome (and I'm
sorry).