### PR TITLE
Fix bug in test framework where interface counter was not incremented

### DIFF
--- a/tests/include.sh
+++ b/tests/include.sh
@@ -61,6 +61,7 @@ start_mesh_iw() {
         # basic-rates must match that in set_sup_basic_rates()
         sudo iw dev $iface mesh join byteme freq 2412 NOHT basic-rates 1,2,5.5,11,6,12,24
 
+        let i=$((i+1))
         IW_IFACES+=($iface)
     done
 }


### PR DESCRIPTION
This seems to have been a typo - we need to increment the interface counter when creating multiple interfaces (compare `start_mesh_iw()` with `start_meshd()`, which is not missing the counter).