### PR TITLE
Delete sta cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ LIST(APPEND libsae_sources
 	common.c
 	crypto/aes_siv.c
 	rekey.c
+	peers.c
 	sae.c
 )
 

--- a/ampe.c
+++ b/ampe.c
@@ -1548,7 +1548,7 @@ int ampe_initialize(struct mesh_node *mesh, struct ampe_cb *callbacks) {
 
   /* TODO: move these to a config file */
   ampe_conf.retry_timeout_ms = 1000;
-  ampe_conf.holding_timeout_ms = 10000;
+  ampe_conf.holding_timeout_ms = 3000;
   ampe_conf.confirm_timeout_ms = 1000;
   ampe_conf.max_retries = 10;
   ampe_conf.mesh = mesh;

--- a/common.h
+++ b/common.h
@@ -55,7 +55,7 @@ int parse_buffer(char *, char **);
 #define SAE_DEBUG_STATE_MACHINE 0x04
 #define SAE_DEBUG_CRYPTO 0x08
 #define SAE_DEBUG_CRYPTO_VERB 0x10
-#define AMPE_DEBUG_CANDIDATES 0x20
+#define AMPE_DEBUG_PEERS 0x20
 #define MESHD_DEBUG 0x40
 #define AMPE_DEBUG_FSM 0x80
 #define AMPE_DEBUG_KEYS 0x100

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -361,6 +361,7 @@ static void delete_peer_by_addr(unsigned char *addr) {
 static int handle_del_peer(struct netlink_ctx *nlcfg, struct nl_msg *msg) {
   struct nlattr *tb[NL80211_ATTR_MAX + 1];
   struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+  unsigned char *mac;
 
   nla_parse(
       tb,
@@ -375,8 +376,15 @@ static int handle_del_peer(struct netlink_ctx *nlcfg, struct nl_msg *msg) {
   if (!tb[NL80211_ATTR_MAC] || nla_len(tb[NL80211_ATTR_MAC]) != ETH_ALEN)
     return -1;
 
-  ampe_close_peer_link(nla_data(tb[NL80211_ATTR_MAC]));
-  delete_peer_by_addr(nla_data(tb[NL80211_ATTR_MAC]));
+  mac = nla_data(tb[NL80211_ATTR_MAC]);
+
+  sae_debug(
+      MESHD_DEBUG,
+      "NL80211_DEL_STATION " MACSTR "\n",
+      MAC2STR(mac));
+
+  ampe_close_peer_link(mac);
+  delete_peer_by_addr(mac);
 
   return 0;
 }

--- a/linux/meshd-nl80211.c
+++ b/linux/meshd-nl80211.c
@@ -87,6 +87,12 @@
  *
  *  The kernel is informed of the authenticated and established plink state
  *  when AMPE completes, through the estab_peer_link() callback.
+ *
+ *  Once a station has been uploaded to the kernel, it remains in the
+ *  local peer database until a DEL_STATION message.  This may be initiated
+ *  by us (delete_peer_by_addr()) or by an external entity.  We keep the
+ *  station structure around to avoid initiating new authentication sessions
+ *  until it has been fully removed.
  */
 
 static struct meshd_ctx { struct netlink_ctx *nlcfg; } meshd_ctx;
@@ -352,10 +358,63 @@ int meshd_set_mesh_conf(struct mesh_node *mesh, uint32_t changed) {
   return set_mesh_conf(meshd_ctx.nlcfg, mesh, changed);
 }
 
-static void delete_peer_by_addr(unsigned char *addr) {
+void delete_sta(unsigned char *peer) {
+  struct nl_msg *msg;
+  struct netlink_ctx *nlcfg = meshd_ctx.nlcfg;
+  uint8_t cmd = NL80211_CMD_DEL_STATION;
+  int ret;
+  char *pret;
+
+  if (!peer)
+    return;
+
+  msg = nlmsg_alloc();
+
+  if (!msg)
+    return;
+
+  pret = genlmsg_put(msg, 0, 0, nlcfg->nl80211_id, 0, 0, cmd, 0);
+
+  if (pret == NULL)
+    goto nla_put_failure;
+
+  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
+  NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
+
+  ret = nl_send_auto_complete(nlcfg->cmd_sock, msg);
+  nlmsg_free(msg);
+  msg = NULL;
+  sae_debug(MESHD_DEBUG, "removing peer candidate " MACSTR "\n", MAC2STR(peer));
+  if (ret < 0)
+    fprintf(stderr, "Remove candidate failed: %d (%s)\n", ret, strerror(-ret));
+
+  return;
+nla_put_failure:
+  nlmsg_free(msg);
+  msg = NULL;
+}
+
+static void delete_local_peer_by_addr(unsigned char *addr) {
   struct candidate *peer;
+
   if ((peer = find_peer(addr, 0)))
     delete_peer(&peer);
+}
+
+static void delete_peer_by_addr(unsigned char *addr) {
+  struct candidate *peer;
+
+  if ((peer = find_peer(addr, 0))) {
+    if (peer->in_kernel) {
+      /*
+       * remove from kernel, but wait for handle_del_peer() to remove from
+       * local database.
+       */
+      delete_sta(addr);
+    } else {
+      delete_peer(&peer);
+    }
+  }
 }
 
 static int handle_del_peer(struct netlink_ctx *nlcfg, struct nl_msg *msg) {
@@ -384,7 +443,7 @@ static int handle_del_peer(struct netlink_ctx *nlcfg, struct nl_msg *msg) {
       MAC2STR(mac));
 
   ampe_close_peer_link(mac);
-  delete_peer_by_addr(mac);
+  delete_local_peer_by_addr(mac);
 
   return 0;
 }
@@ -1419,42 +1478,6 @@ void peer_created(unsigned char *peer) {
   }
 }
 
-void peer_deleted(unsigned char *peer) {
-  struct nl_msg *msg;
-  struct netlink_ctx *nlcfg = meshd_ctx.nlcfg;
-  uint8_t cmd = NL80211_CMD_DEL_STATION;
-  int ret;
-  char *pret;
-
-  if (!peer)
-    return;
-
-  msg = nlmsg_alloc();
-
-  if (!msg)
-    return;
-
-  pret = genlmsg_put(msg, 0, 0, nlcfg->nl80211_id, 0, 0, cmd, 0);
-
-  if (pret == NULL)
-    goto nla_put_failure;
-
-  NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, nlcfg->ifindex);
-  NLA_PUT(msg, NL80211_ATTR_MAC, ETH_ALEN, peer);
-
-  ret = nl_send_auto_complete(nlcfg->cmd_sock, msg);
-  nlmsg_free(msg);
-  msg = NULL;
-  sae_debug(MESHD_DEBUG, "removing peer candidate " MACSTR "\n", MAC2STR(peer));
-  if (ret < 0)
-    fprintf(stderr, "Remove candidate failed: %d (%s)\n", ret, strerror(-ret));
-
-  return;
-nla_put_failure:
-  nlmsg_free(msg);
-  msg = NULL;
-}
-
 void fin(
     unsigned short reason,
     unsigned char *peer,
@@ -1474,7 +1497,7 @@ void fin(
     }
     ampe_open_peer_link(peer, cookie);
   } else if (reason) {
-    peer_deleted(peer);
+    delete_peer_by_addr(peer);
   }
 }
 

--- a/peers.c
+++ b/peers.c
@@ -1,0 +1,41 @@
+/* Copyright (c) Facebook, Inc. and its subsidiaries.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include <stddef.h>
+#include "peers.h"
+#include "peer_lists.h"
+
+void dump_peer_list()
+{
+  struct candidate *peer;
+
+  sae_debug(AMPE_DEBUG_PEERS, "--- start peer list ---\n");
+  TAILQ_FOREACH(peer, &peers, entry) {
+    sae_debug(AMPE_DEBUG_PEERS, MACSTR " [sae=%d, ampe=%d]\n",
+      MAC2STR(peer->peer_mac), peer->state, peer->link_state);
+  }
+  sae_debug(AMPE_DEBUG_PEERS, "--- end peer list ---\n");
+}
+

--- a/peers.h
+++ b/peers.h
@@ -90,5 +90,6 @@ struct candidate {
 
 struct candidate *find_peer(unsigned char *mac, int accept);
 void delete_peer(struct candidate **peer);
+void dump_peer_list();
 
 #endif /* _SAE_PEERS_H_ */

--- a/sae.c
+++ b/sae.c
@@ -2640,12 +2640,6 @@ int sae_initialize(
       gd = curr;
     prev = curr;
     curr->next = NULL;
-    sae_debug(
-        SAE_DEBUG_STATE_MACHINE,
-        "group %d is configured, prime is %d"
-        " bytes\n",
-        curr->group_num,
-        BN_num_bytes(curr->prime));
   }
   return 1;
 }

--- a/sae.c
+++ b/sae.c
@@ -254,6 +254,8 @@ static void delete_local_peer_info(struct candidate *delme)
       cb->evl->rem_timeout(peer->rekey_ping_timer);
       peer->rekey_ping_timer = 0;
       TAILQ_REMOVE(&peers, peer, entry);
+      dump_peer_list();
+
       /*
        * PWE, the private value, the PMK and KCK are all secret so
        * take some special care when deleting them.
@@ -1532,6 +1534,7 @@ struct candidate *create_candidate(
   peer->association_id = aid_alloc();
   curr_open++;
 
+  dump_peer_list();
   cb->peer_created(her_mac);
 
   return peer;

--- a/sae.c
+++ b/sae.c
@@ -1985,6 +1985,7 @@ static enum result process_authentication_frame(
             if (sae_debug_mask & SAE_DEBUG_CRYPTO) {
               print_buffer("PMK", peer->pmk, SHA256_DIGEST_LENGTH);
             }
+            peer->state = SAE_ACCEPTED;
             finalize(
                 WLAN_STATUS_SUCCESSFUL,
                 peer,
@@ -2000,7 +2001,6 @@ static enum result process_authentication_frame(
             cb->evl->rem_timeout(peer->t1);
           peer->t1 = cb->evl->add_timeout_with_jitter(
               SRV_SEC(pmk_expiry), reauth, peer, SRV_SEC(REAUTH_JITTER));
-          peer->state = SAE_ACCEPTED;
           break;
         default:
           sae_debug(

--- a/sae.c
+++ b/sae.c
@@ -2348,6 +2348,19 @@ int process_mgmt_frame(
                 sae_debug(SAE_DEBUG_STATE_MACHINE, "correct token received\n");
               }
             }
+
+            /*
+             * let existing stations time out before trying to establish
+             * a new authentication.
+             */
+            if (peer != NULL && peer->link_state == PLINK_HOLDING) {
+              sae_debug(
+                  SAE_DEBUG_STATE_MACHINE,
+                  "ignore auth frame from " MACSTR " while in holding\n",
+                  MAC2STR(frame->sa));
+              return 0;
+            }
+
             /*
              * if we got here that means we're not demanding tokens or we are
              * and the token was correct. In either case we create a protocol

--- a/sae.c
+++ b/sae.c
@@ -227,7 +227,7 @@ static void delete_local_peer_info(struct candidate *delme)
   struct candidate *peer;
 
   TAILQ_FOREACH(peer, &peers, entry) {
-    if (memcmp(delme, peer, sizeof(struct candidate)) == 0) {
+    if (delme == peer) {
       sae_debug(
           SAE_DEBUG_PROTOCOL_MSG,
           "deleting peer at " MACSTR " in state %s\n",

--- a/sae.c
+++ b/sae.c
@@ -292,9 +292,7 @@ void delete_peer(struct candidate **delme)
  * a callback-able version of delete peer
  */
 static void destroy_peer(void *data) {
-  struct candidate *peer = (struct candidate *)data;
-
-  delete_peer(&peer);
+  delete_local_peer_info((struct candidate *) data);
 }
 
 static

--- a/tests/include.sh
+++ b/tests/include.sh
@@ -69,7 +69,7 @@ authsae:
 {
  sae:
   {
-    debug = 480;
+    debug = 486;
     password = "thisisreallysecret";
     group = [19, 26, 21, 25, 20];
     blacklist = 5;

--- a/tests/test001.sh
+++ b/tests/test001.sh
@@ -23,19 +23,19 @@ LOG0=${LOGS[0]}
 LOG1=${LOGS[1]}
 
 # pmk match
-cat ${LOG0} | grep pmk -A 2 > ${TMP0}
-cat ${LOG1} | grep pmk -A 2 > ${TMP1}
+sed -e 's/.*\] //' ${LOG0} | grep pmk -A 2 > ${TMP0}
+sed -e 's/.*\] //' ${LOG1} | grep pmk -A 2 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "pmk mismatch"; cat ${TMP0} ${TMP1}; err_exit "pmk mismatch"; }
 
 # mgtk exchange in both directions
-cat ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 
-cat ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 

--- a/tests/test002.sh
+++ b/tests/test002.sh
@@ -29,32 +29,32 @@ LOG0=${LOGS[0]}
 LOG1=${LOGS[1]}
 
 # pmk match
-cat ${LOG0} | grep pmk -A 2 > ${TMP0}
-cat ${LOG1} | grep pmk -A 2 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep pmk -A 2 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep pmk -A 2 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "pmk mismatch"; cat ${TMP0} ${TMP1}; err_exit "pmk mismatch"; }
 
 # mgtk exchange in both directions
-cat ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep ^mgtk -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 
-cat ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep "Received mgtk:" -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep ^mgtk -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "mgtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "mgtk exchange failed"; }
 
 # igtk exchange in both directions
-cat ${LOG0} | grep ^igtk -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep "Received igtk:" -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep ^igtk -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep "Received igtk:" -A 1 | tail -1 > ${TMP1}
 
 [ -s $TMP0 ] || err_exit "No igtk received"
 
 diff ${TMP0} ${TMP1} || { echo "igtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "igtk exchange failed"; }
 
-cat ${LOG0} | grep "Received igtk:" -A 1 | tail -1 > ${TMP0}
-cat ${LOG1} | grep ^igtk -A 1 | tail -1 > ${TMP1}
+sed -e 's/.*] //' ${LOG0} | grep "Received igtk:" -A 1 | tail -1 > ${TMP0}
+sed -e 's/.*] //' ${LOG1} | grep ^igtk -A 1 | tail -1 > ${TMP1}
 
 diff ${TMP0} ${TMP1} || { echo "igtk mismatch"; cat ${TMP0} ${TMP1}; err_exit "igtk exchange failed"; }
 


### PR DESCRIPTION
This reworks a bunch of things in order to fix a problem where nodes did not delete the station entry when one side reauthenticated.  This can cause a number of issues like ignored BA sessions and one-sided links.

test006.sh and test013.sh specifically check for this issue now; both of them fail at the point they are introduced but pass on tip of this branch.