### PR TITLE
Delete sta cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ LIST(APPEND libsae_sources
 	common.c
 	crypto/aes_siv.c
 	rekey.c
+	peers.c
 	sae.c
 )
 

--- a/common.h
+++ b/common.h
@@ -55,7 +55,7 @@ int parse_buffer(char *, char **);
 #define SAE_DEBUG_STATE_MACHINE 0x04
 #define SAE_DEBUG_CRYPTO 0x08
 #define SAE_DEBUG_CRYPTO_VERB 0x10
-#define AMPE_DEBUG_CANDIDATES 0x20
+#define AMPE_DEBUG_PEERS 0x20
 #define MESHD_DEBUG 0x40
 #define AMPE_DEBUG_FSM 0x80
 #define AMPE_DEBUG_KEYS 0x100

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -1411,7 +1411,7 @@ void peer_created(unsigned char *peer) {
   }
 }
 
-void peer_deleted(unsigned char *peer) {
+void delete_sta(unsigned char *peer) {
   struct nl_msg *msg;
   struct netlink_ctx *nlcfg = meshd_ctx.nlcfg;
   uint8_t cmd = NL80211_CMD_DEL_STATION;
@@ -1466,7 +1466,7 @@ void fin(
     }
     ampe_open_peer_link(peer, cookie);
   } else if (reason) {
-    peer_deleted(peer);
+    delete_sta(peer);
   }
 }
 

--- a/peers.c
+++ b/peers.c
@@ -1,0 +1,41 @@
+/* Copyright (c) Facebook, Inc. and its subsidiaries.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <stddef.h>
+#include "peers.h"
+#include "peer_lists.h"
+
+void dump_peer_list()
+{
+  struct candidate *peer;
+
+  sae_debug(AMPE_DEBUG_PEERS, "--- start peer list ---\n");
+  TAILQ_FOREACH(peer, &peers, entry) {
+    sae_debug(AMPE_DEBUG_PEERS, MACSTR " [sae=%d, ampe=%d]\n",
+      MAC2STR(peer->peer_mac), peer->state, peer->link_state);
+  }
+  sae_debug(AMPE_DEBUG_PEERS, "--- end peer list ---\n");
+}
+

--- a/peers.h
+++ b/peers.h
@@ -90,5 +90,6 @@ struct candidate {
 
 struct candidate *find_peer(unsigned char *mac, int accept);
 void delete_peer(struct candidate **peer);
+void dump_peer_list();
 
 #endif /* _SAE_PEERS_H_ */

--- a/sae.c
+++ b/sae.c
@@ -2640,12 +2640,6 @@ int sae_initialize(
       gd = curr;
     prev = curr;
     curr->next = NULL;
-    sae_debug(
-        SAE_DEBUG_STATE_MACHINE,
-        "group %d is configured, prime is %d"
-        " bytes\n",
-        curr->group_num,
-        BN_num_bytes(curr->prime));
   }
   return 1;
 }

--- a/sae.c
+++ b/sae.c
@@ -254,6 +254,8 @@ static void delete_local_peer_info(struct candidate *delme)
       cb->evl->rem_timeout(peer->rekey_ping_timer);
       peer->rekey_ping_timer = 0;
       TAILQ_REMOVE(&peers, peer, entry);
+      dump_peer_list();
+
       /*
        * PWE, the private value, the PMK and KCK are all secret so
        * take some special care when deleting them.
@@ -1532,6 +1534,7 @@ struct candidate *create_candidate(
   peer->association_id = aid_alloc();
   curr_open++;
 
+  dump_peer_list();
   cb->peer_created(her_mac);
 
   return peer;

--- a/sae.c
+++ b/sae.c
@@ -227,7 +227,7 @@ static void delete_local_peer_info(struct candidate *delme)
   struct candidate *peer;
 
   TAILQ_FOREACH(peer, &peers, entry) {
-    if (memcmp(delme, peer, sizeof(struct candidate)) == 0) {
+    if (delme == peer) {
       sae_debug(
           SAE_DEBUG_PROTOCOL_MSG,
           "deleting peer at " MACSTR " in state %s\n",

--- a/sae.c
+++ b/sae.c
@@ -292,9 +292,7 @@ void delete_peer(struct candidate **delme)
  * a callback-able version of delete peer
  */
 static void destroy_peer(void *data) {
-  struct candidate *peer = (struct candidate *)data;
-
-  delete_peer(&peer);
+  delete_local_peer_info((struct candidate *) data);
 }
 
 static

--- a/tests/include.sh
+++ b/tests/include.sh
@@ -69,7 +69,7 @@ authsae:
 {
  sae:
   {
-    debug = 480;
+    debug = 484;
     password = "thisisreallysecret";
     group = [19, 26, 21, 25, 20];
     blacklist = 5;

--- a/tests/test001.sh
+++ b/tests/test001.sh
@@ -23,19 +23,19 @@ LOG0=${LOGS[0]}
 LOG1=${LOGS[1]}
 
 # pmk match
-cat ${LOG0} | grep pmk -A 2 > ${TMP0}
-cat ${LOG1} | grep pmk -A 2 > ${TMP1}
+sed -e 's/.*\] //' ${LOG0} | grep pmk -A 2 > ${TMP0}
+sed -e 's/.*\] //' ${LOG1} | grep pmk -A 2 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "pmk mismatch"; cat ${TMP0} ${TMP1}; err_exit "pmk mismatch"; }
 
 # mgtk exchange in both directions
-cat ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 
-cat ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 

--- a/tests/test002.sh
+++ b/tests/test002.sh
@@ -29,32 +29,32 @@ LOG0=${LOGS[0]}
 LOG1=${LOGS[1]}
 
 # pmk match
-cat ${LOG0} | grep pmk -A 2 > ${TMP0}
-cat ${LOG1} | grep pmk -A 2 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep pmk -A 2 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep pmk -A 2 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "pmk mismatch"; cat ${TMP0} ${TMP1}; err_exit "pmk mismatch"; }
 
 # mgtk exchange in both directions
-cat ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 
-cat ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 
 # igtk exchange in both directions
-cat ${LOG0} | grep ^igtk -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep "Received igtk:" -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep ^igtk -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep "Received igtk:" -A 1 | tail -1 > ${TMP1}
 
 [ -s $TMP0 ] || err_exit "No igtk received"
 
 diff ${TMP0} ${TMP1} || { echo "igtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "igtk exchange failed"; }
 
-cat ${LOG0} | grep "Received igtk:" -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep ^igtk -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep "Received igtk:" -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep ^igtk -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "igtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "igtk exchange failed"; }
 


### PR DESCRIPTION
These changes are in preparation for deleting stations (from the kernel) when restarting authentication.  This is necessary with some drivers to reset various connection states.

All tests pass locally and there should be no functional changes.