### PR TITLE
Send PLINK_CLOSE frame on removal of a peer

### DIFF
--- a/ampe.h
+++ b/ampe.h
@@ -149,6 +149,7 @@ int process_ampe_frame(
     unsigned char *me,
     void *cookie);
 int ampe_open_peer_link(unsigned char *peer_mac, void *cookie);
+int ampe_close_peer_link(unsigned char *peer_mac);
 
 /* deprecated */
 int start_peer_link(unsigned char *peer_mac, unsigned char *me, void *cookie);

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -391,6 +391,7 @@ handle_del_peer(struct netlink_config_s *nlcfg, struct nl_msg *msg, void *arg) {
   if (!tb[NL80211_ATTR_MAC] || nla_len(tb[NL80211_ATTR_MAC]) != ETH_ALEN)
     return -1;
 
+  ampe_close_peer_link(nla_data(tb[NL80211_ATTR_MAC]));
   delete_peer_by_addr(nla_data(tb[NL80211_ATTR_MAC]));
 
   return 0;

--- a/tests/test006.sh
+++ b/tests/test006.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Test closing of a connection when one side deletes its peer
+#
+. `dirname $0`/include.sh
+
+[ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
+
+cleanup() {
+    sudo killall meshd-nl80211
+    exit 0
+}
+
+trap cleanup SIGINT
+
+nradios=2
+load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
+
+set_default_configs $nradios
+# disable security
+for conf in ${CONFIGS[@]}; do
+    sed -i 's/meshid/is-secure=0;&/' $conf
+done
+
+start_meshd $(get_hwsim_radios) || exit 2
+
+wait_for_plinks $nradios
+
+# Delete the peer from radio 1 -> radio 2
+sudo iw dev smesh0 station del $(cat /sys/class/net/smesh1/address)
+
+sleep 1
+
+# Make sure it is no longer in ESTAB on either peer
+for iface in smesh0 smesh1; do
+    if sudo iw dev $iface station dump | grep -q ESTAB; then
+        echo "Did not de-ESTAB after peer deletion"
+        exit 3
+    fi
+done
+
+echo PASS
+cleanup


### PR DESCRIPTION
We currently do not send an AMPE PLINK_CLOSE frame when a CMD_DEL_STATION event is given to us by the kernel. This results in the other end of our link potentially staying in ESTAB even though we have no intent to talk to it again.

Note: until version 4.8, the kernel would send these frames automatically in all cases. Starting with 4.8, it no longer sends them if userspace mesh peering has been requested.

**Test results before:**
```
ilyacodes@ilyacodes-virtual-machine:~/authsae$ tests/test006.sh 
.
Did not de-ESTAB after peer deletion
ilyacodes@ilyacodes-virtual-machine:~/authsae$ iw smesh0 station dump | grep "Station\|mesh plink:"
Station 02:00:00:00:01:00 (on smesh0)
	mesh plink:	LISTEN
ilyacodes@ilyacodes-virtual-machine:~/authsae$ iw smesh1 station dump | grep "Station\|mesh plink:"
Station 02:00:00:00:00:00 (on smesh1)
	mesh plink:	ESTAB
```

**Test results after:**
```
ilyacodes@ilyacodes-virtual-machine:~/authsae$ tests/test006.sh 
.
PASS
ilyacodes@ilyacodes-virtual-machine:~/authsae$ iw smesh0 station dump | grep "Station\|mesh plink:"
ilyacodes@ilyacodes-virtual-machine:~/authsae$ iw smesh1 station dump | grep "Station\|mesh plink:"
```