### PR TITLE
Enable CI testing for authsae

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: install deps
+          command: apt-get update && apt-get install -y gawk gcc make cmake sudo pkg-config libssl-dev libconfig-dev libnl-3-dev libnl-genl-3-dev kmod iw git curl xz-utils qemu-system-x86
+      - run:
+          name: build
+          command: make
+      - run:
+          name: test
+          command: cd tests/vm && ./vm_run.sh
+      - store_artifacts:
+          path: tests/vm/testout
+      - store_test_results:
+          path: tests/vm/testout

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ install:
 
 clean:
 	rm -rf build
+
+test:
+	cd tests && ./run_tests.sh

--- a/tests/include.sh
+++ b/tests/include.sh
@@ -101,11 +101,15 @@ start_meshd() {
     IFACES=()
     LOGS=()
 
+    LOGDIR=${LOGDIR:-/tmp}
+    TESTNAME=$(basename $0)
+
     sudo rfkill unblock all
     for radio in ${radios[@]}; do
         conf=${CONFIGS[$i]}
         iface="smesh$i"
-        log=/tmp/authsae-$i.log
+        log=$LOGDIR/$TESTNAME/authsae-$i.log
+        mkdir -p $(dirname $log)
 
         if [ $(pgrep -f "meshd-nl80211 -i ${iface}" | wc -l) -eq 0 ]; then
             sudo iw phy $radio interface add $iface type mesh

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,10 +2,14 @@
 #
 # Run all the tests
 #
-
 # Make sure we're running as root
 if [ $UID -ne 0 ]; then
     exec sudo "$0" "$@"
+fi
+
+TESTS="$@"
+if [ -z "$TESTS" ]; then
+    TESTS=$(realpath $(dirname $0)/test*.sh)
 fi
 
 # We require all calls to exit to use `err_exit`
@@ -14,7 +18,7 @@ grep -v "^#" $(realpath $(dirname $0)/test*.sh) | grep "exit" | grep -v "err_exi
 FAILED=0
 
 # Run the tests
-for t in $(realpath $(dirname $0)/test*.sh); do
+for t in $TESTS; do
     desc=$(sed -n 's/^# *//; 3p' $t)
     echo -n "$(basename $t) $desc..."
     $t || FAILED=1

--- a/tests/test003.sh
+++ b/tests/test003.sh
@@ -31,6 +31,6 @@ wait_for_plinks $nradios
 # make sure there is no 'nlerror 29' -- this can happen on kernels
 # >= 4.8 and <= TBD.  If this fails it indicates HT oper switch is
 # broken in the kernel.
-grep "nlerror, cmd 29" /tmp/authsae*.log && err_exit "set meshconf failed"
+grep "nlerror, cmd 29" $LOGDIR/$TESTNAME/authsae*.log && err_exit "set meshconf failed"
 
 echo PASS

--- a/tests/test006.sh
+++ b/tests/test006.sh
@@ -27,11 +27,9 @@ sudo iw dev smesh0 station del $(cat /sys/class/net/smesh1/address)
 
 sleep 1
 
-# Make sure it is no longer in ESTAB on either peer
-for iface in smesh0 smesh1; do
-    if sudo iw dev $iface station dump | grep -q ESTAB; then
-        err_exit "Did not de-ESTAB after peer deletion"
-    fi
+# Make sure both peers sent close
+for i in $LOGDIR/$TESTNAME/authsae*log; do
+    grep -q "Sending plink action 3" $i || err_exit "no close frame in $i"
 done
 
 echo PASS

--- a/tests/test009.sh
+++ b/tests/test009.sh
@@ -28,13 +28,13 @@ done
 start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 wait_for_plinks $nradios
 
-grep -E -q "changing ht protection mode to: [^0]" /tmp/authsae*.log && \
+grep -E -q "changing ht protection mode to: [^0]" $LOGDIR/$TESTNAME/authsae*.log && \
    err_exit "set protection for NON-HT STAs"
 
-grep -q "new unauthed HT sta" /tmp/authsae*.log && \
+grep -q "new unauthed HT sta" $LOGDIR/$TESTNAME/authsae*.log && \
    err_exit "incorrectly created HT STAs"
 
-grep -q "new unauthed VHT sta" /tmp/authsae*.log || \
+grep -q "new unauthed VHT sta" $LOGDIR/$TESTNAME/authsae*.log || \
    err_exit "did not create VHT STAs"
 
 echo PASS

--- a/tests/vm/init
+++ b/tests/vm/init
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Init for authsae VM.
+#
+# This gets execed by the VM's init once the parent directory is
+# mounted under /local.
+#
+dmesg -n 1
+cd /local/tests
+echo "--- begin tests ---"
+export LOGDIR=/local/tests/vm/testout/logs
+./run_tests.sh
+echo "--- end tests ---"
+poweroff -f

--- a/tests/vm/testout-to-junit.sh
+++ b/tests/vm/testout-to-junit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# junit-ize the results from testout.log
+logfile=$1
+numtests=$(cat $logfile | grep -E "^test" | wc -l)
+echo '<testsuites name="vmtests">'
+echo '  <testsuite tests="'$numtests'">'
+cat $logfile | grep -E "^test" | awk '{
+   split($0, x, "PASS|FAIL: ", seps)
+   testname=x[1];
+   if (seps[1] == "PASS") {
+     print "    <testcase classname=\"authsae\" name=\"" testname "\"/>";
+   } else {
+     print "    <testcase classname=\"authsae\" name=\"" testname "\">";
+     print "      <failure type=\"fail\">" x[2] "</failure>";
+     print "    </testcase>";
+   }
+}'
+echo '  </testsuite>'
+echo '</testsuites>'

--- a/tests/vm/vm_run.sh
+++ b/tests/vm/vm_run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# run tests inside a VM, for CI.
+
+# kvm passthrough isn't available in circle ci
+QEMU=${QEMU:-qemu-system-x86_64}
+
+KERNEL=testing-vm-kernel
+ROOTFS=testing-vm-rootfs.img
+
+# download a VM kernel from some random location on the internet
+# the rootfs fstab mounts /dev/local with 9p in /local.  It should
+# have iw and so on installed.
+if [ ! -f $KERNEL ]; then
+    curl -L -O "https://github.com/bcopeland/testing-vm/releases/download/v1.2/$KERNEL"
+fi
+if [ ! -f $ROOTFS ]; then
+    curl -L -O "https://github.com/bcopeland/testing-vm/releases/download/v1.2/$ROOTFS.xz"
+    xz -d $ROOTFS.xz
+fi
+
+export TESTOUT=$(/bin/pwd)/testout
+export LOGDIR=$TESTOUT/logs
+
+mkdir -p $LOGDIR
+mkdir -p $TESTOUT/vmtests
+
+$QEMU \
+  -kernel $KERNEL \
+  -drive file=$ROOTFS,format=raw,if=virtio \
+  -fsdev local,security_model=none,id=fsdev-local,path=../.. \
+  -device virtio-9p-pci,id=fs-local,fsdev=fsdev-local,mount_tag=/dev/local \
+  -serial mon:stdio -nographic -vga none \
+  -append "root=/dev/vda console=ttyS0" | tee $LOGDIR/testout.log
+
+./testout-to-junit.sh $LOGDIR/testout.log > $TESTOUT/vmtests/results.xml
+grep -q failure $TESTOUT/vmtests/results.xml && exit 1
+exit 0


### PR DESCRIPTION
These changes add some infrastructure to run the authsae tests inside a VM, which gives some additional control over which kernel is running and ensures things like mac80211 hwsim are available, and makes it possible to run the test suite on every commit inside a CI service before merging (currently testing using circle ci).  