### PR TITLE
Track and limit peer link count

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -1077,9 +1077,6 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
           cand->t2 =
               cb->evl->add_timeout(SRV_MSEC(cand->timeout), plink_timer, cand);
           changed |= mesh_set_ht_op_mode(cand->conf->mesh);
-          // TODO: update the number of available peer "slots" in mesh config
-          // if (deactivated)
-          //	ieee80211_bss_info_change_notify(sdata, BSS_CHANGED_BEACON);
           plink_frame_tx(cand, PLINK_CLOSE, reason);
           break;
         case OPN_ACPT:
@@ -1092,8 +1089,6 @@ static void fsm_step(struct candidate *cand, enum plink_event event) {
     case PLINK_HOLDING:
       switch (event) {
         case CLS_ACPT:
-          // if (del_timer(&cand->plink_timer))
-          //	cand->ignore_plink_timer = 1;
           fsm_restart(cand);
           break;
         case OPN_ACPT:
@@ -1307,15 +1302,9 @@ int process_ampe_frame(
   if (len < 24 + 1 + 1 + 2 + 2)
     return 0;
 
-  // if (is_multicast_ether_addr(mgmt->da)) {
-  //	sae_debug(AMPE_DEBUG_FSM, "Mesh plink: ignore frame to multicast
-  // address");
-  //	return 0;
-  //}
-
   ies = start_of_ies(mgmt, len, &ies_len);
   parse_ies(ies, ies_len, &elems);
-  if (!elems.mesh_peering) { // || !elems.rsn) {
+  if (!elems.mesh_peering) {
     sae_debug(AMPE_DEBUG_FSM, "Mesh plink: missing necessary peer link ie\n");
     return 0;
   }

--- a/ampe.h
+++ b/ampe.h
@@ -107,6 +107,7 @@ struct meshd_config {
   int rekey_reauth_count_max;
   int rekey_ok_ping_count_max;
 
+  int max_plinks;
   int auto_open_plinks;
 };
 
@@ -127,6 +128,8 @@ struct mesh_node {
   int igtk_keyid;
   uint8_t igtk_ipn[6];
   uint8_t igtk_tx[16];
+
+  int num_estab;
 };
 
 struct ampe_config {

--- a/common.h
+++ b/common.h
@@ -85,4 +85,11 @@ typedef int config_int_t;
 typedef long int config_int_t;
 #endif
 
+#ifndef MIN
+#define MIN(x,y) (((x) < (y)) ? (x) : (y))
+#endif
+#ifndef MAX
+#define MAX(x,y) (((x) > (y)) ? (x) : (y))
+#endif
+
 #endif /* _SAE_COMMON_H_ */

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1232,6 +1232,13 @@ static int join_mesh(struct netlink_ctx *nlcfg, struct mesh_node *mesh) {
         msg, NL80211_MESHCONF_HWMP_ROOT_INTERVAL, mconf->hwmp_root_interval);
   }
 
+  if (mconf->max_plinks > 0) {
+    NLA_PUT_U32(
+        msg,
+        NL80211_MESHCONF_MAX_PEER_LINKS,
+        mconf->max_plinks);
+  }
+
   nla_nest_end(msg, container);
 
   container = nla_nest_start(msg, NL80211_ATTR_MESH_SETUP);
@@ -1553,6 +1560,7 @@ static int meshd_parse_libconfig(
   CONFIG_LOOKUP(
       "hwmp-active-path-to-root-timeout", hwmp_active_path_to_root_timeout, -1);
   CONFIG_LOOKUP("hwmp-root-interval", hwmp_root_interval, -1);
+  CONFIG_LOOKUP("max-plinks", max_plinks, 63);
 
   config->band = MESHD_11b;
 
@@ -1964,6 +1972,9 @@ int main(int argc, char *argv[]) {
   /* default to mcast-rate of 12 Mbps */
   if (meshd_conf.mcast_rate <= 0)
     meshd_conf.mcast_rate = 12;
+
+  if (meshd_conf.max_plinks <= 0)
+    meshd_conf.max_plinks = 63;
 
   mesh.channel_width = meshd_conf.channel_width;
   mesh.control_freq = meshd_conf.control_freq;

--- a/tests/test011.sh
+++ b/tests/test011.sh
@@ -21,10 +21,17 @@ start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 wait_for_plinks $nradios
 
 # no radio should have more than max_peers peers
+# and at least one radio should have max_peers peers
+at_limit=0
 for i in $(seq 0 $((nradios-1))); do
     iface=${IFACES[$i]}
     ct=$(sudo iw dev $iface station dump | grep ESTAB | wc -l)
     [ $ct -le $max_peers ] || err_exit "$iface had $ct > $num_peers peers"
+    if [ $ct -eq $max_peers ]; then
+      at_limit=1
+    fi
 done
+
+[ $at_limit -eq 1 ] || err_exit "no interface at limit of $num_peers peers"
 
 echo PASS

--- a/tests/test011.sh
+++ b/tests/test011.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# respects max_plinks configuration
+#
+. `dirname $0`/include.sh
+
+[ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
+
+wait_for_clean_start
+
+nradios=8
+max_peers=4
+load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
+set_default_configs $nradios
+# set peer link limit
+for conf in ${CONFIGS[@]}; do
+    sed -i 's/meshid/max-plinks='$max_peers';&/' $conf
+done
+start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
+
+wait_for_plinks $nradios
+
+# no radio should have more than max_peers peers
+for i in $(seq 0 $((nradios-1))); do
+    iface=${IFACES[$i]}
+    ct=$(sudo iw dev $iface station dump | grep ESTAB | wc -l)
+    [ $ct -le $max_peers ] || err_exit "$iface had $ct > $num_peers peers"
+done
+
+echo PASS


### PR DESCRIPTION
This implements peer link limits in authsae: we track total number of established links, and prevent peering if we have no more links available.