### PR TITLE
 Replace OPN_IGNR and CNF_IGNR with REQ_RJCT

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -94,12 +94,11 @@ enum plink_event {
   PLINK_UNDEFINED,
   OPN_ACPT,
   OPN_RJCT,
-  OPN_IGNR,
   CNF_ACPT,
   CNF_RJCT,
-  CNF_IGNR,
   CLS_ACPT,
-  CLS_IGNR
+  CLS_IGNR,
+  REQ_RJCT
 };
 
 /*  For debugging use */
@@ -115,12 +114,11 @@ static const char *mpl_events[] = {
         [PLINK_UNDEFINED] = "PLINK_UNDEFINED",
         [OPN_ACPT] = "OPN_ACPT",
         [OPN_RJCT] = "OPN_RJCT",
-        [OPN_IGNR] = "OPN_IGNR",
         [CNF_ACPT] = "CNF_ACPT",
         [CNF_RJCT] = "CNF_RJCT",
-        [CNF_IGNR] = "CNF_IGNR",
         [CLS_ACPT] = "CLS_ACPT",
         [CLS_IGNR] = "CLS_IGNR",
+        [REQ_RJCT] = "REQ_RJCT",
 };
 
 static int plink_frame_tx(
@@ -948,6 +946,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
       switch (event) {
         case OPN_RJCT:
         case CNF_RJCT:
+        case REQ_RJCT:
           reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
         /* no break */
         case CLS_ACPT:
@@ -982,6 +981,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
       switch (event) {
         case OPN_RJCT:
         case CNF_RJCT:
+        case REQ_RJCT:
           reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
         /* no break */
         case CLS_ACPT:
@@ -1033,6 +1033,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
       switch (event) {
         case OPN_RJCT:
         case CNF_RJCT:
+        case REQ_RJCT:
           reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
         /* no break */
         case CLS_ACPT:
@@ -1082,6 +1083,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
       switch (event) {
         case OPN_RJCT:
         case CNF_RJCT:
+        case REQ_RJCT:
           reason = htole16(MESH_CAPABILITY_POLICY_VIOLATION);
         case CLS_ACPT:
           reason = htole16(MESH_CLOSE_RCVD);
@@ -1115,6 +1117,7 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
         case CNF_ACPT:
         case OPN_RJCT:
         case CNF_RJCT:
+        case REQ_RJCT:
           reason = cand->reason;
           plink_frame_tx(cand, PLINK_CLOSE, reason);
           break;
@@ -1422,7 +1425,7 @@ int process_ampe_frame(
         event = OPN_RJCT;
       else if (
           !plink_free_count() || (cand->peer_lid && cand->peer_lid != plid))
-        event = OPN_IGNR;
+        event = REQ_RJCT;
       else {
         cand->peer_lid = plid;
         event = OPN_ACPT;
@@ -1434,7 +1437,7 @@ int process_ampe_frame(
       else if (
           !plink_free_count() ||
           (cand->my_lid != llid || cand->peer_lid != plid))
-        event = CNF_IGNR;
+        event = REQ_RJCT;
       else
         event = CNF_ACPT;
       break;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,12 +2,29 @@
 #
 # Run all the tests
 #
+
+# Make sure we're running as root
 if [ $UID -ne 0 ]; then
     exec sudo "$0" "$@"
 fi
 
+# We require all calls to exit to use `err_exit`
+grep -v "^#" $(realpath $(dirname $0)/test*.sh) | grep "exit" | grep -v "err_exit" && echo "FAIL: only 'err_exit' is supported to exit from a test, please fix" && exit 1
+
+FAILED=0
+
+# Run the tests
 for t in $(realpath $(dirname $0)/test*.sh); do
     desc=$(sed -n 's/^# *//; 3p' $t)
     echo -n "$(basename $t) $desc..."
-    $t || exit 1
+    $t || FAILED=1
 done
+
+echo
+if [ $FAILED -eq 0 ]; then
+    echo "All tests PASSED"
+else
+    echo "Some tests FAILED"
+fi
+
+exit $FAILED

--- a/tests/test003.sh
+++ b/tests/test003.sh
@@ -7,13 +7,7 @@
 
 [ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
 
-cleanup() {
-    sudo killall meshd-nl80211
-    rm -fr "${TMP0}" "${TMP1}"
-    exit 0
-}
-
-trap cleanup SIGINT
+wait_for_clean_start
 
 nradios=4
 load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
@@ -24,7 +18,7 @@ for conf in ${CONFIGS[@]}; do
     sed -i 's/htmode = "none"/htmode = "HT20"/' $conf
 done
 
-start_meshd $(get_hwsim_radios) || exit 2
+start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 wait_for_plinks $nradios
 
 # introduce a non-HT sta to switch from no protection to mixed

--- a/tests/test004.sh
+++ b/tests/test004.sh
@@ -2,16 +2,12 @@
 #
 # establishes peer link without encryption
 #
+
 . `dirname $0`/include.sh
 
 [ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
 
-cleanup() {
-    sudo killall meshd-nl80211
-    exit 0
-}
-
-trap cleanup SIGINT
+wait_for_clean_start
 
 nradios=2
 load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
@@ -22,9 +18,8 @@ for conf in ${CONFIGS[@]}; do
     sed -i 's/meshid/is-secure=0;&/' $conf
 done
 
-start_meshd $(get_hwsim_radios) || exit 2
+start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 
 wait_for_plinks $nradios
 
 echo PASS
-cleanup

--- a/tests/test005.sh
+++ b/tests/test005.sh
@@ -2,16 +2,12 @@
 #
 # user mpm interoperates with kernel mpm
 #
+
 . `dirname $0`/include.sh
 
 [ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
 
-cleanup() {
-    sudo killall meshd-nl80211
-    exit 0
-}
-
-trap cleanup SIGINT
+wait_for_clean_start
 
 nradios=2
 load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
@@ -23,11 +19,10 @@ for conf in ${CONFIGS[@]}; do
 done
 
 read -a hwsim_radios <<<"$(get_hwsim_radios)"
-start_meshd ${hwsim_radios[0]} || exit 1
-start_mesh_iw ${hwsim_radios[1]} || exit 2
+start_meshd ${hwsim_radios[0]} || err_exit "Failed to start meshd-nl80211"
+start_mesh_iw ${hwsim_radios[1]} || err_exit "Failed to start mesh using iw"
 IFACES+=(${IW_IFACES[@]})
 
 wait_for_plinks $nradios
 
 echo PASS
-cleanup

--- a/tests/test007.sh
+++ b/tests/test007.sh
@@ -2,17 +2,12 @@
 #
 # HT40 works
 #
+
 . `dirname $0`/include.sh
 
 [ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
 
-cleanup() {
-    sudo killall meshd-nl80211
-    rm -fr "${TMP0}" "${TMP1}"
-    exit 0
-}
-
-trap cleanup SIGINT
+wait_for_clean_start
 
 nradios=4
 load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
@@ -23,7 +18,7 @@ for conf in ${CONFIGS[@]}; do
     sed -i 's/htmode = "none"/htmode = "HT40-"/; s/11g/11a/; s/channel = 1/channel=153/' $conf
 done
 
-start_meshd $(get_hwsim_radios) || exit 2
+start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 wait_for_plinks $nradios
 
 echo PASS

--- a/tests/test008.sh
+++ b/tests/test008.sh
@@ -2,17 +2,12 @@
 #
 # VHT80 works
 #
+
 . `dirname $0`/include.sh
 
 [ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
 
-cleanup() {
-    sudo killall meshd-nl80211
-    rm -fr "${TMP0}" "${TMP1}"
-    exit 0
-}
-
-trap cleanup SIGINT
+wait_for_clean_start
 
 vht_configs=(
   'channel_width="80"; freq=5745; center_freq1=5775; center_freq2=0;'
@@ -21,6 +16,8 @@ vht_configs=(
 
 nradios=4
 for cfg in "${vht_configs[@]}"; do
+    wait_for_clean_start
+
     load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
     set_default_configs $nradios
 
@@ -29,7 +26,7 @@ for cfg in "${vht_configs[@]}"; do
         sed -i 's/channel.*/'"$cfg"'/; s/htmode.*//; s/11g/11a/' $conf
     done
 
-    start_meshd $(get_hwsim_radios) || exit 2
+    start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
     wait_for_plinks $nradios
 done
 

--- a/tests/test009.sh
+++ b/tests/test009.sh
@@ -2,17 +2,12 @@
 #
 # VHT80 mesh creates VHT STAs
 #
+
 . `dirname $0`/include.sh
 
 [ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
 
-cleanup() {
-    sudo killall meshd-nl80211
-    rm -fr "${TMP0}" "${TMP1}"
-    exit 0
-}
-
-trap cleanup SIGINT
+wait_for_clean_start
 
 cfg='channel_width="80"; freq=5745; center_freq1=5775; center_freq2=0;'
 
@@ -30,7 +25,7 @@ for conf in ${CONFIGS[@]}; do
     let ctr=$(($ctr+1))
 done
 
-start_meshd $(get_hwsim_radios) || exit 2
+start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 wait_for_plinks $nradios
 
 grep -E -q "changing ht protection mode to: [^0]" /tmp/authsae*.log && \


### PR DESCRIPTION
Currently, in cases where we receive open or confirm frames with mismatched link IDs, we ignore them, using non-standard events `OPN_IGNR` and `CNF_IGNR`. This leads to a deadlock if a device `A` loses its link and tries to re-establish: device `B` thinks it's still ESTAB and ignores the new attempts to peer, so device `A` will never reconnect.

In order to avoid this deadlock, we instead will reject these frames with the event `REQ_RJCT`, which is specified in the standard (802.11-2016 sections 14.3.6.2 and 14.3.7.2) as the way to reject incompatible mesh peering frames. This is not strictly correct – we should actually create a new mesh peering instance and start its state machine (section 14.3.5). However, we don't currently currently support multiple mesh peering instances, so this is a temporary workaround.

Additionally, in the standard, the `REQ_RJCT` event is only clearly defined for the `IDLE` state (section 14.4.3, and table+figure 14.2 for MPM, table+figure 14-3 for AMPE), but in practice, it appears to make sense to process it in all states, similarly to `OPN_RJCT` and `CNF_RJCT` (after all, it too is a type of rejection of an incoming mesh peering frame).

A new test is also added for this case, and stability of other tests is improved by adding a cleanup step before/after test execution.

# Testing:
Before change:
```
$ sudo tests/run_tests.sh 
test001.sh establishes an encrypted peer link...PASS
test002.sh exchanges igtk when pmf=1...PASS
test003.sh mixed HT/non-HT neighbors can peer.../tmp/authsae-1.log:nlerror, cmd 29, seq 1543964644: Invalid argument
/tmp/authsae-2.log:nlerror, cmd 29, seq 1543964644: Invalid argument
/tmp/authsae-3.log:nlerror, cmd 29, seq 1543964644: Invalid argument
set meshconf failed
FAIL
test004.sh establishes peer link without encryption...PASS
test005.sh user mpm interoperates with kernel mpm...PASS
test006.sh both ends close peer link when one side deletes its peer...PASS
test007.sh HT40 works...PASS
test008.sh VHT80 works...PASS
test009.sh VHT80 mesh creates VHT STAs...PASS
test010.sh re-ESTABs if one side is force-restarted without sending a PCLOSE...FAIL: smesh0 failed to establish a link
FAIL
```

**After change:**
```
$ sudo tests/run_tests.sh 
test001.sh establishes an encrypted peer link...PASS
test002.sh exchanges igtk when pmf=1...PASS
test003.sh mixed HT/non-HT neighbors can peer.../tmp/authsae-1.log:nlerror, cmd 29, seq 1543964782: Invalid argument
/tmp/authsae-2.log:nlerror, cmd 29, seq 1543964782: Invalid argument
/tmp/authsae-3.log:nlerror, cmd 29, seq 1543964782: Invalid argument
set meshconf failed
FAIL
test004.sh establishes peer link without encryption...PASS
test005.sh user mpm interoperates with kernel mpm...PASS
test006.sh both ends close peer link when one side deletes its peer...PASS
test007.sh HT40 works...PASS
test008.sh VHT80 works...PASS
test009.sh VHT80 mesh creates VHT STAs...PASS
test010.sh re-ESTABs if one side is restarted without closing...PASS
```