### PR TITLE
ampe: fix estab peer link accounting

### DIFF
--- a/ampe.h
+++ b/ampe.h
@@ -128,8 +128,6 @@ struct mesh_node {
   int igtk_keyid;
   uint8_t igtk_ipn[6];
   uint8_t igtk_tx[16];
-
-  int num_estab;
 };
 
 struct ampe_config {

--- a/tests/include.sh
+++ b/tests/include.sh
@@ -134,6 +134,20 @@ err_exit() {
     exit 1
 }
 
+restart_meshd() {
+    local if=$1
+
+    # Kill the meshd running on radio 1 without sending a close
+    pkill -9 -f "meshd-nl80211 -i $if"
+
+    # Remove the old interface
+    ip link set $if down
+    iw $if del
+
+    # Restart meshd there and make sure it works
+    start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
+}
+
 wait_for_plinks() {
     local nradios=$1
 

--- a/tests/include.sh
+++ b/tests/include.sh
@@ -153,6 +153,9 @@ wait_for_plinks() {
 
     # Wait for peer link establishment
     TRIES=50
+    if [ "$IN_VM" -eq 1 ]; then
+        TRIES=200
+    fi
     for i in $(seq 0 $((nradios-1))); do
         log=${LOGS[$i]}
         iface=${IFACES[$i]}

--- a/tests/test010.sh
+++ b/tests/test010.sh
@@ -22,16 +22,7 @@ start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 
 wait_for_plinks $nradios
 
-# Kill the meshd running on radio 1 without sending a close
-pkill -9 -f "meshd-nl80211 -i smesh0"
-
-# Remove the old interface
-ip link set smesh0 down
-iw smesh0 del
-
-# Restart meshd there and make sure it works
-start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
-
+restart_meshd smesh0
 wait_for_plinks $nradios
 
 echo PASS

--- a/tests/test011.sh
+++ b/tests/test011.sh
@@ -20,9 +20,6 @@ start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
 
 wait_for_plinks $nradios
 
-# FIXME currently disabled until plink accounting is fixed
-echo PASS && exec /bin/true
-
 # no radio should have more than max_peers peers
 # and at least one radio should have max_peers peers
 at_limit=0

--- a/tests/test012.sh
+++ b/tests/test012.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# max_plinks survives multiple leave/join
+#
+. `dirname $0`/include.sh
+
+[ $(uname) = "Linux" ] || err_exit "This test only runs on Linux"
+
+wait_for_clean_start
+
+nradios=3
+max_peers=4
+cycles=10
+load_hwsim $nradios || err_exit "Failed to load mac80211-hwsim module."
+set_default_configs $nradios
+# set peer link limit
+for conf in ${CONFIGS[@]}; do
+    sed -i 's/meshid/max-plinks='$max_peers';&/' $conf
+done
+start_meshd $(get_hwsim_radios) || err_exit "Failed to start meshd-nl80211"
+
+wait_for_plinks $nradios
+
+# leave and join the mesh a bunch of times from one radio.
+# if accounting is correct, at the end all peers should
+# have nradios - 1 peers (since that is < max_peers)
+for i in $(seq $cycles); do
+    restart_meshd ${IFACES[0]}
+    wait_for_plinks $nradios
+
+    for j in $(seq 0 $((nradios-1))); do
+        iface=${IFACES[$j]}
+        ct=$(sudo iw dev $iface station dump | grep ESTAB | wc -l)
+        expected=$(( $nradios - 1 ))
+        if [ $ct -ne $(( $nradios - 1)) ]; then
+            err_exit "$iface had < $expected peers (iteration $i)"
+        fi
+    done
+done
+
+echo PASS

--- a/tests/vm/init
+++ b/tests/vm/init
@@ -9,6 +9,7 @@ dmesg -n 1
 cd /local/tests
 echo "--- begin tests ---"
 export LOGDIR=/local/tests/vm/testout/logs
+export IN_VM=1
 ./run_tests.sh
 echo "--- end tests ---"
 poweroff -f


### PR DESCRIPTION
We are incrementing and decrementing the peer link count at
various places, but the current code is insufficient: for
example, SAE code might remove a peer from the peer list if a
second instance of the SAE state machine reaches ACCEPTED (this
happens when you reboot a session, for example), and the AMPE
state machine never gets any kind of notification of that.

Instead of maintaining a count which is hard to get right, simply
compute it whenever we need it by counting up the established
STAs.  This is drier code and doesn't really hurt since there
can be at most a few dozen peers in a typical network.

Add a new test case to verify the functionality.