### PR TITLE
Fix test failure due to existing interfaces

### DIFF
--- a/tests/include.sh
+++ b/tests/include.sh
@@ -4,6 +4,8 @@ load_hwsim() {
     local nradios=$1
     sudo modprobe -r mac80211-hwsim &> /dev/null
     sudo modprobe mac80211-hwsim radios=$nradios
+    # remove any leftover interfaces
+    for i in /sys/devices/virtual/mac80211_hwsim/*/net/*; do sudo iw dev $(basename $i) del; done
 }
 
 get_hwsim_radios() {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Run all the tests
+#
+for t in $(realpath $(dirname $0)/test*.sh); do
+    echo "Running '$(basename $t)'..."
+    $t
+done
+


### PR DESCRIPTION
Sometimes tests would (non-deterministically) fail with an error like:

```
RTNETLINK answers: Name not unique on network
command failed: Network is down (-100)
```

This was due to interfaces that were left from previous runs even after hwsim was re-initialised. To fix this, delete any existing interfaces on hwsim-created radios during hwsim initialisation.

Also add a script to more easily run all the tests, for convenience.