### PR TITLE
Delete timers before starting new ones

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -268,6 +268,7 @@ static inline void fsm_restart(struct candidate *cand) {
   }
 
   peer_ampe_init(&ampe_conf, cand, cand->cookie);
+  cb->evl->rem_timeout(cand->t2);
   cand->t2 = cb->evl->add_timeout(SRV_MSEC(PEER_TIMEOUT_MS), plink_timer, cand);
   cand->estab_attempts++;
 }
@@ -320,6 +321,7 @@ static void plink_timer(void *data) {
         }
         cand->timeout += rand % cand->timeout;
         ++cand->retries;
+        cb->evl->rem_timeout(cand->t2);
         cand->t2 =
             cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
         plink_frame_tx(cand, PLINK_OPEN, 0);
@@ -332,6 +334,7 @@ static void plink_timer(void *data) {
       if (!reason)
         reason = htole16(MESH_CONFIRM_TIMEOUT);
       set_link_state(cand, PLINK_HOLDING);
+      cb->evl->rem_timeout(cand->t2);
       cand->t2 = cb->evl->add_timeout(
           SRV_MSEC(cand->conf->holding_timeout_ms), plink_timer, cand);
       plink_frame_tx(cand, PLINK_CLOSE, reason);
@@ -872,6 +875,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
           break;
         case OPN_ACPT:
           cand->timeout = aconf->retry_timeout_ms;
+          cb->evl->rem_timeout(cand->t2);
           cand->t2 =
               cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
           set_link_state(cand, PLINK_OPN_RCVD);
@@ -895,6 +899,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
           cand->reason = reason;
           set_link_state(cand, PLINK_HOLDING);
           cand->timeout = aconf->holding_timeout_ms;
+          cb->evl->rem_timeout(cand->t2);
           cand->t2 =
               cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
           plink_frame_tx(cand, PLINK_CLOSE, reason);
@@ -907,6 +912,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
         case CNF_ACPT:
           set_link_state(cand, PLINK_CNF_RCVD);
           cand->timeout = aconf->confirm_timeout_ms;
+          cb->evl->rem_timeout(cand->t2);
           cand->t2 =
               cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
           break;
@@ -927,6 +933,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
           cand->reason = reason;
           set_link_state(cand, PLINK_HOLDING);
           cand->timeout = aconf->holding_timeout_ms;
+          cb->evl->rem_timeout(cand->t2);
           cand->t2 =
               cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
           plink_frame_tx(cand, PLINK_CLOSE, reason);
@@ -978,6 +985,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
           cand->reason = reason;
           set_link_state(cand, PLINK_HOLDING);
           cand->timeout = aconf->holding_timeout_ms;
+          cb->evl->rem_timeout(cand->t2);
           cand->t2 =
               cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
           plink_frame_tx(cand, PLINK_CLOSE, reason);
@@ -1022,6 +1030,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
           cand->reason = reason;
           set_link_state(cand, PLINK_HOLDING);
           cand->timeout = aconf->holding_timeout_ms;
+          cb->evl->rem_timeout(cand->t2);
           cand->t2 =
               cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
           changed |= mesh_set_ht_op_mode(cand->conf->mesh);
@@ -1091,6 +1100,7 @@ int start_peer_link(unsigned char *peer_mac, unsigned char *me, void *cookie) {
 
   peer_ampe_init(&ampe_conf, cand, cookie);
   set_link_state(cand, PLINK_OPN_SNT);
+  cb->evl->rem_timeout(cand->t2);
   cand->t2 = cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
 
   sae_debug(

--- a/sae.c
+++ b/sae.c
@@ -1429,10 +1429,12 @@ static void retransmit_peer(void *data) {
   switch (peer->state) {
     case SAE_COMMITTED:
       commit_to_peer(peer, NULL, 0);
+      cb->evl->rem_timeout(peer->t0);
       peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
       break;
     case SAE_CONFIRMED:
       confirm_to_peer(peer);
+      cb->evl->rem_timeout(peer->t0);
       peer->t0 = cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
       break;
     default:
@@ -1541,6 +1543,7 @@ void do_reauth(struct candidate *peer) {
         delete_peer(&newpeer);
       } else {
         commit_to_peer(newpeer, NULL, 0);
+        cb->evl->rem_timeout(newpeer->t0);
         newpeer->t0 =
             cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, newpeer);
         newpeer->state = SAE_COMMITTED;
@@ -1550,6 +1553,7 @@ void do_reauth(struct candidate *peer) {
      * make a hard deletion of this guy in case the reauth fails and we
      * don't end up deleting this instance
      */
+    cb->evl->rem_timeout(peer->t2);
     peer->t2 = cb->evl->add_timeout(SRV_SEC(5), destroy_peer, peer);
 
   } else {
@@ -1643,6 +1647,7 @@ static enum result process_authentication_frame(
            */
           confirm_to_peer(peer);
           peer->sync = 0;
+          cb->evl->rem_timeout(peer->t0);
           peer->t0 =
               cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
           peer->state = SAE_CONFIRMED;
@@ -1679,6 +1684,7 @@ static enum result process_authentication_frame(
                 frame->authenticate.u.var8,
                 (len - (IEEE802_11_HDR_LEN + sizeof(frame->authenticate))));
             peer->sync = 0;
+            cb->evl->rem_timeout(peer->t0);
             peer->t0 =
                 cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
             break;
@@ -1720,6 +1726,7 @@ static enum result process_authentication_frame(
                   "ignore...\n",
                   grp);
             }
+            cb->evl->rem_timeout(peer->t0);
             peer->t0 =
                 cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
             break;
@@ -1728,6 +1735,7 @@ static enum result process_authentication_frame(
            * silently drop any other failure
            */
           if (status != 0) {
+            cb->evl->rem_timeout(peer->t0);
             peer->t0 =
                 cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
             break;
@@ -1758,6 +1766,7 @@ static enum result process_authentication_frame(
                   grp);
               peer->sync++;
               reject_to_peer(peer, frame);
+              cb->evl->rem_timeout(peer->t0);
               peer->t0 =
                   cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
               break;
@@ -1777,6 +1786,7 @@ static enum result process_authentication_frame(
                * the numerically greater MAC address retransmits
                */
               commit_to_peer(peer, NULL, 0);
+              cb->evl->rem_timeout(peer->t0);
               peer->t0 =
                   cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
               break;
@@ -1812,6 +1822,7 @@ static enum result process_authentication_frame(
             }
           }
           confirm_to_peer(peer);
+          cb->evl->rem_timeout(peer->t0);
           peer->t0 =
               cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
           peer->state = SAE_CONFIRMED;
@@ -1825,6 +1836,7 @@ static enum result process_authentication_frame(
           }
           peer->sync++;
           commit_to_peer(peer, NULL, 0);
+          cb->evl->rem_timeout(peer->t0);
           peer->t0 =
               cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
           break;
@@ -1842,6 +1854,7 @@ static enum result process_authentication_frame(
         /*
          * silently discard, but since we cancelled the timer above, reset it
          */
+        cb->evl->rem_timeout(peer->t0);
         peer->t0 =
             cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
         break;
@@ -1859,6 +1872,7 @@ static enum result process_authentication_frame(
             commit_to_peer(peer, NULL, 0);
             confirm_to_peer(peer);
           }
+          cb->evl->rem_timeout(peer->t0);
           peer->t0 =
               cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
           break;
@@ -2197,6 +2211,7 @@ int process_mgmt_frame(
           delete_peer(&peer);
         } else {
           commit_to_peer(peer, NULL, 0);
+          cb->evl->rem_timeout(peer->t0);
           peer->t0 =
               cb->evl->add_timeout(SRV_SEC(retrans), retransmit_peer, peer);
           peer->state = SAE_COMMITTED;


### PR DESCRIPTION
In many cases, we start a new timeout with `add_timeout` without checking whether another timeout is already running. For timers defined by 802.11s (represented by candidate `t0`, `t1`, and `t2` timers), this is not the correct behaviour – they expect a single timer to be running at a time.

Remove any existing timers with `rem_timeout` prior to `add_timeout`ing a new timer setting.

Summary of behaviours:
1. Previous timer id exists, timer running —> remove old one, create new one
1. Previous timer id exists, timer expired —>
   1. case should not happen in `authsae`, timer id is deleted when timer expires
   1. other code using `libsae` MUST no-op removing an expired/non-existent timer
1. Previous timer id = `0` —> timer id `0` is reserved by `libsae`, removing it is no-op per 2.ii above