### PR TITLE
Fix inconsistency with 802.11 spec for sending PLINK_CLOSE frames

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -253,8 +253,6 @@ static inline void fsm_restart(struct candidate *cand) {
       "Deleting peer " MACSTR " to restart FSM\n",
       MAC2STR(cand->peer_mac));
 
-  ampe_close_peer_link(cand->peer_mac);
-
   if (cb->delete_peer)
     cb->delete_peer(cand->peer_mac);
 }
@@ -1006,6 +1004,9 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
 
     case PLINK_ESTAB:
       switch (event) {
+        case OPN_RJCT:
+        case CNF_RJCT:
+          reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
         case CLS_ACPT:
           reason = htole16(MESH_CLOSE_RCVD);
           cand->reason = reason;


### PR DESCRIPTION
In the spec (802.11-2016 tables 14-2 and 14-3) it is specified that PLINK_CLOSE should be sent (`sntCLS`) on events `OPN_RJCT` and `CNF_RJCT` if we are in the `ESTAB` state. This is inconsistent with section 14.4.10, but consistent with `wpa_supplicant`. Add the additional events to the state machine.

Additionally, PR 93 added a call to `ampe_close_link()` in `restart_fsm()` which was incorrect. Remove it.