### PR TITLE
Fix ampe for confirm and close

### DIFF
--- a/ampe.c
+++ b/ampe.c
@@ -258,6 +258,7 @@ static void peer_ampe_init(
 
   RAND_bytes((unsigned char *)&llid, sizeof(llid));
   RAND_bytes(cand->my_nonce, sizeof(cand->my_nonce));
+  memset(cand->peer_nonce, 0, sizeof(cand->peer_nonce));
   cand->cookie = cookie;
   cand->my_lid = llid;
   cand->peer_lid = 0;
@@ -611,7 +612,10 @@ static bool protection_is_valid(
     free(clear_ampe_ie);
     return false;
   }
-  memcpy(cand->peer_nonce, ies_parsed.ampe->local_nonce, 32);
+
+  if (memcmp(cand->peer_nonce, null_nonce, 32) == 0) {
+    memcpy(cand->peer_nonce, ies_parsed.ampe->local_nonce, 32);
+  }
 
   gtkdata = ies_parsed.ampe->variable;
 

--- a/ampe.c
+++ b/ampe.c
@@ -526,14 +526,14 @@ static int check_frame_protection(
       ampe_ie_len < 2 + sizeof(struct ampe_ie) + 16 + 8 + 4) {
     sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE too small\n");
     return -1;
-  }
 
-  /* if PMF, then we also need IGTKData */
-  if (mesh->conf->pmf) {
-    if (ampe_ie_len <
-        2 + sizeof(struct ampe_ie) + 16 + 8 + 4 + 2 + 6 + 16 /* IGTKData */) {
-      sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE missing IGTK\n");
-      return -1;
+    /* if PMF, then we also need IGTKData */
+    if (mesh->conf->pmf) {
+      if (ampe_ie_len <
+          2 + sizeof(struct ampe_ie) + 16 + 8 + 4 + 2 + 6 + 16 /* IGTKData */) {
+        sae_debug(AMPE_DEBUG_KEYS, "Verify frame: AMPE IE missing IGTK\n");
+        return -1;
+      }
     }
   }
 
@@ -597,6 +597,9 @@ static int check_frame_protection(
   }
 
   sae_hexdump(AMPE_DEBUG_KEYS, "AMPE IE: ", clear_ampe_ie, ampe_ie_len);
+
+  if (ftype == PLINK_CLOSE)
+    return 0;
 
   parse_ies(clear_ampe_ie, ampe_ie_len, &ies_parsed);
 


### PR DESCRIPTION
This corrects a few problems with the way confirm and close frames are generated in authsae compared to the requirements in the standard.