### PR TITLE
Mixed ht fix

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -183,9 +183,12 @@ static void derive_aek(struct candidate *cand) {
   sae_hexdump(AMPE_DEBUG_KEYS, "aek: ", cand->aek, sizeof(cand->aek));
 }
 
-/* determine and set the correct ht operation mode for all established peers
- * according to 802.11mb 9.23.3. Return MESH_CONF_CHANGED_HT bit if a new
- * operation mode was selected */
+/*
+ * Determine and set the correct ht operation mode for all established peers
+ * according to 802.11-2016 10.26.3.5.
+ *
+ * Return MESH_CONF_CHANGED_HT bit if a new operation mode was selected.
+ */
 static uint32_t mesh_set_ht_op_mode(struct mesh_node *mesh) {
   struct candidate *peer;
   uint32_t changed = 0;

--- a/ampe.c
+++ b/ampe.c
@@ -1233,6 +1233,38 @@ static bool matches_local(struct mesh_node *mesh, struct info_elems *elems) {
           : 0);
 }
 
+void ampe_set_peer_ies(struct candidate *cand, struct info_elems *elems) {
+  if (elems->sup_rates) {
+    memcpy(cand->sup_rates, elems->sup_rates, elems->sup_rates_len);
+    cand->sup_rates_len = elems->sup_rates_len;
+    if (elems->ext_rates) {
+      memcpy(
+          cand->sup_rates + elems->sup_rates_len,
+          elems->ext_rates,
+          elems->ext_rates_len);
+      cand->sup_rates_len += elems->ext_rates_len;
+    }
+  }
+
+  if (elems->ht_cap) {
+    cand->ht_cap = memdup(elems->ht_cap, elems->ht_cap_len);
+  }
+
+  if (elems->ht_info) {
+    cand->ht_info = memdup(elems->ht_info, elems->ht_info_len);
+  }
+
+  if (elems->vht_cap) {
+    cand->vht_cap = memdup(elems->vht_cap, elems->vht_cap_len);
+  }
+
+  if (elems->vht_info) {
+    cand->vht_info = memdup(elems->vht_info, elems->vht_info_len);
+  }
+
+  cand->ch_width = ht_op_to_channel_width(cand->ht_info, cand->vht_info);
+}
+
 /**
  * process_ampe_frame - process an ampe frame
  * @frame:     The full frame
@@ -1371,33 +1403,7 @@ int process_ampe_frame(
   if (cand->my_lid == 0)
     peer_ampe_init(&ampe_conf, cand, cookie);
 
-  if (elems.sup_rates) {
-    memcpy(cand->sup_rates, elems.sup_rates, elems.sup_rates_len);
-    cand->sup_rates_len = elems.sup_rates_len;
-    if (elems.ext_rates) {
-      memcpy(
-          cand->sup_rates + elems.sup_rates_len,
-          elems.ext_rates,
-          elems.ext_rates_len);
-      cand->sup_rates_len += elems.ext_rates_len;
-    }
-  }
-
-  if (elems.ht_cap) {
-    cand->ht_cap = memdup(elems.ht_cap, elems.ht_cap_len);
-  }
-
-  if (elems.ht_info) {
-    cand->ht_info = memdup(elems.ht_info, elems.ht_info_len);
-  }
-
-  if (elems.vht_cap) {
-    cand->vht_cap = memdup(elems.vht_cap, elems.vht_cap_len);
-  }
-
-  if (elems.vht_info) {
-    cand->vht_info = memdup(elems.vht_info, elems.vht_info_len);
-  }
+  ampe_set_peer_ies(cand, &elems);
 
   check_frame_protection(cand, mgmt, len, &elems);
 

--- a/ampe.c
+++ b/ampe.c
@@ -1379,6 +1379,14 @@ int process_ampe_frame(
     memcpy(&cand->ht_info, elems.ht_info, elems.ht_info_len);
   }
 
+  if (elems.vht_cap && elems.vht_cap_len <= sizeof(cand->vht_cap)) {
+    memcpy(&cand->vht_cap, elems.vht_cap, elems.vht_cap_len);
+  }
+
+  if (elems.vht_info && elems.vht_info_len <= sizeof(cand->vht_info)) {
+    memcpy(&cand->vht_info, elems.vht_info, elems.vht_info_len);
+  }
+
   check_frame_protection(cand, mgmt, len, &elems);
 
   cand->cookie = cookie;

--- a/ampe.c
+++ b/ampe.c
@@ -135,6 +135,15 @@ static inline void set_link_state(
   cb->set_plink_state(cand->peer_mac, state, cand->cookie);
 }
 
+static void *memdup(const void *src, size_t size) {
+  void *dst = malloc(size);
+
+  if (dst)
+    memcpy(dst, src, size);
+
+  return dst;
+}
+
 static int plink_free_count() {
   sae_debug(AMPE_DEBUG_FSM, "TODO: return available peer link slots\n");
   return 99;
@@ -1374,20 +1383,20 @@ int process_ampe_frame(
     }
   }
 
-  if (elems.ht_cap && elems.ht_cap_len <= sizeof(cand->ht_cap)) {
-    memcpy(&cand->ht_cap, elems.ht_cap, elems.ht_cap_len);
+  if (elems.ht_cap) {
+    cand->ht_cap = memdup(elems.ht_cap, elems.ht_cap_len);
   }
 
-  if (elems.ht_info && elems.ht_info_len <= sizeof(cand->ht_info)) {
-    memcpy(&cand->ht_info, elems.ht_info, elems.ht_info_len);
+  if (elems.ht_info) {
+    cand->ht_info = memdup(elems.ht_info, elems.ht_info_len);
   }
 
-  if (elems.vht_cap && elems.vht_cap_len <= sizeof(cand->vht_cap)) {
-    memcpy(&cand->vht_cap, elems.vht_cap, elems.vht_cap_len);
+  if (elems.vht_cap) {
+    cand->vht_cap = memdup(elems.vht_cap, elems.vht_cap_len);
   }
 
-  if (elems.vht_info && elems.vht_info_len <= sizeof(cand->vht_info)) {
-    memcpy(&cand->vht_info, elems.vht_info, elems.vht_info_len);
+  if (elems.vht_info) {
+    cand->vht_info = memdup(elems.vht_info, elems.vht_info_len);
   }
 
   check_frame_protection(cand, mgmt, len, &elems);

--- a/ampe.h
+++ b/ampe.h
@@ -106,6 +106,8 @@ struct meshd_config {
   int rekey_ping_jitter; /* in msec */
   int rekey_reauth_count_max;
   int rekey_ok_ping_count_max;
+
+  int auto_open_plinks;
 };
 
 /* the single global interface and mesh node info we're handling.

--- a/ampe.h
+++ b/ampe.h
@@ -171,6 +171,10 @@ int process_ampe_frame(
 int ampe_open_peer_link(unsigned char *peer_mac, void *cookie);
 int ampe_close_peer_link(unsigned char *peer_mac);
 
+
+struct candidate;
+void ampe_set_peer_ies(struct candidate *peer, struct info_elems *elems);
+
 /* deprecated */
 int start_peer_link(unsigned char *peer_mac, unsigned char *me, void *cookie);
 

--- a/chan.h
+++ b/chan.h
@@ -7,4 +7,7 @@ int ieee80211_channel_to_frequency(int chan, enum ieee80211_band band);
 
 int ieee80211_frequency_to_channel(int freq);
 
+enum channel_width ht_op_to_channel_width(
+    struct ht_op_ie *ht_op,
+    struct vht_op_ie *vht_op);
 #endif /* __CHAN_H */

--- a/ieee802_11.h
+++ b/ieee802_11.h
@@ -248,6 +248,11 @@ struct ht_op_ie {
   uint8_t basic_set[16];
 } __attribute__((packed));
 
+struct vht_cap_ie {
+  uint32_t cap;
+  struct vht_mcs_info mcs;
+} __attribute__((packed));
+
 struct vht_op_ie {
   uint8_t width;
   uint8_t center_chan1;

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1335,17 +1335,17 @@ void estab_peer_link(
     elems.sup_rates = cand->sup_rates;
     elems.sup_rates_len = cand->sup_rates_len;
 
-    elems.ht_cap = (unsigned char *)&cand->ht_cap;
-    elems.ht_cap_len = sizeof(cand->ht_cap);
+    elems.ht_cap = (unsigned char *)cand->ht_cap;
+    elems.ht_cap_len = sizeof(*cand->ht_cap);
 
-    elems.ht_info = (unsigned char *)&cand->ht_info;
-    elems.ht_info_len = sizeof(cand->ht_info);
+    elems.ht_info = (unsigned char *)cand->ht_info;
+    elems.ht_info_len = sizeof(*cand->ht_info);
 
-    elems.vht_cap = (unsigned char *)&cand->vht_cap;
-    elems.vht_cap_len = sizeof(cand->vht_cap);
+    elems.vht_cap = (unsigned char *)cand->vht_cap;
+    elems.vht_cap_len = sizeof(*cand->vht_cap);
 
-    elems.vht_info = (unsigned char *)&cand->vht_info;
-    elems.vht_info_len = sizeof(cand->vht_info);
+    elems.vht_info = (unsigned char *)cand->vht_info;
+    elems.vht_info_len = sizeof(*cand->vht_info);
 
     ret = add_unauthenticated_sta(nlcfg, peer, &elems);
     if (ret)

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -556,7 +556,9 @@ static int add_unauthenticated_sta(
   ret = nl_send_auto_complete(nlcfg->cmd_sock, msg);
   sae_debug(
       MESHD_DEBUG,
-      "new unauthed sta (seq num=%d)\n",
+      "new unauthed %s sta (seq num=%d)\n",
+      ((elems->vht_cap) ? "VHT" :
+       (elems->ht_cap) ? "HT" : "NOHT"),
       nlmsg_hdr(msg)->nlmsg_seq);
   nlmsg_free(msg);
   msg = NULL;

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -585,6 +585,11 @@ static int new_candidate_handler(
   struct info_elems elems;
   struct candidate *peer;
 
+  /* We don't do anything with beacons if auto_open_plinks = false */
+  if (!meshd_conf.auto_open_plinks) {
+    return NL_SKIP;
+  }
+
   /* check that all the required info exists: source address
    * (arrives as bssid), meshid, mesh config(TODO!) and RSN
    * */
@@ -1729,6 +1734,8 @@ static int meshd_parse_libconfig(
         config->rekey_ok_ping_count_max);
     return -1;
   }
+
+  CONFIG_LOOKUP("auto_open_plinks", auto_open_plinks, 1);
 
 #undef CONFIG_LOOKUP
 

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1362,6 +1362,12 @@ void estab_peer_link(
     elems.ht_info = (unsigned char *)&cand->ht_info;
     elems.ht_info_len = sizeof(cand->ht_info);
 
+    elems.vht_cap = (unsigned char *)&cand->vht_cap;
+    elems.vht_cap_len = sizeof(cand->vht_cap);
+
+    elems.vht_info = (unsigned char *)&cand->vht_info;
+    elems.vht_info_len = sizeof(cand->vht_info);
+
     ret = add_unauthenticated_sta(nlcfg, peer, &elems);
     if (ret)
       return;

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -225,54 +225,6 @@ set_sup_basic_rates(struct meshd_config *mconf, u16 *rates, int rates_len) {
   }
 }
 
-static enum channel_width ht_op_to_channel_width(
-    struct ht_op_ie *ht_op,
-    struct vht_op_ie *vht_op) {
-  enum nl80211_chan_width channel_width;
-
-  if (!ht_op)
-    return NL80211_CHAN_WIDTH_20_NOHT;
-
-  /* Determine width from VHT operation element, 802.11-2016 tables 9-252,3 */
-  if (vht_op) {
-    switch (vht_op->width) {
-      case 3: /* deprecated */
-        return NL80211_CHAN_WIDTH_80P80;
-
-      case 2: /* deprecated */
-        return NL80211_CHAN_WIDTH_160;
-
-      case 1: /* 80-160; determine based on center freq settings */
-        if (!vht_op->center_chan2) {
-          return NL80211_CHAN_WIDTH_80;
-        }
-        if (abs(vht_op->center_chan2 - vht_op->center_chan1) == 8) {
-          return NL80211_CHAN_WIDTH_160;
-        }
-        return NL80211_CHAN_WIDTH_80P80;
-
-      case 0: /* 20 or 40, handled below */
-      default:
-        break;
-    }
-  }
-
-  switch (ht_op->ht_param & IEEE80211_HT_PARAM_CHA_SEC_OFFSET) {
-    case IEEE80211_HT_PARAM_CHA_SEC_NONE:
-      return NL80211_CHAN_WIDTH_20;
-      break;
-    case IEEE80211_HT_PARAM_CHA_SEC_ABOVE:
-    case IEEE80211_HT_PARAM_CHA_SEC_BELOW:
-      return NL80211_CHAN_WIDTH_40;
-      break;
-    default:
-      channel_width = NL80211_CHAN_WIDTH_20_NOHT;
-      break;
-  }
-
-  return channel_width;
-}
-
 static int get_mac_addr(const char *ifname, uint8_t *macaddr) {
   int fd;
   struct ifreq ifr;

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -613,8 +613,9 @@ static int new_candidate_handler(
    * we received two NEW_PEER_CANDIDATE events for the same peer, this will fail
    */
   if ((peer = find_peer(bcn.sa, 0))) {
-    peer->ch_width = ht_op_to_channel_width(
-        (struct ht_op_ie *)elems.ht_info, (struct vht_op_ie *)elems.vht_info);
+
+    ampe_set_peer_ies(peer, &elems);
+
     if (!peer->in_kernel &&
         add_unauthenticated_sta(nlcfg, bcn.sa, &elems) == 0) {
       peer->in_kernel = true;

--- a/peers.h
+++ b/peers.h
@@ -80,11 +80,11 @@ struct candidate {
   unsigned int rekey_ok;
   unsigned int rekey_ok_ping_rx;
 
-  struct ht_cap_ie ht_cap;
-  struct ht_op_ie ht_info;
+  struct ht_cap_ie *ht_cap;
+  struct ht_op_ie *ht_info;
 
-  struct vht_cap_ie vht_cap;
-  struct vht_op_ie vht_info;
+  struct vht_cap_ie *vht_cap;
+  struct vht_op_ie *vht_info;
 
   bool in_kernel;
 };

--- a/peers.h
+++ b/peers.h
@@ -83,6 +83,9 @@ struct candidate {
   struct ht_cap_ie ht_cap;
   struct ht_op_ie ht_info;
 
+  struct vht_cap_ie vht_cap;
+  struct vht_op_ie vht_info;
+
   bool in_kernel;
 };
 

--- a/sae.c
+++ b/sae.c
@@ -270,6 +270,10 @@ void delete_peer(struct candidate **delme) {
       BN_free(peer->my_scalar);
       EC_POINT_free(peer->my_element);
       aid_free(peer->association_id);
+      free(peer->ht_cap);
+      free(peer->ht_info);
+      free(peer->vht_cap);
+      free(peer->vht_info);
       free(*delme);
       *delme = NULL;
       return;

--- a/tests/test009.sh
+++ b/tests/test009.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# VHT80 mesh creates VHT STAs
+#
+. `dirname $0`/include.sh
+
+[ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
+
+cleanup() {
+    sudo killall meshd-nl80211
+    rm -fr "${TMP0}" "${TMP1}"
+    exit 0
+}
+
+trap cleanup SIGINT
+
+cfg='channel_width="80"; freq=5745; center_freq1=5775; center_freq2=0;'
+
+nradios=4
+load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
+set_default_configs $nradios
+
+# enable VHT on all radios, disable auto plinks in half of them
+ctr=0
+for conf in ${CONFIGS[@]}; do
+    sed -i 's/channel.*/'"$cfg"'/; s/htmode.*//; s/11g/11a/' $conf
+    if [ $(($ctr & 1)) -eq 0 ]; then
+       sed -i 's/meshid/auto_open_plinks=0;&/' $conf
+    fi
+    let ctr=$(($ctr+1))
+done
+
+start_meshd $(get_hwsim_radios) || exit 2
+wait_for_plinks $nradios
+
+grep -E -q "changing ht protection mode to: [^0]" /tmp/authsae*.log && \
+   err_exit "set protection for NON-HT STAs"
+
+grep -q "new unauthed HT sta" /tmp/authsae*.log && \
+   err_exit "incorrectly created HT STAs"
+
+grep -q "new unauthed VHT sta" /tmp/authsae*.log || \
+   err_exit "did not create VHT STAs"
+
+echo PASS


### PR DESCRIPTION
These changes are needed to ensure that all VHT stations have access to VHT rates.  In some cases, depending on which frames we processed first, such stations were treated as HT-only.